### PR TITLE
feat(ui): 暖调浅色重设计（Claude 观感 / 布局 B）

### DIFF
--- a/assets/icons/check.svg
+++ b/assets/icons/check.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3.5 8.5l3 3 6-7"/></svg>

--- a/assets/icons/chevron-down.svg
+++ b/assets/icons/chevron-down.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6l4 4 4-4"/></svg>

--- a/assets/icons/window-close.svg
+++ b/assets/icons/window-close.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"><line x1="4" y1="4" x2="12" y2="12"/><line x1="12" y1="4" x2="4" y2="12"/></svg>

--- a/assets/icons/window-maximize.svg
+++ b/assets/icons/window-maximize.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"><rect x="3.5" y="3.5" width="9" height="9" rx="1"/></svg>

--- a/assets/icons/window-minimize.svg
+++ b/assets/icons/window-minimize.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round"><line x1="3.5" y1="8" x2="12.5" y2="8"/></svg>

--- a/assets/icons/window-restore.svg
+++ b/assets/icons/window-restore.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"><rect x="3" y="5" width="8" height="8" rx="1"/><path d="M5.5 5V3.5a1 1 0 0 1 1-1H13a1 1 0 0 1 1 1V10a1 1 0 0 1-1 1h-1.5"/></svg>

--- a/docs/superpowers/plans/2026-06-17-ui-redesign-warm-light.md
+++ b/docs/superpowers/plans/2026-06-17-ui-redesign-warm-light.md
@@ -1,0 +1,837 @@
+# UI 重设计（暖调浅色 / 布局 B）Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 把 Poopman 重设计为 Claude/Anthropic 暖调浅色观感（纸感背景 + 珊瑚橘强调色 + 紧凑布局），覆盖全部面板。
+
+**Architecture:** 两层。① 新增 `src/theme.rs`，在 `gpui_component::init` 后用 `Theme::global_mut(cx)` 覆盖颜色/字体/圆角 token——因所有组件已读 `cx.theme()`，这一层即统一全局配色;② 逐面板结构微调(历史单行、内层 tab 下划线、状态栏 pill 等)。`theme.rs` 同时集中尺寸常量,替换散落的 `px()`。
+
+**Tech Stack:** Rust, GPUI 0.2.2, gpui-component 0.5.1。关键 API 已核实:`gpui_component::Theme` 在 crate 根导出;`Theme: DerefMut<Target=ThemeColor>`;`Theme::global_mut(cx) -> &mut Theme`;字段 `mode/radius/radius_lg/font_family/mono_font_family`;`gpui::rgb(0xRRGGBB).into()` → `Hsla`。
+
+**Spec:** `docs/superpowers/specs/2026-06-17-ui-redesign-design.md`
+**视觉基准:** `docs/superpowers/specs/2026-06-17-ui-redesign-mockup.html`(实现时逐面板对照)
+
+**验证约束:** WSL2 无法运行/链接 GUI(缺 `libxkbcommon`),也跑不了 `cargo test`。每个任务的自动门禁是 **`cargo check`(无新增 warning)**。视觉正确性由开发者在 **Windows** 真机 `cargo build --release`(需设 `GPUI_FXC_PATH`)后对照 mockup 目视验收;建议在 Task 1 后(确认全局配色)和 Task 7 后(完整)各做一次真机验收。
+
+---
+
+## File Structure
+
+- **新增** `src/theme.rs` — 调色板常量、尺寸常量、`apply_theme(cx)`、`method_color(method, theme)`。
+- **改** `src/main.rs` — 声明 `mod theme`;`gpui_component::init(cx)` 后调用 `theme::apply_theme(cx)`。
+- **改** `src/app.rs` — `px()` 字面量换尺寸常量;侧栏背景用 `sidebar` token。
+- **改** `src/request_editor.rs` — `px()` 换常量;内层 tab 改下划线式。
+- **改** `src/body_editor.rs` — `px()` 换常量;次要按钮统一暖调。
+- **改** `src/history_panel.rs` — 去 logo 圆点、单行紧凑、方法文字标签、发丝分隔、浅珊瑚选中。
+- **改** `src/tab_bar.rs` — 方法实心徽章改文字标签;复用 `method_color`。
+- **改** `src/response_viewer.rs` — 状态栏 pill + 元信息;响应体卡片化。
+
+---
+
+## Task 1: 主题模块 + 全局应用（配色层）
+
+**Files:**
+- Create: `src/theme.rs`
+- Modify: `src/main.rs`
+
+- [ ] **Step 1: 创建 `src/theme.rs`**
+
+写入完整内容:
+
+```rust
+//! Warm-light ("Claude paper") theme: palette, layout dimensions, and the
+//! global theme application applied once at startup.
+
+use gpui::{px, App, Hsla};
+use gpui_component::{Theme, ThemeMode};
+
+use crate::types::HttpMethod;
+
+// ===== Palette (warm paper light), as 0xRRGGBB =====
+const BACKGROUND: u32 = 0xFAF9F5; // main canvas
+const SIDEBAR: u32 = 0xF0EEE6; // sidebar / muted surfaces
+const SURFACE: u32 = 0xFFFFFF; // white surfaces (input / popover)
+const FOREGROUND: u32 = 0x1A1915; // primary text
+const MUTED_FG: u32 = 0x73706A; // secondary text
+const BORDER: u32 = 0xE7E4DA; // hairline border
+const HOVER: u32 = 0xEBE8DE; // subtle warm hover bg
+const PRIMARY: u32 = 0xC15F3C; // coral / terracotta accent
+const PRIMARY_HOVER: u32 = 0xAD5435;
+const WASH: u32 = 0xF3E7E0; // light coral selection wash
+const WASH_BORDER: u32 = 0xE8D3C8;
+const SUCCESS: u32 = 0x4F8A5B; // 2xx / GET
+const DANGER: u32 = 0xC0503F; // 4xx-5xx / DELETE
+const WARNING: u32 = 0xC98A3C; // amber / POST,PUT
+const SCROLLBAR: u32 = 0xD8D4C8;
+
+// ===== Layout dimensions (px) =====
+pub const SIDEBAR_WIDTH: f32 = 264.;
+pub const SIDEBAR_MIN: f32 = 200.;
+pub const SIDEBAR_MAX: f32 = 420.;
+pub const REQUEST_INITIAL_HEIGHT: f32 = 350.;
+pub const REQUEST_MIN: f32 = 150.;
+pub const REQUEST_MAX: f32 = 700.;
+pub const METHOD_SELECT_WIDTH: f32 = 92.;
+pub const RAW_SUBTYPE_WIDTH: f32 = 120.;
+
+/// Convert a 0xRRGGBB literal into an Hsla theme color.
+fn c(hex: u32) -> Hsla {
+    gpui::rgb(hex).into()
+}
+
+/// Semantic color for an HTTP method label (used by tab bar + history).
+pub fn method_color(method: HttpMethod, theme: &Theme) -> Hsla {
+    match method {
+        HttpMethod::GET => theme.success,
+        HttpMethod::POST | HttpMethod::PUT | HttpMethod::PATCH => theme.warning,
+        HttpMethod::DELETE => theme.danger,
+        HttpMethod::HEAD | HttpMethod::OPTIONS => theme.muted_foreground,
+    }
+}
+
+/// Apply the warm-light theme to the global Theme. Call once after
+/// `gpui_component::init(cx)`.
+pub fn apply_theme(cx: &mut App) {
+    let theme = Theme::global_mut(cx);
+    theme.mode = ThemeMode::Light;
+    theme.radius = px(6.);
+    theme.radius_lg = px(8.);
+
+    // Surfaces & text
+    theme.background = c(BACKGROUND);
+    theme.foreground = c(FOREGROUND);
+    theme.muted = c(SIDEBAR);
+    theme.muted_foreground = c(MUTED_FG);
+    theme.border = c(BORDER);
+    theme.input = c(SURFACE);
+    theme.popover = c(SURFACE);
+    theme.popover_foreground = c(FOREGROUND);
+    theme.secondary = c(SIDEBAR);
+    theme.secondary_foreground = c(FOREGROUND);
+    theme.secondary_hover = c(HOVER);
+    theme.secondary_active = c(HOVER);
+
+    // Sidebar
+    theme.sidebar = c(SIDEBAR);
+    theme.sidebar_foreground = c(FOREGROUND);
+    theme.sidebar_border = c(BORDER);
+
+    // Accent / primary (coral)
+    theme.primary = c(PRIMARY);
+    theme.primary_hover = c(PRIMARY_HOVER);
+    theme.primary_active = c(PRIMARY_HOVER);
+    theme.primary_foreground = c(SURFACE);
+    theme.ring = c(PRIMARY);
+    theme.caret = c(PRIMARY);
+    theme.accent = c(WASH);
+    theme.accent_foreground = c(FOREGROUND);
+    theme.selection = c(WASH);
+
+    // Lists (history rows)
+    theme.list = c(SIDEBAR);
+    theme.list_hover = c(HOVER);
+    theme.list_active = c(WASH);
+    theme.list_active_border = c(WASH_BORDER);
+
+    // Tabs
+    theme.tab = c(BACKGROUND);
+    theme.tab_active = c(SURFACE);
+
+    // Status semantics
+    theme.success = c(SUCCESS);
+    theme.success_foreground = c(SURFACE);
+    theme.danger = c(DANGER);
+    theme.danger_foreground = c(SURFACE);
+    theme.danger_hover = c(DANGER);
+    theme.danger_active = c(DANGER);
+    theme.warning = c(WARNING);
+    theme.warning_foreground = c(SURFACE);
+
+    // Scrollbar
+    theme.scrollbar_thumb = c(SCROLLBAR);
+    theme.scrollbar_thumb_hover = c(MUTED_FG);
+}
+```
+
+- [ ] **Step 2: 在 `main.rs` 声明模块并调用**
+
+在 `src/main.rs` 的模块声明区(`mod app;` 那一组)加入,保持字母序附近即可:
+
+```rust
+mod theme;
+```
+
+然后把 `app.run` 闭包里的:
+
+```rust
+        gpui_component::init(cx);
+```
+
+改为:
+
+```rust
+        gpui_component::init(cx);
+        crate::theme::apply_theme(cx);
+```
+
+- [ ] **Step 3: `cargo check`**
+
+Run: `cargo check`
+Expected: 退出 0。除既有的 2 个 dead-code warning(`toggle_formdata_type`、`from_request`)外无新增 error/warning。
+(若报 `method_color` 未使用的 warning,属正常——Task 3/4 才会用到;先加 `#[allow(dead_code)]` 于 `method_color` 上,在 Task 4 移除。)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/theme.rs src/main.rs
+git commit -m "feat(ui): Add warm-light theme module and apply globally
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 5: (检查点)Windows 真机验收全局配色**
+
+在 Windows 终端:
+```powershell
+$env:GPUI_FXC_PATH = "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x64\fxc.exe"
+cargo run --release
+```
+Expected: 背景变暖纸色、Send 按钮/内层 tab 选中/历史选中均为珊瑚色系,无黑/亮蓝/亮绿杂色(结构尚未调整属正常)。
+
+---
+
+## Task 2: 尺寸常量替换 `px()` 字面量
+
+**Files:**
+- Modify: `src/app.rs`, `src/request_editor.rs`, `src/body_editor.rs`
+
+- [ ] **Step 1: `app.rs` 顶部引入常量**
+
+在 `src/app.rs` 现有 `use crate::...` 区加入:
+
+```rust
+use crate::theme::{
+    REQUEST_INITIAL_HEIGHT, REQUEST_MAX, REQUEST_MIN, SIDEBAR_MAX, SIDEBAR_MIN, SIDEBAR_WIDTH,
+};
+```
+
+- [ ] **Step 2: `app.rs` 替换历史面板与请求区尺寸**
+
+把:
+```rust
+                        resizable_panel()
+                            .size(px(280.)) // Initial width
+                            .size_range(px(200.)..px(500.)) // Can resize between 200px-500px
+```
+改为:
+```rust
+                        resizable_panel()
+                            .size(px(SIDEBAR_WIDTH))
+                            .size_range(px(SIDEBAR_MIN)..px(SIDEBAR_MAX))
+```
+
+把:
+```rust
+                                            resizable_panel()
+                                                .size(px(350.)) // Request editor initial size
+                                                .size_range(px(150.)..px(700.)) // Can resize between 150px-700px
+```
+改为:
+```rust
+                                            resizable_panel()
+                                                .size(px(REQUEST_INITIAL_HEIGHT))
+                                                .size_range(px(REQUEST_MIN)..px(REQUEST_MAX))
+```
+
+- [ ] **Step 3: `request_editor.rs` 替换 method 选择器宽度**
+
+在 `use crate::...` 区加入 `use crate::theme::METHOD_SELECT_WIDTH;`,然后把 URL 栏里的:
+```rust
+                                .w(px(100.))
+                                .child(Select::new(&self.method_select)),
+```
+改为:
+```rust
+                                .w(px(METHOD_SELECT_WIDTH))
+                                .child(Select::new(&self.method_select)),
+```
+
+- [ ] **Step 4: `body_editor.rs` 替换 Raw 子类型下拉宽度**
+
+加入 `use crate::theme::RAW_SUBTYPE_WIDTH;`,把:
+```rust
+                            div()
+                                .w(px(120.))
+                                .child(Select::new(&self.raw_subtype_select))
+```
+改为:
+```rust
+                            div()
+                                .w(px(RAW_SUBTYPE_WIDTH))
+                                .child(Select::new(&self.raw_subtype_select))
+```
+
+- [ ] **Step 5: `cargo check`**
+
+Run: `cargo check`
+Expected: 退出 0,无新增 warning。(`px(0.)`/`px(0.1)` 滚动偏移保持不变,不提取。)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app.rs src/request_editor.rs src/body_editor.rs
+git commit -m "refactor(ui): Replace hardcoded layout px() with theme dimension constants
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: History 面板 — 单行紧凑
+
+**Files:**
+- Modify: `src/history_panel.rs`
+
+- [ ] **Step 1: 去掉 header 的 logo 圆点**
+
+把:
+```rust
+                        h_flex()
+                            .items_center()
+                            .gap_2()
+                            .child(
+                                Icon::default()
+                                    .path("icons/logo.svg")
+                                    .size_5()
+                            )
+                            .child(div().font_weight(FontWeight::SEMIBOLD).child("History"))
+```
+改为:
+```rust
+                        div()
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .text_color(theme.foreground)
+                            .child("History")
+```
+若 `Icon` 因此不再使用,删除其 `use` 导入以免 warning(检查 `history_panel.rs` 顶部 `use gpui_component::{... Icon ...}`,移除 `Icon`)。
+
+- [ ] **Step 2: 列表容器去重边框、收紧**
+
+把列表容器:
+```rust
+                    v_flex()
+                        .size_full()
+                        .gap_2()
+                        .p_2()
+                        .children(self.history.iter().map(|item| {
+```
+改为(改用 `theme.sidebar` 背景、小间距、内边距收紧):
+```rust
+                    v_flex()
+                        .size_full()
+                        .gap_0p5()
+                        .px_2()
+                        .py_1()
+                        .children(self.history.iter().map(|item| {
+```
+
+- [ ] **Step 3: 重写单条历史项为紧凑单行**
+
+定位到 item 渲染块。当前它读取 `let method = item.request.method.as_str();` 并用 `method_color = match method { "GET" => theme.success, ... }`、外层是带粗边框的卡片。替换整个 item 渲染(从 `let method = ...` 到该 item `div()...` 结束)为:
+
+```rust
+                            let item_id = item.id;
+                            let is_selected = self.selected_id == Some(item_id);
+                            let verb = item.request.method.as_str();
+                            let verb_color = crate::theme::method_color(item.request.method, theme);
+                            let url = item.request.url.clone();
+                            let time = Self::format_relative_time(&item.timestamp);
+                            let item_clone = item.clone();
+
+                            h_flex()
+                                .id(("history-item", item_id as u64))
+                                .gap_2()
+                                .items_start()
+                                .w_full()
+                                .px_2p5()
+                                .py_1p5()
+                                .rounded(theme.radius)
+                                .border_1()
+                                .border_color(if is_selected {
+                                    theme.list_active_border
+                                } else {
+                                    gpui::transparent_black()
+                                })
+                                .bg(if is_selected {
+                                    theme.list_active
+                                } else {
+                                    gpui::transparent_black()
+                                })
+                                .cursor_pointer()
+                                .hover(|s| s.bg(if is_selected { theme.list_active } else { theme.list_hover }))
+                                .on_click(cx.listener(move |this, _event: &gpui::ClickEvent, window, cx| {
+                                    this.on_item_click(&item_clone, window, cx);
+                                }))
+                                .child(
+                                    // small mono method label, no filled pill
+                                    div()
+                                        .flex_shrink_0()
+                                        .w(px(34.))
+                                        .text_right()
+                                        .text_xs()
+                                        .font_weight(FontWeight::BOLD)
+                                        .text_color(verb_color)
+                                        .child(verb),
+                                )
+                                .child(
+                                    v_flex()
+                                        .min_w_0()
+                                        .flex_1()
+                                        .gap_0p5()
+                                        .child(
+                                            div()
+                                                .text_sm()
+                                                .text_color(theme.foreground)
+                                                .overflow_x_hidden()
+                                                .whitespace_nowrap()
+                                                .text_ellipsis()
+                                                .child(url),
+                                        )
+                                        .child(
+                                            div()
+                                                .text_xs()
+                                                .text_color(theme.muted_foreground)
+                                                .child(time),
+                                        ),
+                                )
+```
+
+> 注意:此块**移除**了旧的 `status_color` 徽章逻辑(历史不存响应,徽章无意义)。若编译报 `status_color`/`method_color`(旧局部)未使用,一并删除其残留定义。
+
+- [ ] **Step 4: 引入 `px` 与确认 `FontWeight` 可用**
+
+确认 `history_panel.rs` 顶部已有 `use gpui::*;`(含 `px`、`FontWeight`、`transparent_black`)。当前文件已 `use gpui::prelude::FluentBuilder as _;` 和 `use gpui::*;`,无需新增。
+
+- [ ] **Step 5: `cargo check`**
+
+Run: `cargo check`
+Expected: 退出 0,无新增 warning。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/history_panel.rs
+git commit -m "feat(ui): Compact single-line history rows with text method labels
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Tab 栏 — 方法文字标签
+
+**Files:**
+- Modify: `src/tab_bar.rs`
+
+- [ ] **Step 1: 顶部引入 `method_color`**
+
+把:
+```rust
+use gpui_component::{h_flex, ActiveTheme as _};
+```
+改为:
+```rust
+use gpui_component::{h_flex, ActiveTheme as _};
+
+use crate::theme::method_color;
+```
+
+- [ ] **Step 2: 用语义色文字标签替换实心徽章**
+
+把当前计算 `method_color` 的硬编码块:
+```rust
+                        // Method color badge
+                        let method_color = match tab.request.method {
+                            crate::types::HttpMethod::GET => gpui::rgb(0x61affe),
+                            crate::types::HttpMethod::POST => gpui::rgb(0x49cc90),
+                            crate::types::HttpMethod::PUT => gpui::rgb(0xfca130),
+                            crate::types::HttpMethod::DELETE => gpui::rgb(0xf93e3e),
+                            crate::types::HttpMethod::PATCH => gpui::rgb(0x50e3c2),
+                            crate::types::HttpMethod::HEAD => gpui::rgb(0x9012fe),
+                            crate::types::HttpMethod::OPTIONS => gpui::rgb(0x0d5aa7),
+                        };
+```
+改为:
+```rust
+                        let verb_color = method_color(tab.request.method, theme);
+```
+
+然后把那段实心徽章 child:
+```rust
+                            .child(
+                                // Method badge
+                                div()
+                                    .px_1p5()
+                                    .py_0p5()
+                                    .rounded_sm()
+                                    .bg(method_color)
+                                    .child(
+                                        div()
+                                            .text_xs()
+                                            .font_weight(gpui::FontWeight::BOLD)
+                                            .text_color(gpui::white())
+                                            .child(method)
+                                    )
+                            )
+```
+改为(去掉实心底色,文字着语义色):
+```rust
+                            .child(
+                                div()
+                                    .text_xs()
+                                    .font_weight(gpui::FontWeight::BOLD)
+                                    .text_color(verb_color)
+                                    .child(method)
+                            )
+```
+
+- [ ] **Step 3: 选中态用纸白浮层而非晕染色块**
+
+把 tab 容器的:
+```rust
+                            .bg(if is_active { theme.list_active } else { theme.background })
+```
+改为:
+```rust
+                            .bg(if is_active { theme.tab_active } else { theme.background })
+```
+
+- [ ] **Step 4: 移除 Task 1 给 `method_color` 加的 `#[allow(dead_code)]`**
+
+在 `src/theme.rs` 中删除 `method_color` 上方的 `#[allow(dead_code)]`(现已被 tab_bar/history 使用)。
+
+- [ ] **Step 5: `cargo check`**
+
+Run: `cargo check`
+Expected: 退出 0,无新增 warning。
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tab_bar.rs src/theme.rs
+git commit -m "feat(ui): Tab method badges become text labels; white active tab
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: 请求区 — 内层 tab 下划线式
+
+**Files:**
+- Modify: `src/request_editor.rs`
+
+- [ ] **Step 1: 把三个内层 tab 按钮改为下划线式 div**
+
+定位 render 中 Headers/Params/Body 三个 `Button::new("tab-headers"/"tab-params"/"tab-body")...when(self.active_tab == N, |btn| btn.primary())...` 的横排容器。把这三颗 Button 各自替换为下划线式可点击 div。以 Headers 为例,把:
+```rust
+                                .child(
+                                    Button::new("tab-headers")
+                                        .ghost()
+                                        .label("Headers")
+                                        .when(self.active_tab == 0, |btn| btn.primary())
+                                        .on_click(cx.listener(
+                                            |this, _event: &gpui::ClickEvent, _window, cx| {
+                                                this.active_tab = 0;
+                                                cx.notify();
+                                            },
+                                        )),
+                                )
+```
+改为:
+```rust
+                                .child(
+                                    div()
+                                        .id("tab-headers")
+                                        .px_0p5()
+                                        .pb_2()
+                                        .text_sm()
+                                        .cursor_pointer()
+                                        .border_b_2()
+                                        .when(self.active_tab == 0, |this| {
+                                            this.border_color(theme.primary)
+                                                .text_color(theme.primary)
+                                                .font_weight(FontWeight::SEMIBOLD)
+                                        })
+                                        .when(self.active_tab != 0, |this| {
+                                            this.border_color(gpui::transparent_black())
+                                                .text_color(theme.muted_foreground)
+                                        })
+                                        .on_click(cx.listener(
+                                            |this, _event: &gpui::ClickEvent, _window, cx| {
+                                                this.active_tab = 0;
+                                                cx.notify();
+                                            },
+                                        ))
+                                        .child("Headers"),
+                                )
+```
+对 Params(`active_tab == 1`,id `"tab-params"`,文案 `"Params"`)、Body(`active_tab == 2`,id `"tab-body"`,文案 `"Body"`)做完全相同的替换(仅 id/索引/文案不同)。
+
+- [ ] **Step 2: 给三个 tab 的横排容器加下边框作为基线**
+
+把包裹这三个 tab 的 `div().flex().flex_row().gap_1()`(紧邻上面三 child 的父容器)改为:
+```rust
+                            div()
+                                .flex()
+                                .flex_row()
+                                .gap_5()
+                                .border_b_1()
+                                .border_color(theme.border)
+```
+(原为 `.gap_1()` 无下边框;改为 `gap_5` 拉开间距 + 下边框作下划线基线。)
+
+- [ ] **Step 3: 确认 `theme` 在 render 作用域可用**
+
+`request_editor.rs` 的 `render` 开头已有 `let theme = cx.theme();`,上述 `theme.primary` 等可直接用。`FontWeight` 来自 `use gpui::*;`(已存在)。
+
+- [ ] **Step 4: `cargo check`**
+
+Run: `cargo check`
+Expected: 退出 0,无新增 warning。
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/request_editor.rs
+git commit -m "feat(ui): Underline-style Headers/Params/Body tabs
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Body 编辑器 — 次要按钮统一暖调
+
+**Files:**
+- Modify: `src/body_editor.rs`
+
+- [ ] **Step 1: Format/Validate 按钮统一为次要(ghost)风格**
+
+在 render 中找到 Format 与 Validate 按钮。Validate 已是 `.ghost()`;把 Format 也改为 `.ghost()` 以与整体克制风一致。把:
+```rust
+                            Button::new("format-button")
+                                .small()
+                                .label("Format")
+```
+改为:
+```rust
+                            Button::new("format-button")
+                                .small()
+                                .ghost()
+                                .label("Format")
+```
+
+- [ ] **Step 2: `cargo check`**
+
+Run: `cargo check`
+Expected: 退出 0,无新增 warning。
+(其余 body 控件——单选、下拉、代码区——均读 `cx.theme()`,已随 Task 1 主题自动变暖,无需逐一改。)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/body_editor.rs
+git commit -m "style(ui): Make Body Format button secondary to match tone
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: 响应区 — 状态 pill + 卡片化
+
+**Files:**
+- Modify: `src/response_viewer.rs`
+
+- [ ] **Step 1: 状态栏改为 pill + 元信息(去整条灰块)**
+
+`render_status_bar` 中,有响应时的 `h_flex()....bg(cx.theme().muted)....` 整条容器。把它的 `.bg(cx.theme().muted)` 去掉、加下边框,使状态栏与画布同色仅靠分隔线区分。把:
+```rust
+            h_flex()
+                .gap_3()
+                .items_center()
+                .p_2()
+                .bg(cx.theme().muted)
+                .border_b_1()
+                .border_color(cx.theme().border)
+```
+改为:
+```rust
+            h_flex()
+                .gap_3()
+                .items_center()
+                .px_4()
+                .py_2p5()
+                .border_b_1()
+                .border_color(cx.theme().border)
+```
+其中 `200 OK` 色块(`.bg(status_color).text_color(gpui::white())`)保留为 pill;把它的圆角统一:把那块的 `.rounded(cx.theme().radius)` 保留即可(主题已设 6px)。`Time: {} ms` / `Size: {} bytes` 文案保持。
+
+- [ ] **Step 2: 无响应时的状态栏同样去灰块**
+
+把无响应分支:
+```rust
+            h_flex()
+                .p_2()
+                .bg(cx.theme().muted)
+                .border_b_1()
+                .border_color(cx.theme().border)
+                .child("No response yet")
+```
+改为:
+```rust
+            h_flex()
+                .px_4()
+                .py_2p5()
+                .border_b_1()
+                .border_color(cx.theme().border)
+                .text_color(cx.theme().muted_foreground)
+                .child("No response yet")
+```
+
+- [ ] **Step 3: 响应体卡片化**
+
+在 `render` 的 Body tab 分支(`when(self.active_tab == 0, ...)`),把包住 `Input::new(&self.body_display)` 的容器加上卡片样式。把:
+```rust
+                            this.child(
+                                div()
+                                    .flex()
+                                    .flex_col()
+                                    .flex_1()
+                                    .w_full()
+                                    .child(
+                                        Input::new(&self.body_display)
+                                            .disabled(is_error)
+                                            .w_full()
+                                            .h_full(),
+                                    ),
+                            )
+```
+改为:
+```rust
+                            this.child(
+                                div()
+                                    .flex()
+                                    .flex_col()
+                                    .flex_1()
+                                    .w_full()
+                                    .rounded(theme.radius_lg)
+                                    .border_1()
+                                    .border_color(theme.border)
+                                    .bg(theme.popover)
+                                    .overflow_hidden()
+                                    .child(
+                                        Input::new(&self.body_display)
+                                            .disabled(is_error)
+                                            .w_full()
+                                            .h_full(),
+                                    ),
+                            )
+```
+注:`render` 开头已有 `let theme = cx.theme();`;`radius_lg` 是 `Theme` 字段,可直接用。
+
+- [ ] **Step 4: Body/Headers 内层 tab 改下划线式**
+
+与 Task 5 同法,把响应区的 `Button::new("tab-body")` 与 `Button::new("tab-headers")`(各带 `.when(self.active_tab == N, |btn| btn.primary())`)替换为下划线式 div。以 Body 为例,把:
+```rust
+                                .child(
+                                    Button::new("tab-body")
+                                        .ghost()
+                                        .label("Body")
+                                        .when(self.active_tab == 0, |btn| btn.primary())
+                                        .on_click(cx.listener(
+                                            |this, _event: &gpui::ClickEvent, _window, cx| {
+                                                this.active_tab = 0;
+                                                cx.notify();
+                                            },
+                                        )),
+                                )
+```
+改为:
+```rust
+                                .child(
+                                    div()
+                                        .id("resp-tab-body")
+                                        .px_0p5()
+                                        .pb_2()
+                                        .text_sm()
+                                        .cursor_pointer()
+                                        .border_b_2()
+                                        .when(self.active_tab == 0, |this| {
+                                            this.border_color(theme.primary)
+                                                .text_color(theme.primary)
+                                                .font_weight(FontWeight::SEMIBOLD)
+                                        })
+                                        .when(self.active_tab != 0, |this| {
+                                            this.border_color(gpui::transparent_black())
+                                                .text_color(theme.muted_foreground)
+                                        })
+                                        .on_click(cx.listener(
+                                            |this, _event: &gpui::ClickEvent, _window, cx| {
+                                                this.active_tab = 0;
+                                                cx.notify();
+                                            },
+                                        ))
+                                        .child("Body"),
+                                )
+```
+对 Headers(`active_tab == 1`,id `"resp-tab-headers"`,文案 `"Headers"`)做相同替换。并把这两个 tab 的父横排容器 `div().flex().flex_row().gap_1()` 改为 `div().flex().flex_row().gap_5().border_b_1().border_color(theme.border)`(与 Task 5 Step 2 一致)。
+
+- [ ] **Step 5: 确认 `FontWeight` 导入**
+
+`response_viewer.rs` 顶部已 `use gpui::*;`(含 `FontWeight`、`transparent_black`)。无需新增。
+
+- [ ] **Step 6: `cargo check`**
+
+Run: `cargo check`
+Expected: 退出 0,无新增 warning。
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/response_viewer.rs
+git commit -m "feat(ui): Response status pill + card-framed body + underline tabs
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+- [ ] **Step 8: (最终检查点)Windows 真机完整验收**
+
+```powershell
+$env:GPUI_FXC_PATH = "C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x64\fxc.exe"
+cargo build --release
+```
+然后运行 `target\release\poopman.exe`,对照 `2026-06-17-ui-redesign-mockup.html` 逐项核对(见 spec「验证策略」6 点):全局暖纸 + 珊瑚橘、历史单行无圆点、内层 tab 下划线(请求区与响应区一致)、URL 栏/Send/卡片观感、响应 pill + 卡片化、切 tab/加载历史样式稳定。
+
+---
+
+## Self-Review
+
+**Spec 覆盖:**
+- 全局暖调主题 → Task 1 ✓
+- 调色板各 token(含 `card` 用 `popover`/`input` 代替)→ Task 1 apply_theme ✓
+- 字体/圆角 → Task 1(radius/radius_lg)✓
+- 尺寸常量解决 hardcode → Task 1 定义 + Task 2 替换 ✓(`px(0.)`/`px(0.1)` 明确不动)
+- 历史单行 + 去 ● 圆点 + 方法文字标签 + 浅珊瑚选中 → Task 3 ✓
+- Tab 栏方法文字标签 + 卡片选中 → Task 4 ✓
+- 请求区内层 tab 下划线式 → Task 5 ✓
+- Body 次要按钮统一 → Task 6 ✓
+- 响应状态 pill + 卡片化 + 下划线 tab → Task 7 ✓
+- 范围红线(不做深色/Collections/逻辑)→ 全程未触碰功能逻辑 ✓
+
+**占位符扫描:** 无 TBD/TODO;所有代码步骤含完整可粘贴代码。
+
+**类型/命名一致:** `apply_theme(cx: &mut App)`、`method_color(method: HttpMethod, theme: &Theme) -> Hsla`、尺寸常量名(`SIDEBAR_WIDTH` 等)在 Task 1 定义,Task 2/3/4 引用一致;下划线 tab 模式(`border_b_2` + `when(active)` 着 `primary`)在 Task 5 与 Task 7 写法一致。
+
+**验证现实性:** 已说明 WSL2 仅能 `cargo check`,真机 `cargo build --release` + 目视对照 mockup;`method_color` 的 dead-code 过渡在 Task 1 加 `#[allow]`、Task 4 移除,避免中途 warning。

--- a/docs/superpowers/specs/2026-06-17-ui-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-17-ui-redesign-design.md
@@ -1,0 +1,131 @@
+# UI 重设计：暖调浅色（Claude 观感）/ 布局 B
+
+**日期**: 2026-06-17
+**范围**: 全量 UI 重设计（视觉 + 布局），覆盖所有面板组件 + 新增主题模块
+**类型**: 重设计（视觉/布局），非功能性改动
+**参考预览**: `docs/superpowers/specs/2026-06-17-ui-redesign-mockup.html`（已确认观感方向）
+
+## 背景与目标
+
+当前 UI「丑」的核心问题(基于真机截图诊断):
+
+1. **配色不统一** —— 同屏混用绿(GET 徽章)、黑(Send / 内层 tab 选中)、蓝(tab 栏/历史选中)三种强调色,无统一主色。
+2. **内层 tab 黑色实心药丸** —— 在浅色界面中突兀笨重。
+3. **历史卡片过大** —— 每条 ~95px、重边框,密度低。
+4. **竖向空间浪费** —— 灰色大写区块标题、过大 padding;状态栏是糙灰块。
+5. **输入框灰底偏旧**;小瑕疵(History 旁孤立 ● 圆点、POST 徽章发灰)。
+
+**目标**:重做为 Claude/Anthropic 暖调观感 —— 纸感暖背景、单一珊瑚橘强调色、克制排版、柔和圆角、发丝边框、紧凑而呼吸感的密度。
+
+## 已确认决策
+
+- **风格方向**: Claude/Anthropic 暖调
+- **主题范围**: 仅**暖调浅色**(深色为后续 Phase 2,本次不做)
+- **重设计程度**: 全量重做布局(非仅换肤)
+- **整体布局**: **方案 B** —— 侧边栏(历史)+ 主区(请求在上 / 响应在下,竖向分割)
+
+## 架构
+
+两层实现,关注点分离:
+
+1. **全局主题层** —— 新增 `src/theme.rs`,定义暖调调色板并在 `gpui_component::init` 之后通过 `Theme::global_mut(cx)` 覆盖颜色 token、字体、圆角。`Theme` 通过 `DerefMut` 暴露 `ThemeColor` 全部字段。由于所有组件已读 `cx.theme()`,改 token 即全局生效——这一层就治掉配色不统一(内层 tab 的 `.primary()` 自动变珊瑚、蓝色选中态走 `list_active`/`tab_active` 也跟着统一)。
+2. **组件结构层** —— 逐面板调整布局与密度(历史单行化、内层 tab 下划线式、状态栏重做、响应卡片化等)。
+
+另**新增** `src/ui.rs`(或 `theme.rs` 内的子模块)集中存放尺寸常量,替换散落的 `px()` 魔法数字(顺带解决"hardcode"问题)。
+
+### 文件清单
+
+- **新增** `src/theme.rs` —— 调色板常量 + `apply_theme(cx)`(设置颜色/字体/圆角)+ 布局尺寸常量。
+- **改** `src/main.rs` —— `gpui_component::init(cx)` 后调用 `crate::theme::apply_theme(cx)`。
+- **改** `src/history_panel.rs` —— 紧凑单行、方法文字标签、发丝分隔、浅珊瑚选中、去掉 ● 圆点。
+- **改** `src/tab_bar.rs` —— 卡片式 tab(选中态纸白 + 边框,非蓝色块)。
+- **改** `src/request_editor.rs` —— URL 栏、内层 tab 下划线式、headers/params 表格留白收紧。
+- **改** `src/body_editor.rs` —— 内层(单选/Format/Validate)按钮风格统一为暖调。
+- **改** `src/response_viewer.rs` —— 状态栏重做(色块 pill + 元信息)、响应体卡片化、JSON 着色沿用。
+- **改** `src/app.rs` —— 复用 `theme.rs` 的尺寸常量替换 `px()` 字面量;侧边栏背景用 `sidebar` token。
+
+## 调色板（warm paper light）
+
+| 用途 | token | 色值 (hex) | 说明 |
+|---|---|---|---|
+| 主画布 | `background` | `#FAF9F5` | 暖米白纸感 |
+| 侧边栏 | `sidebar` | `#F0EEE6` | 略深一档暖纸 |
+| 输入框/卡片浮层 | `input` / `popover` | `#FFFFFF` | 纯白浮于纸面(gpui-component 无 `card` token,白色表面用 `input`/`popover`) |
+| 主文字 | `foreground` | `#1A1915` | 暖近黑 |
+| 次要文字 | `muted_foreground` | `#73706A` | 暖灰 |
+| 发丝边框 | `border` / `sidebar_border` | `#E7E4DA` | 极淡暖灰 |
+| **主强调色** | `primary` / `ring` / `tab_active` | **`#C15F3C`** | Claude 珊瑚/陶土橘 |
+| 强调色 hover | `primary_hover` | `#AD5435` | |
+| 强调色上文字 | `primary_foreground` | `#FFFFFF` | |
+| 选中/高亮 | `list_active` / `selection` / `accent` | `#F3E7E0` | 浅珊瑚晕染 |
+| 选中边框 | `list_active_border` | `#E8D3C8` | |
+| 2xx 状态 | `success` | `#4F8A5B` | 收敛暖绿 |
+| 4xx/5xx 状态 | `danger` | `#C0503F` | 暖红 |
+| 警告/3xx | `warning` | `#C98A3C` | 暖琥珀 |
+| 滚动条 thumb | `scrollbar_thumb` | `#D8D4C8` | 暖灰 |
+
+> 颜色以 hex 给出;实现时通过 `gpui::rgb(0xRRGGBB).into()` 转为 `Hsla` 赋给对应 token。未单独列出的 token(如 `secondary`/`accordion`/`tab` 等)统一推导自同一暖色系(浅表面=background/`#FAF9F5`,文字=foreground,边框=border),避免遗漏处露出旧色。注:gpui-component 0.5.1 **无 `card` token**,凡需纯白卡片表面处用 `popover`(浮层)或 `input`(输入)token。
+
+## 字体与形状
+
+- **圆角**: 卡片/响应体 `8px`,输入/按钮/tab `6px`。设 `Theme.radius`。
+- **正文字体**: 保留系统 UI sans(不打包字体,避免体积/授权)。
+- **等宽字体**: Body/Response 代码区用 `mono_font_family`(保留系统等宽)。
+
+## 各组件结构设计
+
+### 侧边栏 / History (`history_panel.rs`)
+- **去掉** "History" 左侧孤立 ● 圆点。
+- 每条历史:**单行紧凑**布局 —— 左侧小号等宽**方法文字标签**(`GET` 绿 / `POST` 琥珀 / `DELETE` 红,无实心底色),右侧 URL 单行省略 + 下方小号时间。
+- 行间用**发丝分隔/留白**取代重边框卡片;hover 浅灰、选中浅珊瑚晕染(`list_active` + `list_active_border`)。
+- 背景使用 `sidebar` token。
+
+### Tab 栏 (`tab_bar.rs`)
+- 卡片式 tab:选中态为纸白底 + 上/左/右发丝边框 + 顶部圆角(贴合下方内容区),未选中为透明 + 暖灰文字。
+- tab 内方法小标签用语义色;关闭 ✕ 暖灰、hover 转 danger。
+- `＋` 新建按钮:暖灰、hover 珊瑚。
+
+### 请求区 (`request_editor.rs`)
+- **URL 栏**: method 选择器(纸白卡片 + 边框,方法名语义色)| URL 输入(纸白卡片)| Send 按钮(珊瑚实心 + hover 加深)。
+- **内层 tab(Headers/Params/Body)**: **下划线式** —— 选中珊瑚文字 + 珊瑚下划线 + 半粗;未选中暖灰,hover 转主文字。取代当前黑色实心药丸。
+- **表格行**: checkbox 选中态珊瑚;输入框纸白 + 发丝边框;只读/预定义项浅灰底 + 暖灰字;行距收紧。
+
+### Body 编辑器 (`body_editor.rs`)
+- None/Raw/Form-data 单选、子类型下拉、Format/Validate 按钮统一暖调(次要按钮:透明/浅底 + 暖灰字 + hover 浅珊瑚)。
+- 代码编辑区随主题(纸白底、发丝边框、圆角)。
+
+### 响应区 (`response_viewer.rs`)
+- **状态栏重做**: `200 OK` 小**色块 pill**(2xx 绿 / 4xx-5xx 红 / 网络错误红),后接 `128 ms`、`1.2 KB` 元信息(数值主文字、单位暖灰),取代当前整条灰块。
+- **响应体卡片化**: 纸白卡片 + 发丝边框 + 圆角 + 内边距;沿用 JSON 语法着色(key 珊瑚、字符串绿、数字赭),行号暖灰。
+- Body/Headers 切换用下划线式内层 tab(与请求区一致)。
+- 空态文案居中、暖灰。
+
+## 尺寸常量（解决 hardcode）
+
+`theme.rs` 中集中定义,替换 `app.rs` / `request_editor.rs` / `body_editor.rs` 的 `px()` 字面量:
+
+| 常量 | 值 | 替换处 |
+|---|---|---|
+| `SIDEBAR_WIDTH` | 264px | app.rs 历史面板初始宽度(原 280) |
+| `SIDEBAR_MIN` / `SIDEBAR_MAX` | 200 / 420 | app.rs 范围 |
+| `REQUEST_INITIAL_HEIGHT` | 350px | app.rs |
+| `REQUEST_MIN` / `REQUEST_MAX` | 150 / 700 | app.rs |
+| `METHOD_SELECT_WIDTH` | 92px | request_editor.rs(原 100) |
+| `RAW_SUBTYPE_WIDTH` | 120px | body_editor.rs |
+
+> `px(0.)`/`px(0.1)` 为滚动偏移内部计算,**不**提取(非设计值)。
+
+## 验证策略
+
+- WSL2 无法运行 GUI,自动门禁为 `cargo check`(无新增 warning)。
+- Windows 真机 `cargo build --release`(需 `GPUI_FXC_PATH`)产出可执行文件后,**对照参考 HTML 预览**逐面板目视验收:
+  1. 全局暖纸背景 + 珊瑚橘强调色,无残留绿/黑/蓝杂色
+  2. 历史单行紧凑、无 ● 圆点、选中浅珊瑚
+  3. 内层 tab 下划线式(请求区与响应区一致)
+  4. URL 栏 / Send 按钮 / 卡片观感符合预览
+  5. 响应状态栏 pill + 元信息、响应体卡片化 + JSON 着色
+  6. 切 tab / 加载历史后样式稳定,无错位
+
+## 范围红线（YAGNI）
+
+本次**仅**做暖调浅色的视觉 + 布局重设计。**不**包含:深色主题(Phase 2)、主题切换 UI、Collections、环境变量、图标体系重做、动效。功能逻辑(请求发送、同步、历史)一律不动。

--- a/docs/superpowers/specs/2026-06-17-ui-redesign-mockup.html
+++ b/docs/superpowers/specs/2026-06-17-ui-redesign-mockup.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Poopman 重设计预览 — 暖调浅色 / 布局 B</title>
+<style>
+  :root{
+    --bg:#FAF9F5;          /* 主画布 */
+    --sidebar:#F0EEE6;     /* 侧边栏 */
+    --card:#FFFFFF;        /* 卡片/输入框 */
+    --fg:#1A1915;          /* 主文字 */
+    --muted:#73706A;       /* 次要文字 */
+    --border:#E7E4DA;      /* 发丝边框 */
+    --primary:#C15F3C;     /* 珊瑚/陶土橘 强调色 */
+    --primary-hover:#AD5435;
+    --primary-fg:#FFFFFF;
+    --wash:#F3E7E0;        /* 选中浅珊瑚晕染 */
+    --success:#4F8A5B;
+    --danger:#C0503F;
+    --warn:#C98A3C;
+    --radius-card:8px;
+    --radius-ctl:6px;
+    --mono:"SF Mono",ui-monospace,"Cascadia Code","Consolas",monospace;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  html,body{height:100%}
+  body{
+    font-family:-apple-system,"Segoe UI",system-ui,sans-serif;
+    background:var(--bg);color:var(--fg);font-size:13px;line-height:1.45;
+    -webkit-font-smoothing:antialiased;
+  }
+  .caption{padding:6px 14px;font-size:12px;color:var(--muted);background:var(--sidebar);border-bottom:1px solid var(--border)}
+  .caption b{color:var(--primary)}
+
+  .app{display:flex;height:calc(100vh - 33px)}
+
+  /* ---------- Sidebar ---------- */
+  .sidebar{width:264px;flex:none;background:var(--sidebar);border-right:1px solid var(--border);display:flex;flex-direction:column}
+  .sidebar-head{display:flex;align-items:center;justify-content:space-between;padding:14px 16px 10px}
+  .sidebar-head h1{font-size:14px;font-weight:600;letter-spacing:.2px}
+  .sidebar-head .clear{font-size:12px;color:var(--muted);cursor:pointer}
+  .sidebar-head .clear:hover{color:var(--primary)}
+  .hist{overflow-y:auto;padding:2px 8px 8px}
+  .hist-item{display:flex;align-items:baseline;gap:8px;padding:7px 10px;border-radius:var(--radius-ctl);cursor:pointer;border:1px solid transparent}
+  .hist-item:hover{background:rgba(0,0,0,.03)}
+  .hist-item.active{background:var(--wash);border-color:#E8D3C8}
+  .verb{font-family:var(--mono);font-size:10.5px;font-weight:700;letter-spacing:.4px;flex:none;width:34px;text-align:right;padding-top:1px}
+  .verb.get{color:var(--success)}
+  .verb.post{color:var(--warn)}
+  .verb.del{color:var(--danger)}
+  .hist-main{min-width:0;flex:1}
+  .hist-url{font-size:12.5px;color:var(--fg);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .hist-time{font-size:11px;color:var(--muted);margin-top:1px}
+
+  /* ---------- Main ---------- */
+  .main{flex:1;display:flex;flex-direction:column;min-width:0}
+
+  /* tab strip */
+  .tabs{display:flex;align-items:center;gap:4px;padding:8px 12px 0;background:var(--bg)}
+  .tab{display:flex;align-items:center;gap:7px;padding:7px 12px;border-radius:8px 8px 0 0;font-size:12.5px;color:var(--muted);cursor:pointer;border:1px solid transparent;border-bottom:none}
+  .tab .v{font-family:var(--mono);font-size:10px;font-weight:700}
+  .tab.active{background:var(--card);color:var(--fg);border-color:var(--border)}
+  .tab .x{color:var(--muted);font-size:13px;opacity:.6}
+  .tab .x:hover{opacity:1;color:var(--danger)}
+  .tab-add{padding:6px 9px;color:var(--muted);cursor:pointer;border-radius:6px;font-size:15px}
+  .tab-add:hover{background:rgba(0,0,0,.04);color:var(--primary)}
+  .tabs-rule{height:1px;background:var(--border)}
+
+  .req{padding:16px 18px;display:flex;flex-direction:column;gap:12px;flex:1;min-height:0;overflow:auto}
+
+  /* URL bar */
+  .urlbar{display:flex;gap:8px;align-items:stretch}
+  .method{display:flex;align-items:center;gap:6px;font-family:var(--mono);font-weight:700;font-size:12px;color:var(--success);
+    background:var(--card);border:1px solid var(--border);border-radius:var(--radius-ctl);padding:0 12px;cursor:pointer;flex:none}
+  .method .car{color:var(--muted);font-weight:400}
+  .url{flex:1;background:var(--card);border:1px solid var(--border);border-radius:var(--radius-ctl);padding:9px 12px;font-size:13px;color:var(--fg)}
+  .url.ph{color:var(--muted)}
+  .send{flex:none;background:var(--primary);color:var(--primary-fg);border:none;border-radius:var(--radius-ctl);padding:0 20px;font-size:13px;font-weight:600;cursor:pointer;display:flex;align-items:center;gap:6px}
+  .send:hover{background:var(--primary-hover)}
+
+  /* inner underline tabs */
+  .itabs{display:flex;gap:20px;border-bottom:1px solid var(--border)}
+  .itab{padding:6px 1px 9px;font-size:13px;color:var(--muted);cursor:pointer;border-bottom:2px solid transparent;margin-bottom:-1px}
+  .itab.active{color:var(--primary);border-bottom-color:var(--primary);font-weight:600}
+  .itab:hover:not(.active){color:var(--fg)}
+
+  /* headers table */
+  .ktable{display:flex;flex-direction:column;gap:6px}
+  .krow{display:flex;align-items:center;gap:10px}
+  .ck{width:15px;height:15px;border-radius:4px;border:1.5px solid #CFC9BC;flex:none;position:relative;background:var(--card)}
+  .ck.on{background:var(--primary);border-color:var(--primary)}
+  .ck.on::after{content:"";position:absolute;left:4px;top:1px;width:4px;height:8px;border:solid #fff;border-width:0 2px 2px 0;transform:rotate(45deg)}
+  .kin{flex:1;background:var(--card);border:1px solid var(--border);border-radius:var(--radius-ctl);padding:7px 11px;font-size:12.5px;min-width:0;color:var(--fg)}
+  .kin.dim{color:var(--muted)}
+  .kin.locked{background:#FBFAF6;color:var(--muted)}
+
+  /* ---------- Response ---------- */
+  .resp{border-top:1px solid var(--border);display:flex;flex-direction:column;height:42%;flex:none;background:var(--bg)}
+  .statusbar{display:flex;align-items:center;gap:14px;padding:10px 18px;border-bottom:1px solid var(--border)}
+  .pill{font-family:var(--mono);font-size:11.5px;font-weight:700;color:#fff;background:var(--success);padding:3px 9px;border-radius:5px}
+  .meta{font-size:12px;color:var(--muted)}
+  .meta b{color:var(--fg);font-weight:600}
+  .resp-itabs{display:flex;gap:20px;padding:0 18px;border-bottom:1px solid var(--border)}
+  .body{flex:1;overflow:auto;padding:14px 18px;font-family:var(--mono);font-size:12.5px;line-height:1.6;background:var(--card);margin:12px 18px 16px;border:1px solid var(--border);border-radius:var(--radius-card)}
+  .ln{color:#B8B2A4;-webkit-user-select:none;display:inline-block;width:22px;text-align:right;margin-right:14px}
+  .j-key{color:var(--primary)}
+  .j-str{color:#3F7E54}
+  .j-num{color:#9A5B2E}
+  .j-punc{color:var(--muted)}
+</style>
+</head>
+<body>
+  <div class="caption">静态预览 · 布局 <b>B</b>(侧边栏 + 请求上/响应下)· 暖调浅色 · 强调色 <b>#C15F3C</b> — 非真实应用，仅看观感方向（数据为虚构占位）</div>
+  <div class="app">
+
+    <!-- Sidebar -->
+    <aside class="sidebar">
+      <div class="sidebar-head">
+        <h1>History</h1>
+        <span class="clear">Clear</span>
+      </div>
+      <div class="hist">
+        <div class="hist-item active">
+          <span class="verb get">GET</span>
+          <div class="hist-main">
+            <div class="hist-url">api.example.com/v1/users/profile</div>
+            <div class="hist-time">2 hours ago</div>
+          </div>
+        </div>
+        <div class="hist-item">
+          <span class="verb get">GET</span>
+          <div class="hist-main">
+            <div class="hist-url">api.example.com/v1/products?page=1</div>
+            <div class="hist-time">3 hours ago</div>
+          </div>
+        </div>
+        <div class="hist-item">
+          <span class="verb get">GET</span>
+          <div class="hist-main">
+            <div class="hist-url">example.com/health</div>
+            <div class="hist-time">yesterday</div>
+          </div>
+        </div>
+        <div class="hist-item">
+          <span class="verb post">POST</span>
+          <div class="hist-main">
+            <div class="hist-url">api.example.com/v1/messages/send</div>
+            <div class="hist-time">yesterday</div>
+          </div>
+        </div>
+        <div class="hist-item">
+          <span class="verb post">POST</span>
+          <div class="hist-main">
+            <div class="hist-url">api.example.com/v1/coupons/claim</div>
+            <div class="hist-time">2 days ago</div>
+          </div>
+        </div>
+        <div class="hist-item">
+          <span class="verb post">POST</span>
+          <div class="hist-main">
+            <div class="hist-url">api.example.com/v1/orders/create</div>
+            <div class="hist-time">2 days ago</div>
+          </div>
+        </div>
+        <div class="hist-item">
+          <span class="verb del">DEL</span>
+          <div class="hist-main">
+            <div class="hist-url">api.example.com/v1/coupons/8821</div>
+            <div class="hist-time">3 days ago</div>
+          </div>
+        </div>
+      </div>
+    </aside>
+
+    <!-- Main -->
+    <section class="main">
+      <div class="tabs">
+        <div class="tab"><span class="v" style="color:var(--success)">GET</span> New Request <span class="x">✕</span></div>
+        <div class="tab active"><span class="v" style="color:var(--success)">GET</span> users/profile <span class="x">✕</span></div>
+        <div class="tab-add">＋</div>
+      </div>
+      <div class="tabs-rule"></div>
+
+      <div class="req">
+        <!-- URL bar -->
+        <div class="urlbar">
+          <div class="method">GET <span class="car">▾</span></div>
+          <div class="url">https://api.example.com/v1/users/profile?active=true&amp;role=admin&amp;page=1</div>
+          <button class="send">Send ▸</button>
+        </div>
+
+        <!-- inner tabs -->
+        <div class="itabs">
+          <div class="itab">Headers</div>
+          <div class="itab active">Params</div>
+          <div class="itab">Body</div>
+        </div>
+
+        <!-- params table -->
+        <div class="ktable">
+          <div class="krow"><span class="ck on"></span><input class="kin" value="active"><input class="kin" value="true"></div>
+          <div class="krow"><span class="ck on"></span><input class="kin" value="role"><input class="kin" value="admin"></div>
+          <div class="krow"><span class="ck on"></span><input class="kin" value="page"><input class="kin" value="1"></div>
+          <div class="krow"><span class="ck"></span><input class="kin dim" placeholder="Parameter"><input class="kin dim" placeholder="Value"></div>
+        </div>
+      </div>
+
+      <!-- Response -->
+      <div class="resp">
+        <div class="statusbar">
+          <span class="pill">200 OK</span>
+          <span class="meta"><b>128</b> ms</span>
+          <span class="meta"><b>1.2</b> KB</span>
+        </div>
+        <div class="resp-itabs">
+          <div class="itab active">Body</div>
+          <div class="itab">Headers</div>
+        </div>
+        <div class="body"><div><span class="ln">1</span><span class="j-punc">{</span></div><div><span class="ln">2</span>  <span class="j-key">"code"</span><span class="j-punc">:</span> <span class="j-num">0</span><span class="j-punc">,</span></div><div><span class="ln">3</span>  <span class="j-key">"message"</span><span class="j-punc">:</span> <span class="j-str">"success"</span><span class="j-punc">,</span></div><div><span class="ln">4</span>  <span class="j-key">"data"</span><span class="j-punc">:</span> <span class="j-punc">{</span></div><div><span class="ln">5</span>    <span class="j-key">"id"</span><span class="j-punc">:</span> <span class="j-num">1024</span><span class="j-punc">,</span></div><div><span class="ln">6</span>    <span class="j-key">"name"</span><span class="j-punc">:</span> <span class="j-str">"Ada"</span><span class="j-punc">,</span></div><div><span class="ln">7</span>    <span class="j-key">"active"</span><span class="j-punc">:</span> <span class="j-num">true</span></div><div><span class="ln">8</span>  <span class="j-punc">}</span></div><div><span class="ln">9</span><span class="j-punc">}</span></div></div>
+      </div>
+    </section>
+
+  </div>
+</body>
+</html>

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use gpui::*;
 use gpui_component::{
-    ActiveTheme as _,
+    v_flex, ActiveTheme as _, TitleBar,
     resizable::{h_resizable, resizable_panel, v_resizable},
 };
 use gpui::px;
@@ -349,10 +349,21 @@ impl Render for PoopmanApp {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
 
-        div()
+        v_flex()
             .size_full()
             .bg(theme.background)
             .child(
+                // Custom warm title bar (replaces the white native title bar)
+                TitleBar::new().child(
+                    div()
+                        .text_sm()
+                        .font_weight(FontWeight::SEMIBOLD)
+                        .text_color(theme.foreground)
+                        .child("Poopman"),
+                ),
+            )
+            .child(
+                div().flex_1().min_h_0().child(
                 h_resizable("history-main-splitter")
                     .child(
                         // Left: History panel with resizable width
@@ -404,6 +415,7 @@ impl Render for PoopmanApp {
                             )
                             .into_any_element(),
                     ),
+            ),
             )
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,6 +12,9 @@ use crate::request_editor::{RequestCompleted, RequestEditor};
 use crate::request_tab::RequestTab;
 use crate::response_viewer::ResponseViewer;
 use crate::tab_bar::{NewTabClicked, TabBar, TabClicked, TabCloseClicked};
+use crate::theme::{
+    REQUEST_INITIAL_HEIGHT, REQUEST_MAX, REQUEST_MIN, SIDEBAR_MAX, SIDEBAR_MIN, SIDEBAR_WIDTH,
+};
 
 /// Main application view
 pub struct PoopmanApp {
@@ -354,8 +357,8 @@ impl Render for PoopmanApp {
                     .child(
                         // Left: History panel with resizable width
                         resizable_panel()
-                            .size(px(280.)) // Initial width
-                            .size_range(px(200.)..px(500.)) // Can resize between 200px-500px
+                            .size(px(SIDEBAR_WIDTH))
+                            .size_range(px(SIDEBAR_MIN)..px(SIDEBAR_MAX))
                             .child(
                                 div()
                                     .size_full()
@@ -383,8 +386,8 @@ impl Render for PoopmanApp {
                                     v_resizable("request-response-splitter")
                                         .child(
                                             resizable_panel()
-                                                .size(px(350.)) // Request editor initial size
-                                                .size_range(px(150.)..px(700.)) // Can resize between 150px-700px
+                                                .size(px(REQUEST_INITIAL_HEIGHT))
+                                                .size_range(px(REQUEST_MIN)..px(REQUEST_MAX))
                                                 .child(self.request_editor.clone()),
                                         )
                                         .child(

--- a/src/body_editor.rs
+++ b/src/body_editor.rs
@@ -597,7 +597,7 @@ impl Render for BodyEditor {
                         this.child(
                             div()
                                 .w(px(RAW_SUBTYPE_WIDTH))
-                                .child(Select::new(&self.raw_subtype_select))
+                                .child(Select::new(&self.raw_subtype_select).small())
                         )
                         .child(
                             Button::new("format-button")
@@ -640,6 +640,11 @@ impl Render for BodyEditor {
                         .flex_col()
                         .flex_1()
                         .w_full()
+                        .rounded(theme.radius_lg)
+                        .border_1()
+                        .border_color(theme.border)
+                        .bg(theme.popover)
+                        .overflow_hidden()
                         .child(
                             Input::new(&self.raw_body_editor).w_full().h_full()
                         )

--- a/src/body_editor.rs
+++ b/src/body_editor.rs
@@ -2,7 +2,7 @@ use gpui::prelude::FluentBuilder as _;
 use gpui::*;
 use gpui::px;
 use gpui_component::{
-    button::*, checkbox::Checkbox, h_flex, input::{Input, InputState, InputEvent as InputChangeEvent},
+    button::*, checkbox::Checkbox, h_flex, input::{Input, InputState, InputEvent as InputChangeEvent, TabSize},
     select::*, v_flex, ActiveTheme as _, IndexPath, Sizable as _,
 };
 
@@ -86,6 +86,7 @@ impl BodyEditor {
                 .code_editor(current_raw_subtype.as_str())
                 .line_number(true)
                 .indent_guides(true)
+                .tab_size(TabSize { tab_size: 4, hard_tabs: false })
                 .placeholder(get_placeholder_for_subtype(current_raw_subtype))
         });
 

--- a/src/body_editor.rs
+++ b/src/body_editor.rs
@@ -602,6 +602,7 @@ impl Render for BodyEditor {
                         .child(
                             Button::new("format-button")
                                 .small()
+                                .ghost()
                                 .label("Format")
                                 .on_click(cx.listener(|this, _event, window, cx| {
                                     this.format_raw_body(window, cx);

--- a/src/body_editor.rs
+++ b/src/body_editor.rs
@@ -2,12 +2,11 @@ use gpui::prelude::FluentBuilder as _;
 use gpui::*;
 use gpui::px;
 use gpui_component::{
-    button::*, checkbox::Checkbox, h_flex, input::{Input, InputState, InputEvent as InputChangeEvent}, radio::RadioGroup,
+    button::*, checkbox::Checkbox, h_flex, input::{Input, InputState, InputEvent as InputChangeEvent},
     select::*, v_flex, ActiveTheme as _, IndexPath, Sizable as _,
 };
 
 use crate::types::{BodyType, FormDataRow, FormDataValue, RawSubtype};
-use crate::theme::RAW_SUBTYPE_WIDTH;
 
 use gpui::Subscription;
 
@@ -502,35 +501,6 @@ impl BodyEditor {
         cx.notify();
     }
 
-    /// Validate current raw body content
-    fn validate_raw_body(&mut self, cx: &mut Context<Self>) {
-        let content = self.raw_body_editor.read(cx).value().to_string();
-
-        let result = match self.current_raw_subtype {
-            RawSubtype::Json => crate::code_formatter::validate_json(&content),
-            RawSubtype::Xml => crate::code_formatter::validate_xml(&content),
-            _ => {
-                // Text and JavaScript don't need validation
-                return;
-            }
-        };
-
-        match result {
-            Ok(_) => {
-                if !content.trim().is_empty() {
-                    self.validation_message = Some(format!("✓ Valid {}", self.current_raw_subtype.as_str().to_uppercase()));
-                    self.validation_error = false;
-                } else {
-                    self.validation_message = None;
-                }
-            }
-            Err(err) => {
-                self.validation_message = Some(err);
-                self.validation_error = true;
-            }
-        }
-        cx.notify();
-    }
 
     fn select_file_for_row(&mut self, index: usize, _: &ClickEvent, window: &mut Window, cx: &mut Context<Self>) {
         let path = cx.prompt_for_paths(PathPromptOptions {
@@ -569,55 +539,71 @@ impl Render for BodyEditor {
             .flex_1()
             .min_h_0()  // Critical for scrolling to work in form-data
             .child(
-                // Body type selector (RadioGroup) with Raw subtype dropdown always visible
+                // Body type selector (custom muted radios) + Raw controls right-aligned
                 h_flex()
-                    .gap_2()
+                    .justify_between()
                     .items_center()
+                    .w_full()
                     .child(
-                        RadioGroup::horizontal("body-type")
-                            .children(vec!["None", "Raw", "Form-data"])
-                            .selected_index(Some(self.body_type_index))
-                            .on_click(cx.listener(|this, selected_ix: &usize, _window, cx| {
-                                this.body_type_index = *selected_ix;
-
-                                // Emit event to notify Content-Type changes
-                                let content_type = match *selected_ix {
-                                    0 => None, // BodyType::None
-                                    1 => Some(this.current_raw_subtype.content_type().to_string()), // Raw
-                                    2 => Some("multipart/form-data".to_string()), // FormData
-                                    _ => None,
-                                };
-
-                                cx.emit(BodyTypeChanged { content_type });
-                                cx.notify();
-                            }))
+                        h_flex().gap_4().items_center().children(
+                            ["None", "Raw", "Form-data"].into_iter().enumerate().map(|(i, label)| {
+                                let selected = self.body_type_index == i;
+                                h_flex()
+                                    .id(("body-type", i))
+                                    .gap_1p5()
+                                    .items_center()
+                                    .cursor_pointer()
+                                    .on_click(cx.listener(move |this, _, _window, cx| {
+                                        this.body_type_index = i;
+                                        let content_type = match i {
+                                            0 => None,
+                                            1 => Some(this.current_raw_subtype.content_type().to_string()),
+                                            2 => Some("multipart/form-data".to_string()),
+                                            _ => None,
+                                        };
+                                        cx.emit(BodyTypeChanged { content_type });
+                                        cx.notify();
+                                    }))
+                                    .child(
+                                        div()
+                                            .size(px(14.))
+                                            .rounded_full()
+                                            .border_1()
+                                            .border_color(if selected { theme.primary } else { theme.border })
+                                            .flex()
+                                            .items_center()
+                                            .justify_center()
+                                            .when(selected, |d| {
+                                                d.child(div().size(px(6.)).rounded_full().bg(theme.primary))
+                                            }),
+                                    )
+                                    .child(
+                                        div()
+                                            .text_sm()
+                                            .text_color(if selected {
+                                                theme.foreground
+                                            } else {
+                                                theme.muted_foreground
+                                            })
+                                            .child(label),
+                                    )
+                            }),
+                        ),
                     )
-                    .when(self.body_type_index == 1, |this| {
-                        // Raw subtype dropdown and format button - only show when Raw is selected
-                        this.child(
-                            div()
-                                .w(px(RAW_SUBTYPE_WIDTH))
-                                .child(Select::new(&self.raw_subtype_select).small())
-                        )
-                        .child(
-                            Button::new("format-button")
-                                .small()
-                                .ghost()
-                                .label("Format")
-                                .on_click(cx.listener(|this, _event, window, cx| {
-                                    this.format_raw_body(window, cx);
-                                }))
-                        )
-                        .child(
-                            Button::new("validate-button")
-                                .small()
-                                .ghost()
-                                .label("Validate")
-                                .on_click(cx.listener(|this, _event, _window, cx| {
-                                    this.validate_raw_body(cx);
-                                }))
-                        )
-                    })
+                    .child(
+                        h_flex().gap_3().items_center().when(self.body_type_index == 1, |this| {
+                            this.child(Select::new(&self.raw_subtype_select).small().appearance(false))
+                                .child(
+                                    Button::new("format-button")
+                                        .small()
+                                        .ghost()
+                                        .label("Format")
+                                        .on_click(cx.listener(|this, _event, window, cx| {
+                                            this.format_raw_body(window, cx);
+                                        })),
+                                )
+                        }),
+                    )
             )
             // Body content based on selected type
             .when(self.body_type_index == 0, |this| {

--- a/src/body_editor.rs
+++ b/src/body_editor.rs
@@ -7,6 +7,7 @@ use gpui_component::{
 };
 
 use crate::types::{BodyType, FormDataRow, FormDataValue, RawSubtype};
+use crate::theme::RAW_SUBTYPE_WIDTH;
 
 use gpui::Subscription;
 
@@ -595,7 +596,7 @@ impl Render for BodyEditor {
                         // Raw subtype dropdown and format button - only show when Raw is selected
                         this.child(
                             div()
-                                .w(px(120.))
+                                .w(px(RAW_SUBTYPE_WIDTH))
                                 .child(Select::new(&self.raw_subtype_select))
                         )
                         .child(

--- a/src/body_editor.rs
+++ b/src/body_editor.rs
@@ -590,8 +590,16 @@ impl Render for BodyEditor {
                             })
                         )
                         .when(self.body_type_index == 1, |this| {
-                            // JSON subtype dropdown sits right after the radios (left-packed)
-                            this.child(Select::new(&self.raw_subtype_select).small().appearance(false))
+                            // JSON subtype dropdown, slightly separated from the radios.
+                            // Explicit menu_width so longer names (JavaScript) aren't truncated.
+                            this.child(
+                                div().ml_2().child(
+                                    Select::new(&self.raw_subtype_select)
+                                        .small()
+                                        .appearance(false)
+                                        .menu_width(px(130.)),
+                                ),
+                            )
                         }),
                     )
                     .child(

--- a/src/body_editor.rs
+++ b/src/body_editor.rs
@@ -546,7 +546,7 @@ impl Render for BodyEditor {
                     .w_full()
                     .child(
                         h_flex().gap_4().items_center().children(
-                            ["None", "Raw", "Form-data"].into_iter().enumerate().map(|(i, label)| {
+                            ["none", "raw", "form-data"].into_iter().enumerate().map(|(i, label)| {
                                 let selected = self.body_type_index == i;
                                 h_flex()
                                     .id(("body-type", i))
@@ -587,21 +587,25 @@ impl Render for BodyEditor {
                                             })
                                             .child(label),
                                     )
-                            }),
-                        ),
+                            })
+                        )
+                        .when(self.body_type_index == 1, |this| {
+                            // JSON subtype dropdown sits right after the radios (left-packed)
+                            this.child(Select::new(&self.raw_subtype_select).small().appearance(false))
+                        }),
                     )
                     .child(
-                        h_flex().gap_3().items_center().when(self.body_type_index == 1, |this| {
-                            this.child(Select::new(&self.raw_subtype_select).small().appearance(false))
-                                .child(
-                                    Button::new("format-button")
-                                        .small()
-                                        .ghost()
-                                        .label("Format")
-                                        .on_click(cx.listener(|this, _event, window, cx| {
-                                            this.format_raw_body(window, cx);
-                                        })),
-                                )
+                        // Right-aligned action, like Postman's Beautify
+                        h_flex().items_center().when(self.body_type_index == 1, |this| {
+                            this.child(
+                                Button::new("beautify-button")
+                                    .small()
+                                    .ghost()
+                                    .label("Beautify")
+                                    .on_click(cx.listener(|this, _event, window, cx| {
+                                        this.format_raw_body(window, cx);
+                                    })),
+                            )
                         }),
                     )
             )

--- a/src/code_formatter.rs
+++ b/src/code_formatter.rs
@@ -37,6 +37,7 @@ pub fn format_json(input: &str) -> Result<String, String> {
 /// # Returns
 /// * `Ok(())` - Valid JSON
 /// * `Err(String)` - Validation error message
+#[allow(dead_code)] // retained for tests and future validation feature
 pub fn validate_json(input: &str) -> Result<(), String> {
     if input.trim().is_empty() {
         return Ok(()); // Empty is considered valid (no content to validate)

--- a/src/code_formatter.rs
+++ b/src/code_formatter.rs
@@ -3,19 +3,32 @@
 //! This module provides pure functions for formatting and validating JSON, XML,
 //! and JavaScript code. All functions are stateless and can be tested independently.
 
+use serde::Serialize;
+
+/// Pretty-print a parsed JSON value with 4-space indentation (Postman-style).
+pub fn pretty_json_4(value: &serde_json::Value) -> Result<String, String> {
+    let mut buf = Vec::new();
+    let formatter = serde_json::ser::PrettyFormatter::with_indent(b"    ");
+    let mut ser = serde_json::Serializer::with_formatter(&mut buf, formatter);
+    value
+        .serialize(&mut ser)
+        .map_err(|e| format!("JSON format error: {}", e))?;
+    String::from_utf8(buf).map_err(|e| format!("JSON encode error: {}", e))
+}
+
 /// Format JSON string with pretty indentation.
 ///
 /// # Arguments
 /// * `input` - Raw JSON string
 ///
 /// # Returns
-/// * `Ok(String)` - Formatted JSON with 2-space indentation
+/// * `Ok(String)` - Formatted JSON with 4-space indentation
 /// * `Err(String)` - Parse error message
 ///
 /// # Examples
 /// ```
 /// let formatted = format_json(r#"{"key":"value"}"#)?;
-/// assert_eq!(formatted, "{\n  \"key\": \"value\"\n}");
+/// assert_eq!(formatted, "{\n    \"key\": \"value\"\n}");
 /// ```
 pub fn format_json(input: &str) -> Result<String, String> {
     if input.trim().is_empty() {
@@ -25,8 +38,7 @@ pub fn format_json(input: &str) -> Result<String, String> {
     let value: serde_json::Value = serde_json::from_str(input)
         .map_err(|e| format!("JSON parse error: {}", e))?;
 
-    serde_json::to_string_pretty(&value)
-        .map_err(|e| format!("JSON format error: {}", e))
+    pretty_json_4(&value)
 }
 
 /// Validate JSON syntax without formatting.
@@ -134,6 +146,13 @@ mod tests {
         assert!(result.contains("\"key\""));
         assert!(result.contains("\"value\""));
         assert!(result.contains('\n')); // Has newlines
+    }
+
+    #[test]
+    fn test_format_json_4_space_indent() {
+        // Postman-style 4-space indentation
+        let result = format_json(r#"{"key":"value"}"#).unwrap();
+        assert_eq!(result, "{\n    \"key\": \"value\"\n}");
     }
 
     #[test]

--- a/src/history_panel.rs
+++ b/src/history_panel.rs
@@ -1,7 +1,7 @@
 use gpui::prelude::FluentBuilder as _;
 use gpui::*;
 use gpui_component::{
-    button::*, h_flex, Icon, scroll::ScrollableElement as _, v_flex, ActiveTheme as _,
+    button::*, h_flex, scroll::ScrollableElement as _, v_flex, ActiveTheme as _,
     Sizable as _,
 };
 use std::sync::Arc;
@@ -100,15 +100,10 @@ impl Render for HistoryPanel {
                     .border_b_1()
                     .border_color(theme.border)
                     .child(
-                        h_flex()
-                            .items_center()
-                            .gap_2()
-                            .child(
-                                Icon::default()
-                                    .path("icons/logo.svg")
-                                    .size_5()
-                            )
-                            .child(div().font_weight(FontWeight::SEMIBOLD).child("History"))
+                        div()
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .text_color(theme.foreground)
+                            .child("History")
                     )
                     .child(
                         Button::new("clear-btn")
@@ -136,96 +131,58 @@ impl Render for HistoryPanel {
                     // List - use size_full to fill available space
                     v_flex()
                         .size_full()
-                        .gap_2()
-                        .p_2()
+                        .gap_0p5()
+                        .px_2()
+                        .py_1()
                         .children(self.history.iter().map(|item| {
                             let item_id = item.id;
                             let is_selected = self.selected_id == Some(item_id);
-                            let method = item.request.method.as_str();
-                            let url = &item.request.url;
+                            let verb = item.request.method.as_str();
+                            let verb_color = crate::theme::method_color(item.request.method, theme);
+                            let url = item.request.url.clone();
                             let time = Self::format_relative_time(&item.timestamp);
-
-                            let method_color = match method {
-                                "GET" => theme.success,
-                                "POST" => theme.accent,
-                                "PUT" => theme.warning,
-                                "DELETE" => theme.danger,
-                                _ => theme.muted_foreground,
-                            };
-
-                            let status_color = if let Some(response) = &item.response {
-                                if response.is_success() {
-                                    Some(theme.success)
-                                } else if response.is_error() {
-                                    Some(theme.danger)
-                                } else {
-                                    Some(theme.accent)
-                                }
-                            } else {
-                                None
-                            };
-
                             let item_clone = item.clone();
 
-                            div()
+                            h_flex()
                                 .id(("history-item", item_id as u64))
+                                .gap_2()
+                                .items_start()
                                 .w_full()
-                                .px_3()
-                                .py_2()
-                                .bg(if is_selected {
-                                    theme.list_active
-                                } else {
-                                    theme.list
-                                })
+                                .px_2p5()
+                                .py_1p5()
+                                .rounded(theme.radius)
                                 .border_1()
                                 .border_color(if is_selected {
                                     theme.list_active_border
                                 } else {
-                                    theme.border
+                                    gpui::transparent_black()
                                 })
-                                .rounded(theme.radius)
+                                .bg(if is_selected {
+                                    theme.list_active
+                                } else {
+                                    gpui::transparent_black()
+                                })
                                 .cursor_pointer()
-                                .on_click(cx.listener(
-                                    move |this, _event: &gpui::ClickEvent, window, cx| {
-                                        this.on_item_click(&item_clone, window, cx);
-                                    },
-                                ))
+                                .hover(|s| s.bg(if is_selected { theme.list_active } else { theme.list_hover }))
+                                .on_click(cx.listener(move |this, _event: &gpui::ClickEvent, window, cx| {
+                                    this.on_item_click(&item_clone, window, cx);
+                                }))
+                                .child(
+                                    // small mono method label, no filled pill
+                                    div()
+                                        .flex_shrink_0()
+                                        .w(px(34.))
+                                        .text_right()
+                                        .text_xs()
+                                        .font_weight(FontWeight::BOLD)
+                                        .text_color(verb_color)
+                                        .child(verb),
+                                )
                                 .child(
                                     v_flex()
-                                        .gap_1()
-                                        .child(
-                                            h_flex()
-                                                .gap_2()
-                                                .items_center()
-                                                .child(
-                                                    div()
-                                                        .px_2()
-                                                        .py_1()
-                                                        .rounded(theme.radius)
-                                                        .bg(method_color)
-                                                        .text_color(gpui::white())
-                                                        .text_xs()
-                                                        .flex_shrink_0()
-                                                        .child(method),
-                                                )
-                                                .when_some(status_color, |this, color| {
-                                                    this.child(
-                                                        div()
-                                                            .px_2()
-                                                            .py_1()
-                                                            .rounded(theme.radius)
-                                                            .bg(color)
-                                                            .text_color(gpui::white())
-                                                            .text_xs()
-                                                            .flex_shrink_0()
-                                                                                                                          .child(
-                                                                                                                            item.response
-                                                                                                                                .as_ref()
-                                                                                                                                .map(|r| r.status_text())
-                                                                                                                                .unwrap_or("NET ERR"),
-                                                                                                                        ),                                                    )
-                                                }),
-                                        )
+                                        .min_w_0()
+                                        .flex_1()
+                                        .gap_0p5()
                                         .child(
                                             div()
                                                 .text_sm()
@@ -233,7 +190,7 @@ impl Render for HistoryPanel {
                                                 .overflow_x_hidden()
                                                 .whitespace_nowrap()
                                                 .text_ellipsis()
-                                                .child(url.clone()),
+                                                .child(url),
                                         )
                                         .child(
                                             div()

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,12 @@ fn main() {
         crate::theme::apply_theme(cx);
 
         cx.spawn(async move |cx| {
-            cx.open_window(WindowOptions::default(), |window, cx| {
+            let window_options = WindowOptions {
+                titlebar: Some(gpui_component::TitleBar::title_bar_options()),
+                window_min_size: Some(size(px(720.), px(480.))),
+                ..Default::default()
+            };
+            cx.open_window(window_options, |window, cx| {
                 let view = cx.new(|cx| PoopmanApp::new(window, cx));
                 cx.new(|cx| Root::new(view, window, cx))
             })?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod request_editor;
 mod request_tab;
 mod response_viewer;
 mod tab_bar;
+mod theme;
 mod types;
 mod url_params;
 
@@ -100,6 +101,7 @@ fn main() {
 
     app.run(move |cx| {
         gpui_component::init(cx);
+        crate::theme::apply_theme(cx);
 
         cx.spawn(async move |cx| {
             cx.open_window(WindowOptions::default(), |window, cx| {

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -1074,42 +1074,83 @@ impl Render for RequestEditor {
                             div()
                                 .flex()
                                 .flex_row()
-                                .gap_1()
+                                .gap_5()
+                                .border_b_1()
+                                .border_color(theme.border)
                                 .child(
-                                    Button::new("tab-headers")
-                                        .ghost()
-                                        .label("Headers")
-                                        .when(self.active_tab == 0, |btn| btn.primary())
+                                    div()
+                                        .id("tab-headers")
+                                        .px_0p5()
+                                        .pb_2()
+                                        .text_sm()
+                                        .cursor_pointer()
+                                        .border_b_2()
+                                        .when(self.active_tab == 0, |this| {
+                                            this.border_color(theme.primary)
+                                                .text_color(theme.primary)
+                                                .font_weight(FontWeight::SEMIBOLD)
+                                        })
+                                        .when(self.active_tab != 0, |this| {
+                                            this.border_color(gpui::transparent_black())
+                                                .text_color(theme.muted_foreground)
+                                        })
                                         .on_click(cx.listener(
                                             |this, _event: &gpui::ClickEvent, _window, cx| {
                                                 this.active_tab = 0;
                                                 cx.notify();
                                             },
-                                        )),
+                                        ))
+                                        .child("Headers"),
                                 )
                                 .child(
-                                    Button::new("tab-params")
-                                        .ghost()
-                                        .label("Params")
-                                        .when(self.active_tab == 1, |btn| btn.primary())
+                                    div()
+                                        .id("tab-params")
+                                        .px_0p5()
+                                        .pb_2()
+                                        .text_sm()
+                                        .cursor_pointer()
+                                        .border_b_2()
+                                        .when(self.active_tab == 1, |this| {
+                                            this.border_color(theme.primary)
+                                                .text_color(theme.primary)
+                                                .font_weight(FontWeight::SEMIBOLD)
+                                        })
+                                        .when(self.active_tab != 1, |this| {
+                                            this.border_color(gpui::transparent_black())
+                                                .text_color(theme.muted_foreground)
+                                        })
                                         .on_click(cx.listener(
                                             |this, _event: &gpui::ClickEvent, _window, cx| {
                                                 this.active_tab = 1;
                                                 cx.notify();
                                             },
-                                        )),
+                                        ))
+                                        .child("Params"),
                                 )
                                 .child(
-                                    Button::new("tab-body")
-                                        .ghost()
-                                        .label("Body")
-                                        .when(self.active_tab == 2, |btn| btn.primary())
+                                    div()
+                                        .id("tab-body")
+                                        .px_0p5()
+                                        .pb_2()
+                                        .text_sm()
+                                        .cursor_pointer()
+                                        .border_b_2()
+                                        .when(self.active_tab == 2, |this| {
+                                            this.border_color(theme.primary)
+                                                .text_color(theme.primary)
+                                                .font_weight(FontWeight::SEMIBOLD)
+                                        })
+                                        .when(self.active_tab != 2, |this| {
+                                            this.border_color(gpui::transparent_black())
+                                                .text_color(theme.muted_foreground)
+                                        })
                                         .on_click(cx.listener(
                                             |this, _event: &gpui::ClickEvent, _window, cx| {
                                                 this.active_tab = 2;
                                                 cx.notify();
                                             },
-                                        )),
+                                        ))
+                                        .child("Body"),
                                 ),
                         )
                         .when(self.active_tab == 0, |this| {

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -12,6 +12,7 @@ use gpui_component::input::InputEvent;
 use crate::body_editor::{BodyEditor, BodyTypeChanged};
 use crate::types::{HeaderType, HttpMethod, PredefinedHeader, RequestData, ResponseData};
 use crate::url_params::{self, QueryParam};
+use crate::theme::METHOD_SELECT_WIDTH;
 
 /// Event emitted when a request is sent and response is received
 #[derive(Clone)]
@@ -1038,7 +1039,7 @@ impl Render for RequestEditor {
                             // Method selector - prevent it from growing
                             div()
                                 .flex_shrink_0()
-                                .w(px(100.))
+                                .w(px(METHOD_SELECT_WIDTH))
                                 .child(Select::new(&self.method_select)),
                         )
                         .child(

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -1020,14 +1020,6 @@ impl Render for RequestEditor {
                 .border_b_1()
                 .border_color(theme.border)
                 .child(
-                    // Section title
-                    div()
-                        .text_sm()
-                        .font_weight(FontWeight::SEMIBOLD)
-                        .text_color(theme.muted_foreground)
-                        .child("REQUEST"),
-                )
-                .child(
                     // URL bar
                     div()
                         .flex()

--- a/src/response_viewer.rs
+++ b/src/response_viewer.rs
@@ -19,6 +19,7 @@ impl ResponseViewer {
                 .code_editor("json")
                 .line_number(true)
                 .multi_line(true)
+                .tab_size(TabSize { tab_size: 4, hard_tabs: false })
         });
 
         Self {

--- a/src/response_viewer.rs
+++ b/src/response_viewer.rs
@@ -188,23 +188,11 @@ impl Render for ResponseViewer {
             .bg(theme.background)
             .on_click(cx.listener(|_, _, _, cx| cx.stop_propagation())) // Prevent click events from propagating
             .child(
-                // Response section with header
+                // Response status bar (self-styled with its own padding + bottom border)
                 div()
                     .flex()
                     .flex_col()
-                    .gap_3()
-                    .p_4()
                     .w_full()
-                    .border_b_1()
-                    .border_color(theme.border)
-                    .child(
-                        // Section title
-                        div()
-                            .text_sm()
-                            .font_weight(FontWeight::SEMIBOLD)
-                            .text_color(theme.muted_foreground)
-                            .child("RESPONSE"),
-                    )
                     .child(self.render_status_bar(cx)),
             )
             .when_some(self.response.as_ref(), |this, _| {

--- a/src/response_viewer.rs
+++ b/src/response_viewer.rs
@@ -1,6 +1,6 @@
 use gpui::prelude::FluentBuilder as _;
 use gpui::*;
-use gpui_component::{button::*, h_flex, input::*, v_flex, ActiveTheme as _};
+use gpui_component::{h_flex, input::*, v_flex, ActiveTheme as _};
 
 use crate::types::ResponseData;
 
@@ -93,8 +93,8 @@ impl ResponseViewer {
             h_flex()
                 .gap_3()
                 .items_center()
-                .p_2()
-                .bg(cx.theme().muted)
+                .px_4()
+                .py_2p5()
                 .border_b_1()
                 .border_color(cx.theme().border)
                 .child(
@@ -121,10 +121,11 @@ impl ResponseViewer {
                 })
         } else {
             h_flex()
-                .p_2()
-                .bg(cx.theme().muted)
+                .px_4()
+                .py_2p5()
                 .border_b_1()
                 .border_color(cx.theme().border)
+                .text_color(cx.theme().muted_foreground)
                 .child("No response yet")
         }
     }
@@ -219,30 +220,58 @@ impl Render for ResponseViewer {
                             div()
                                 .flex()
                                 .flex_row()
-                                .gap_1()
+                                .gap_5()
+                                .border_b_1()
+                                .border_color(theme.border)
                                 .child(
-                                    Button::new("tab-body")
-                                        .ghost()
-                                        .label("Body")
-                                        .when(self.active_tab == 0, |btn| btn.primary())
+                                    div()
+                                        .id("resp-tab-body")
+                                        .px_0p5()
+                                        .pb_2()
+                                        .text_sm()
+                                        .cursor_pointer()
+                                        .border_b_2()
+                                        .when(self.active_tab == 0, |this| {
+                                            this.border_color(theme.primary)
+                                                .text_color(theme.primary)
+                                                .font_weight(FontWeight::SEMIBOLD)
+                                        })
+                                        .when(self.active_tab != 0, |this| {
+                                            this.border_color(gpui::transparent_black())
+                                                .text_color(theme.muted_foreground)
+                                        })
                                         .on_click(cx.listener(
                                             |this, _event: &gpui::ClickEvent, _window, cx| {
                                                 this.active_tab = 0;
                                                 cx.notify();
                                             },
-                                        )),
+                                        ))
+                                        .child("Body"),
                                 )
                                 .child(
-                                    Button::new("tab-headers")
-                                        .ghost()
-                                        .label("Headers")
-                                        .when(self.active_tab == 1, |btn| btn.primary())
+                                    div()
+                                        .id("resp-tab-headers")
+                                        .px_0p5()
+                                        .pb_2()
+                                        .text_sm()
+                                        .cursor_pointer()
+                                        .border_b_2()
+                                        .when(self.active_tab == 1, |this| {
+                                            this.border_color(theme.primary)
+                                                .text_color(theme.primary)
+                                                .font_weight(FontWeight::SEMIBOLD)
+                                        })
+                                        .when(self.active_tab != 1, |this| {
+                                            this.border_color(gpui::transparent_black())
+                                                .text_color(theme.muted_foreground)
+                                        })
                                         .on_click(cx.listener(
                                             |this, _event: &gpui::ClickEvent, _window, cx| {
                                                 this.active_tab = 1;
                                                 cx.notify();
                                             },
-                                        )),
+                                        ))
+                                        .child("Headers"),
                                 ),
                         )
                         .when(self.active_tab == 0, |this| {
@@ -256,6 +285,11 @@ impl Render for ResponseViewer {
                                     .flex_col()
                                     .flex_1()
                                     .w_full()
+                                    .rounded(theme.radius_lg)
+                                    .border_1()
+                                    .border_color(theme.border)
+                                    .bg(theme.popover)
+                                    .overflow_hidden()
                                     .child(
                                         Input::new(&self.body_display)
                                             .disabled(is_error)

--- a/src/response_viewer.rs
+++ b/src/response_viewer.rs
@@ -39,7 +39,7 @@ impl ResponseViewer {
         // Try to format JSON body for better display
         let formatted_body =
             if let Ok(json) = serde_json::from_str::<serde_json::Value>(&response.body) {
-                serde_json::to_string_pretty(&json).unwrap_or(response.body.clone())
+                crate::code_formatter::pretty_json_4(&json).unwrap_or(response.body.clone())
             } else {
                 response.body.clone()
             };

--- a/src/tab_bar.rs
+++ b/src/tab_bar.rs
@@ -3,6 +3,7 @@ use gpui::px;
 use gpui_component::{h_flex, ActiveTheme as _};
 
 use crate::request_tab::RequestTab;
+use crate::theme::method_color;
 
 /// Event emitted when a tab is clicked
 #[derive(Clone)]
@@ -83,16 +84,7 @@ impl Render for TabBar {
                         let tab_index = index;
                         let method = tab.request.method.as_str();
 
-                        // Method color badge
-                        let method_color = match tab.request.method {
-                            crate::types::HttpMethod::GET => gpui::rgb(0x61affe),
-                            crate::types::HttpMethod::POST => gpui::rgb(0x49cc90),
-                            crate::types::HttpMethod::PUT => gpui::rgb(0xfca130),
-                            crate::types::HttpMethod::DELETE => gpui::rgb(0xf93e3e),
-                            crate::types::HttpMethod::PATCH => gpui::rgb(0x50e3c2),
-                            crate::types::HttpMethod::HEAD => gpui::rgb(0x9012fe),
-                            crate::types::HttpMethod::OPTIONS => gpui::rgb(0x0d5aa7),
-                        };
+                        let verb_color = method_color(tab.request.method, theme);
 
                         h_flex()
                             .id(("tab", tab.id))
@@ -103,25 +95,17 @@ impl Render for TabBar {
                             .rounded_sm()
                             .border_1()
                             .border_color(if is_active { theme.border } else { gpui::transparent_black() })
-                            .bg(if is_active { theme.list_active } else { theme.background })
+                            .bg(if is_active { theme.tab_active } else { theme.background })
                             .cursor_pointer()
                             .on_click(cx.listener(move |this, event, window, cx| {
                                 this.on_tab_click(tab_index, event, window, cx);
                             }))
                             .child(
-                                // Method badge
                                 div()
-                                    .px_1p5()
-                                    .py_0p5()
-                                    .rounded_sm()
-                                    .bg(method_color)
-                                    .child(
-                                        div()
-                                            .text_xs()
-                                            .font_weight(gpui::FontWeight::BOLD)
-                                            .text_color(gpui::white())
-                                            .child(method)
-                                    )
+                                    .text_xs()
+                                    .font_weight(gpui::FontWeight::BOLD)
+                                    .text_color(verb_color)
+                                    .child(method)
                             )
                             .child(
                                 // Tab title

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -117,4 +117,8 @@ pub fn apply_theme(cx: &mut App) {
     // Scrollbar
     theme.scrollbar_thumb = c(SCROLLBAR);
     theme.scrollbar_thumb_hover = c(MUTED_FG);
+
+    // Custom title bar (warm, matches sidebar)
+    theme.title_bar = c(SIDEBAR);
+    theme.title_bar_border = c(BORDER);
 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -47,7 +47,6 @@ fn c(hex: u32) -> Hsla {
 }
 
 /// Semantic color for an HTTP method label (used by tab bar + history).
-#[allow(dead_code)]
 pub fn method_color(method: HttpMethod, theme: &Theme) -> Hsla {
     match method {
         HttpMethod::GET => theme.success,

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,0 +1,121 @@
+//! Warm-light ("Claude paper") theme: palette, layout dimensions, and the
+//! global theme application applied once at startup.
+
+use gpui::{px, App, Hsla};
+use gpui_component::{Theme, ThemeMode};
+
+use crate::types::HttpMethod;
+
+// ===== Palette (warm paper light), as 0xRRGGBB =====
+const BACKGROUND: u32 = 0xFAF9F5; // main canvas
+const SIDEBAR: u32 = 0xF0EEE6; // sidebar / muted surfaces
+const SURFACE: u32 = 0xFFFFFF; // white surfaces (input / popover)
+const FOREGROUND: u32 = 0x1A1915; // primary text
+const MUTED_FG: u32 = 0x73706A; // secondary text
+const BORDER: u32 = 0xE7E4DA; // hairline border
+const HOVER: u32 = 0xEBE8DE; // subtle warm hover bg
+const PRIMARY: u32 = 0xC15F3C; // coral / terracotta accent
+const PRIMARY_HOVER: u32 = 0xAD5435;
+const WASH: u32 = 0xF3E7E0; // light coral selection wash
+const WASH_BORDER: u32 = 0xE8D3C8;
+const SUCCESS: u32 = 0x4F8A5B; // 2xx / GET
+const DANGER: u32 = 0xC0503F; // 4xx-5xx / DELETE
+const WARNING: u32 = 0xC98A3C; // amber / POST,PUT
+const SCROLLBAR: u32 = 0xD8D4C8;
+
+// ===== Layout dimensions (px) =====
+#[allow(dead_code)]
+pub const SIDEBAR_WIDTH: f32 = 264.;
+#[allow(dead_code)]
+pub const SIDEBAR_MIN: f32 = 200.;
+#[allow(dead_code)]
+pub const SIDEBAR_MAX: f32 = 420.;
+#[allow(dead_code)]
+pub const REQUEST_INITIAL_HEIGHT: f32 = 350.;
+#[allow(dead_code)]
+pub const REQUEST_MIN: f32 = 150.;
+#[allow(dead_code)]
+pub const REQUEST_MAX: f32 = 700.;
+#[allow(dead_code)]
+pub const METHOD_SELECT_WIDTH: f32 = 92.;
+#[allow(dead_code)]
+pub const RAW_SUBTYPE_WIDTH: f32 = 120.;
+
+/// Convert a 0xRRGGBB literal into an Hsla theme color.
+fn c(hex: u32) -> Hsla {
+    gpui::rgb(hex).into()
+}
+
+/// Semantic color for an HTTP method label (used by tab bar + history).
+#[allow(dead_code)]
+pub fn method_color(method: HttpMethod, theme: &Theme) -> Hsla {
+    match method {
+        HttpMethod::GET => theme.success,
+        HttpMethod::POST | HttpMethod::PUT | HttpMethod::PATCH => theme.warning,
+        HttpMethod::DELETE => theme.danger,
+        HttpMethod::HEAD | HttpMethod::OPTIONS => theme.muted_foreground,
+    }
+}
+
+/// Apply the warm-light theme to the global Theme. Call once after
+/// `gpui_component::init(cx)`.
+pub fn apply_theme(cx: &mut App) {
+    let theme = Theme::global_mut(cx);
+    theme.mode = ThemeMode::Light;
+    theme.radius = px(6.);
+    theme.radius_lg = px(8.);
+
+    // Surfaces & text
+    theme.background = c(BACKGROUND);
+    theme.foreground = c(FOREGROUND);
+    theme.muted = c(SIDEBAR);
+    theme.muted_foreground = c(MUTED_FG);
+    theme.border = c(BORDER);
+    theme.input = c(SURFACE);
+    theme.popover = c(SURFACE);
+    theme.popover_foreground = c(FOREGROUND);
+    theme.secondary = c(SIDEBAR);
+    theme.secondary_foreground = c(FOREGROUND);
+    theme.secondary_hover = c(HOVER);
+    theme.secondary_active = c(HOVER);
+
+    // Sidebar
+    theme.sidebar = c(SIDEBAR);
+    theme.sidebar_foreground = c(FOREGROUND);
+    theme.sidebar_border = c(BORDER);
+
+    // Accent / primary (coral)
+    theme.primary = c(PRIMARY);
+    theme.primary_hover = c(PRIMARY_HOVER);
+    theme.primary_active = c(PRIMARY_HOVER);
+    theme.primary_foreground = c(SURFACE);
+    theme.ring = c(PRIMARY);
+    theme.caret = c(PRIMARY);
+    theme.accent = c(WASH);
+    theme.accent_foreground = c(FOREGROUND);
+    theme.selection = c(WASH);
+
+    // Lists (history rows)
+    theme.list = c(SIDEBAR);
+    theme.list_hover = c(HOVER);
+    theme.list_active = c(WASH);
+    theme.list_active_border = c(WASH_BORDER);
+
+    // Tabs
+    theme.tab = c(BACKGROUND);
+    theme.tab_active = c(SURFACE);
+
+    // Status semantics
+    theme.success = c(SUCCESS);
+    theme.success_foreground = c(SURFACE);
+    theme.danger = c(DANGER);
+    theme.danger_foreground = c(SURFACE);
+    theme.danger_hover = c(DANGER);
+    theme.danger_active = c(DANGER);
+    theme.warning = c(WARNING);
+    theme.warning_foreground = c(SURFACE);
+
+    // Scrollbar
+    theme.scrollbar_thumb = c(SCROLLBAR);
+    theme.scrollbar_thumb_hover = c(MUTED_FG);
+}


### PR DESCRIPTION
## 概述

全量 UI 重设计,目标 Claude/Anthropic 暖调观感(纸感背景 + 珊瑚橘强调色),布局 B(侧边栏 + 请求上/响应下)。两层实现:全局主题模块统一配色,各面板结构微调治密度/笨重。

## 主要改动

**主题层**
- 新增 `src/theme.rs`:暖调调色板(纸白 `#FAF9F5` / 珊瑚 `#C15F3C` / 发丝边框)、字体圆角、尺寸常量,`gpui_component::init` 后经 `Theme::global_mut` 全局应用 —— 一次性统一原先杂乱的绿/黑/蓝强调色
- 顺带把散落的 `px()` 魔法数字提成具名常量

**自定义标题栏**
- 用 gpui-component `TitleBar` 替掉白色原生标题栏,自绘最小化/最大化/关闭(新增 4 个窗口控制 SVG,库不自带),消除左上角怪图标

**各面板**
- History:单行紧凑、方法文字标签(去实心药丸)、去掉 logo 圆点、浅珊瑚选中
- Tab 栏:方法文字标签、纸白选中态
- 请求区:内层 tab 下划线式;去掉 REQUEST/RESPONSE 大写标题
- Body:Postman 风格选择行(小写 `none/raw/form-data` 小号灰字单选、无边框 JSON 下拉左贴、Beautify 右对齐);删除冗余 Validate;JSON 下拉加宽防截断
- 响应区:状态 `200 OK` 色块 pill + 元信息、响应体卡片化、下划线 tab
- JSON:Beautify 与代码编辑器均改 4 空格缩进(`pretty_json_4` + 编辑器 `tab_size(4)`)

## 验证

- `cargo check` / `cargo check --tests` 干净(仅 2 个预先存在的 dead-code 警告)
- Windows release 多轮构建链接通过、真机逐项目视验收(对照 `docs/superpowers/specs/2026-06-17-ui-redesign-mockup.html`)
- 新增单测 `test_format_json_4_space_indent`

## 范围外(后续)

深色主题、gzip 解压、form-data 真 multipart、二进制响应、Collections/环境变量/认证。功能逻辑未改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)