### PR TITLE
feat: 真正的 multipart/form-data 上传

### DIFF
--- a/src/body_editor.rs
+++ b/src/body_editor.rs
@@ -287,7 +287,7 @@ impl BodyEditor {
         let content_type = match body {
             BodyType::None => None,
             BodyType::Raw { subtype, .. } => Some(subtype.content_type().to_string()),
-            BodyType::FormData(_) => Some("multipart/form-data".to_string()),
+            BodyType::FormData(_) => Some("multipart/form-data; boundary=<auto>".to_string()),
         };
 
         cx.emit(BodyTypeChanged { content_type });
@@ -559,7 +559,7 @@ impl Render for BodyEditor {
                                         let content_type = match i {
                                             0 => None,
                                             1 => Some(this.current_raw_subtype.content_type().to_string()),
-                                            2 => Some("multipart/form-data".to_string()),
+                                            2 => Some("multipart/form-data; boundary=<auto>".to_string()),
                                             _ => None,
                                         };
                                         cx.emit(BodyTypeChanged { content_type });

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -1,11 +1,21 @@
 use std::sync::OnceLock;
 use anyhow::Result;
-use gpui::http_client::http;
 use tokio::runtime::Runtime;
+
+use crate::types::{BodyType, FormDataValue, HttpMethod};
 
 static RUNTIME: OnceLock<Runtime> = OnceLock::new();
 
-/// Simple HTTP client that manages its own tokio runtime
+/// A fully-read HTTP response. The body is collected on the tokio runtime
+/// (reqwest's body stream requires its reactor), so callers can use it freely.
+pub struct HttpResponse {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    pub body: Vec<u8>,
+}
+
+/// HTTP client that builds reqwest requests natively and manages its own
+/// tokio runtime.
 pub struct HttpClient {
     client: reqwest::Client,
 }
@@ -19,34 +29,22 @@ impl HttpClient {
         Self { client }
     }
 
+    /// Send a request built from our own model.
+    ///
+    /// - `BodyType::Raw` is sent as a raw byte body.
+    /// - `BodyType::FormData` is sent as real `multipart/form-data` via
+    ///   reqwest's `multipart::Form` (it generates the boundary and the
+    ///   `Content-Type` header; file parts are read from disk with their MIME
+    ///   guessed from the extension).
     pub async fn send(
         &self,
-        request: http::Request<gpui::http_client::AsyncBody>,
-    ) -> Result<http::Response<gpui::http_client::AsyncBody>> {
-        let (parts, body) = request.into_parts();
+        method: HttpMethod,
+        url: String,
+        headers: Vec<(String, String)>,
+        body: BodyType,
+    ) -> Result<HttpResponse> {
+        let client = self.client.clone();
 
-        // Convert AsyncBody to bytes
-        let body_bytes = match body.0 {
-            gpui::http_client::Inner::Empty => vec![],
-            gpui::http_client::Inner::Bytes(cursor) => cursor.into_inner().to_vec(),
-            gpui::http_client::Inner::AsyncReader(mut reader) => {
-                use futures::AsyncReadExt;
-                let mut bytes = Vec::new();
-                reader.read_to_end(&mut bytes).await?;
-                bytes
-            }
-        };
-
-        // Build reqwest request
-        let mut req = self.client
-            .request(parts.method, parts.uri.to_string())
-            .headers(parts.headers);
-
-        if !body_bytes.is_empty() {
-            req = req.body(body_bytes);
-        }
-
-        // Send request in tokio runtime
         let runtime = RUNTIME.get_or_init(|| {
             tokio::runtime::Builder::new_multi_thread()
                 .worker_threads(2)
@@ -55,22 +53,74 @@ impl HttpClient {
                 .expect("Failed to initialize tokio runtime")
         });
 
-        let response = runtime.spawn(async move {
-            req.send().await
-        }).await??;
+        runtime
+            .spawn(async move {
+                let reqwest_method = reqwest::Method::from_bytes(method.as_str().as_bytes())?;
+                let mut req = client.request(reqwest_method, &url);
 
-        // Convert response
-        let status = response.status();
-        let headers = response.headers().clone();
-        let body_bytes = response.bytes().await?;
+                let is_form = matches!(body, BodyType::FormData(_));
+                for (key, value) in &headers {
+                    // Never send a manual Content-Length — reqwest computes the correct
+                    // one from the actual body. A stale value (e.g. the predefined "0")
+                    // truncates the request body server-side (multipart boundary then
+                    // can't be found -> 400). reqwest's .header() appends, so we must
+                    // skip it here rather than rely on override.
+                    if key.eq_ignore_ascii_case("content-length") {
+                        continue;
+                    }
+                    // For multipart, let reqwest set Content-Type — it includes the
+                    // boundary. A manually-set one would lack the boundary.
+                    if is_form && key.eq_ignore_ascii_case("content-type") {
+                        continue;
+                    }
+                    req = req.header(key.as_str(), value.as_str());
+                }
 
-        let mut builder = http::Response::builder()
-            .status(status)
-            .version(http::Version::HTTP_11);
+                match body {
+                    BodyType::None => {}
+                    BodyType::Raw { content, .. } => {
+                        req = req.body(content.into_bytes());
+                    }
+                    BodyType::FormData(rows) => {
+                        let mut form = reqwest::multipart::Form::new();
+                        for row in rows {
+                            if !row.enabled || row.key.is_empty() {
+                                continue;
+                            }
+                            match row.value {
+                                FormDataValue::Text(text) => {
+                                    form = form.text(row.key, text);
+                                }
+                                FormDataValue::File { path } => {
+                                    if path.is_empty() {
+                                        continue;
+                                    }
+                                    // Reads the file and guesses MIME from its extension.
+                                    form = form.file(row.key, &path).await.map_err(|e| {
+                                        anyhow::anyhow!("Failed to read file '{}': {}", path, e)
+                                    })?;
+                                }
+                            }
+                        }
+                        req = req.multipart(form);
+                    }
+                }
 
-        *builder.headers_mut().unwrap() = headers;
+                let response = req.send().await?;
+                let status = response.status().as_u16();
+                let headers = response
+                    .headers()
+                    .iter()
+                    .filter_map(|(k, v)| v.to_str().ok().map(|s| (k.to_string(), s.to_string())))
+                    .collect::<Vec<_>>();
+                let body = response.bytes().await?.to_vec();
 
-        let body = gpui::http_client::AsyncBody::from(body_bytes.to_vec());
-        Ok(builder.body(body)?)
+                Ok::<HttpResponse, anyhow::Error>(HttpResponse {
+                    status,
+                    headers,
+                    body,
+                })
+            })
+            .await?
     }
 }

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -1,5 +1,3 @@
-use futures::AsyncReadExt;
-use gpui::http_client::{http, AsyncBody};
 use gpui::prelude::FluentBuilder as _;
 use gpui::*;
 use gpui::px;
@@ -226,7 +224,7 @@ impl RequestEditor {
         let content_type = match &request.body {
             crate::types::BodyType::None => None,
             crate::types::BodyType::Raw { subtype, .. } => Some(subtype.content_type().to_string()),
-            crate::types::BodyType::FormData(_) => Some("multipart/form-data".to_string()),
+            crate::types::BodyType::FormData(_) => Some("multipart/form-data; boundary=<auto>".to_string()),
         };
         self.update_content_type_from_body(&content_type, window, cx);
 
@@ -875,64 +873,16 @@ impl RequestEditor {
         cx.spawn_in(window, async move |this, cx| {
             let start = std::time::Instant::now();
 
-            // Use HttpClient which manages its own tokio runtime
+            // HttpClient builds the reqwest request natively (real multipart for form-data)
             let client = crate::http_client::HttpClient::new();
-
-            // Build HTTP request using http crate from gpui
-            let mut request_builder = http::Request::builder().method(method.as_str()).uri(&url);
-
-            // Add headers
-            for (key, value) in &headers {
-                request_builder = request_builder.header(key.as_str(), value.as_str());
-            }
-
-            // Build body based on type
-            let body_bytes = match &body {
-                crate::types::BodyType::None => Vec::new(),
-                crate::types::BodyType::Raw { content, .. } => content.clone().into_bytes(),
-                crate::types::BodyType::FormData(rows) => {
-                    // Build form data (simplified, actual multipart would be more complex)
-                    let mut form_parts = vec![];
-                    for row in rows {
-                        if row.enabled {
-                            match &row.value {
-                                crate::types::FormDataValue::Text(text) => {
-                                    form_parts.push(format!("{}={}", row.key, text));
-                                }
-                                crate::types::FormDataValue::File { path } => {
-                                    form_parts.push(format!("{}=@{}", row.key, path));
-                                }
-                            }
-                        }
-                    }
-                    form_parts.join("&").into_bytes()
-                }
-            };
-
-            // Add body with error handling
-            let http_request = match if !body_bytes.is_empty() {
-                request_builder.body(AsyncBody::from(body_bytes))
-            } else {
-                request_builder.body(AsyncBody::default())
-            } {
-                Ok(req) => req,
-                Err(e) => {
-                    log::error!("Failed to build HTTP request for URL '{}': {}", url, e);
-                    this.update(cx, |this, cx| {
-                        this.loading = false;
-                        cx.notify();
-                    })?;
-                    return Ok(());
-                }
-            };
 
             log::debug!("Sending HTTP request...");
 
             // Send request
-            let response = match client.send(http_request).await {
+            let response = match client.send(method, url.clone(), headers.clone(), body.clone()).await {
                 Ok(r) => r,
                 Err(e) => {
-                    // Handle request error (timeout, network error, etc.)
+                    // Handle request error (network error, file read error, etc.)
                     let duration = start.elapsed();
                     let error_message = format!("Request failed: {}", e);
                     log::error!("{}", error_message);
@@ -957,33 +907,17 @@ impl RequestEditor {
             };
 
             let duration = start.elapsed();
-            let status = response.status().as_u16();
+            let status = response.status;
 
             log::debug!("Request completed with status {} in {}ms", status, duration.as_millis());
 
-            // Collect response headers
-            let mut resp_headers = vec![];
-            for (key, value) in response.headers() {
-                if let Ok(v) = value.to_str() {
-                    resp_headers.push((key.to_string(), v.to_string()));
-                }
-            }
-
-            // Read response body
-            let mut body_reader = response.into_body();
-            let mut body_bytes = Vec::new();
-            body_reader
-                .read_to_end(&mut body_bytes)
-                .await
-                .unwrap_or_default();
-            let response_body = String::from_utf8_lossy(&body_bytes).to_string();
-
-            log::debug!("Response body size: {} bytes", body_bytes.len());
+            let response_body = String::from_utf8_lossy(&response.body).to_string();
+            log::debug!("Response body size: {} bytes", response.body.len());
 
             let response_data = ResponseData {
                 status: Some(status),
                 duration_ms: duration.as_millis() as u64,
-                headers: resp_headers,
+                headers: response.headers,
                 body: response_body,
             };
 


### PR DESCRIPTION
## 问题

Form-data 发送是假的:把 `key=value`/`key=@path` 拼成 `&` 连接的普通字符串当 body 发,文件没真读、没 multipart 边界。

## 方案(A:HttpClient 原生构建 reqwest 请求)

- 重构 `HttpClient::send`:入参改为 `(method, url, headers, BodyType)`,内部直接拼 reqwest 请求;返回已读完的 `HttpResponse { status, headers, body }`(body 在 tokio runtime 内读取,避免 reactor 问题)。去掉了多余的 gpui `http::Request<AsyncBody>` 中转。
- Form-data 用 `reqwest::multipart::Form`:文本用 `Part::text`,文件用 `Form::file`(自动读盘 + 按扩展名猜 MIME,依赖 `mime_guess`,已在依赖树),reqwest 自动设带 boundary 的 Content-Type。
- **正确性修复(关键)**:reqwest 的 `.header()` 是追加而非覆盖,所以:
  - form-data 时剥掉手动 `Content-Type`(否则和 reqwest 的 boundary 头并存)
  - **一律剥掉手动 `Content-Length`**(预定义的 `0` 会把请求体截断,服务器找不到 boundary → 400;改由 reqwest 按实际 body 计算)
- UI:form-data 时 Content-Type 显示为 `multipart/form-data; boundary=<auto>`(只读),明示 boundary 发送时自动生成,不误导。

## 验证

- `cargo check` 干净(仅 2 个预先存在的 dead-code 警告)
- Windows release 构建通过;真机实测 `https://postman-echo.com/post` Form-data(文本字段 + 文件)返回 200,回显 `form`/`files` 正确、`Content-Type` 带 boundary

## 备注

httpbin.org 测试时遇到 503(该免费服务不稳定),换 postman-echo 验证通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)