### PR TITLE
fix: Params 加载时空白(焦点仲裁回归修复)

### DIFF
--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -216,8 +216,10 @@ impl RequestEditor {
         // Add one empty custom header row at the end with subscription
         self.add_custom_header_row(window, cx);
 
-        // Parse URL to populate params (this will also add subscriptions)
-        self.parse_url_to_params(window, cx);
+        // Populate params from the URL. Use the ungated rebuild directly: this is a
+        // programmatic load, so the URL input does not hold focus and the focus-gated
+        // parse_url_to_params would otherwise bail and leave Params empty.
+        self.rebuild_params_from_url(window, cx);
 
         // Force sync Content-Type with body type to auto-correct any inconsistencies in history
         let content_type = match &request.body {
@@ -545,6 +547,15 @@ impl RequestEditor {
             return;
         }
 
+        self.rebuild_params_from_url(window, cx);
+    }
+
+    /// Rebuild the params list from the URL's query string. No focus gating.
+    ///
+    /// Used by the focus-gated `parse_url_to_params` wrapper (live URL edits) and
+    /// directly by `load_request`, where the URL is set programmatically and never
+    /// holds focus — so it must populate params unconditionally.
+    fn rebuild_params_from_url(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let url_str = self.url_input.read(cx).value().to_string();
         let new_params = url_params::parse_query_params(&url_str);
 


### PR DESCRIPTION
## 问题

PR #1 的焦点仲裁重构引入了一个回归:**Params 标签在加载请求时空白**。

- 从历史打开带查询串的请求(如 `?isAdmin=false&tenantCode=...`)→ Params 标签无任何行,本该解析出对应行
- 新建 tab → Params 连默认空输入行都没有

## 根因

`load_request` 末尾调用 `parse_url_to_params` 来填充 Params,但 #1 给该函数加了"URL 未持有焦点就 return"的焦点门禁。加载是程序化操作,URL 此刻没有焦点 → 函数直接 return → Params 永远填不上。

## 修复

拆出一个**无焦点门禁**的 `rebuild_params_from_url`:
- `parse_url_to_params` 保留焦点门禁,继续处理实时 `Change` 事件(防双向同步死循环)
- `load_request` 直接调用 `rebuild_params_from_url`(程序化填充,无条件执行)

与另一方向已有的 `sync_params_to_url` / `rebuild_url_from_params` 拆分对称。

## 验证

- `cargo check` 通过
- Windows release 构建通过,真机验证 4 项全过:
  1. 从历史打开带查询串请求 → Params 正确解析出各行 + 末尾空行
  2. 新建 tab → Params 有一个空输入行
  3. URL 打字 `?a=1&b=2` → Params 实时出现 a、b(焦点仲裁仍正常)
  4. 改 Params → URL 实时同步

🤖 Generated with [Claude Code](https://claude.com/claude-code)