### PR TITLE
feat: 二进制响应检测、展示与保存

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4450,6 +4450,7 @@ dependencies = [
  "gpui",
  "gpui-component",
  "log",
+ "mime_guess",
  "quick-xml 0.40.1",
  "reqwest",
  "rusqlite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ rusqlite = { version = "0.40", features = ["bundled"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 quick-xml = "0.40"
+mime_guess = "2"
 tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
 url = "2.5"
 urlencoding = "2.1"

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -891,7 +891,8 @@ impl RequestEditor {
                         status: None, // Use None to indicate network error
                         duration_ms: duration.as_millis() as u64,
                         headers: vec![],
-                        body: error_message,
+                        body: error_message.into_bytes(),
+                        is_text: true,
                     };
 
                     this.update(cx, |this, cx| {
@@ -911,14 +912,15 @@ impl RequestEditor {
 
             log::debug!("Request completed with status {} in {}ms", status, duration.as_millis());
 
-            let response_body = String::from_utf8_lossy(&response.body).to_string();
-            log::debug!("Response body size: {} bytes", response.body.len());
+            let is_text = crate::types::is_text_response(&response.headers, &response.body);
+            log::debug!("Response body size: {} bytes (text={})", response.body.len(), is_text);
 
             let response_data = ResponseData {
                 status: Some(status),
                 duration_ms: duration.as_millis() as u64,
                 headers: response.headers,
-                body: response_body,
+                body: response.body,
+                is_text,
             };
 
             this.update(cx, |this, cx| {

--- a/src/response_viewer.rs
+++ b/src/response_viewer.rs
@@ -1,8 +1,44 @@
 use gpui::prelude::FluentBuilder as _;
 use gpui::*;
-use gpui_component::{h_flex, input::*, v_flex, ActiveTheme as _};
+use gpui_component::{button::*, h_flex, input::*, v_flex, ActiveTheme as _};
 
 use crate::types::ResponseData;
+
+/// Pick a sensible file extension for a (lowercased, param-stripped) Content-Type.
+///
+/// Uses a curated map for common types because mime_guess's extension ordering is
+/// unreliable (e.g. `image/jpeg` yields `jfif` first), falling back to mime_guess
+/// for the long tail.
+fn extension_for_content_type(ct: &str) -> Option<String> {
+    let curated = match ct {
+        "image/jpeg" => "jpg",
+        "image/png" => "png",
+        "image/gif" => "gif",
+        "image/webp" => "webp",
+        "image/bmp" => "bmp",
+        "image/svg+xml" => "svg",
+        "image/x-icon" | "image/vnd.microsoft.icon" => "ico",
+        "application/pdf" => "pdf",
+        "application/zip" => "zip",
+        "application/gzip" => "gz",
+        "application/json" => "json",
+        "application/xml" | "text/xml" => "xml",
+        "application/javascript" | "text/javascript" => "js",
+        "text/html" => "html",
+        "text/css" => "css",
+        "text/csv" => "csv",
+        "text/plain" => "txt",
+        "audio/mpeg" => "mp3",
+        "video/mp4" => "mp4",
+        _ => "",
+    };
+    if !curated.is_empty() {
+        return Some(curated.to_string());
+    }
+    mime_guess::get_mime_extensions_str(ct)
+        .and_then(|exts| exts.first())
+        .map(|e| e.to_string())
+}
 
 /// Response viewer panel
 pub struct ResponseViewer {
@@ -37,16 +73,21 @@ impl ResponseViewer {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        // Try to format JSON body for better display
-        let formatted_body =
-            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&response.body) {
-                crate::code_formatter::pretty_json_4(&json).unwrap_or(response.body.clone())
+        // Only feed the text editor for text responses; binary is shown in a
+        // dedicated panel and never decoded to (lossy) text.
+        let display = if response.is_text {
+            let text = response.body_text();
+            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) {
+                crate::code_formatter::pretty_json_4(&json).unwrap_or_else(|_| text.to_string())
             } else {
-                response.body.clone()
-            };
+                text.to_string()
+            }
+        } else {
+            String::new()
+        };
 
         self.body_display.update(cx, |input, cx| {
-            input.set_value(&formatted_body, window, cx);
+            input.set_value(&display, window, cx);
         });
 
         self.response = Some(response);
@@ -67,6 +108,35 @@ impl ResponseViewer {
         });
         self.active_tab = 0;
         cx.notify();
+    }
+
+    /// Save the (binary) response body to a file chosen via the OS dialog.
+    fn save_binary(&mut self, _event: &gpui::ClickEvent, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(response) = self.response.as_ref() else {
+            return;
+        };
+        let bytes = response.body.clone();
+        // Suggest a filename with the right extension based on Content-Type.
+        let suggested = response
+            .headers
+            .iter()
+            .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+            .map(|(_, v)| v.split(';').next().unwrap_or("").trim().to_ascii_lowercase())
+            .and_then(|ct| extension_for_content_type(&ct))
+            .map(|ext| format!("response.{}", ext))
+            .unwrap_or_else(|| "response.bin".to_string());
+        let dir = dirs::download_dir()
+            .or_else(dirs::home_dir)
+            .unwrap_or_else(|| std::path::PathBuf::from("."));
+        let rx = cx.prompt_for_new_path(&dir, Some(&suggested));
+        cx.spawn_in(window, async move |_this, _cx| {
+            if let Ok(Ok(Some(path))) = rx.await {
+                if let Err(e) = std::fs::write(&path, &bytes) {
+                    log::error!("Failed to save response to {:?}: {}", path, e);
+                }
+            }
+        })
+        .detach();
     }
 
     fn render_status_bar(&self, cx: &App) -> impl IntoElement {
@@ -264,28 +334,72 @@ impl Render for ResponseViewer {
                                 ),
                         )
                         .when(self.active_tab == 0, |this| {
-                            let is_error = self
-                                .response
-                                .as_ref()
-                                .map_or(false, |r| r.is_network_error());
-                            this.child(
-                                div()
-                                    .flex()
-                                    .flex_col()
-                                    .flex_1()
-                                    .w_full()
-                                    .rounded(theme.radius_lg)
-                                    .border_1()
-                                    .border_color(theme.border)
-                                    .bg(theme.popover)
-                                    .overflow_hidden()
-                                    .child(
-                                        Input::new(&self.body_display)
-                                            .disabled(is_error)
-                                            .w_full()
-                                            .h_full(),
-                                    ),
-                            )
+                            let resp_is_text = self.response.as_ref().map_or(true, |r| r.is_text);
+                            if resp_is_text {
+                                let is_error = self
+                                    .response
+                                    .as_ref()
+                                    .map_or(false, |r| r.is_network_error());
+                                this.child(
+                                    div()
+                                        .flex()
+                                        .flex_col()
+                                        .flex_1()
+                                        .w_full()
+                                        .rounded(theme.radius_lg)
+                                        .border_1()
+                                        .border_color(theme.border)
+                                        .bg(theme.popover)
+                                        .overflow_hidden()
+                                        .child(
+                                            Input::new(&self.body_display)
+                                                .disabled(is_error)
+                                                .w_full()
+                                                .h_full(),
+                                        ),
+                                )
+                            } else {
+                                // Binary response: don't decode to lossy text — show info + Save.
+                                let (content_type, len) = self
+                                    .response
+                                    .as_ref()
+                                    .map(|r| {
+                                        let ct = r
+                                            .headers
+                                            .iter()
+                                            .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+                                            .map(|(_, v)| v.clone())
+                                            .unwrap_or_else(|| "application/octet-stream".to_string());
+                                        (ct, r.body.len())
+                                    })
+                                    .unwrap_or_else(|| ("application/octet-stream".to_string(), 0));
+                                this.child(
+                                    v_flex()
+                                        .flex_1()
+                                        .w_full()
+                                        .items_center()
+                                        .justify_center()
+                                        .gap_2()
+                                        .child(
+                                            div()
+                                                .text_sm()
+                                                .text_color(theme.foreground)
+                                                .child("Binary response"),
+                                        )
+                                        .child(
+                                            div()
+                                                .text_xs()
+                                                .text_color(theme.muted_foreground)
+                                                .child(format!("{} · {} bytes", content_type, len)),
+                                        )
+                                        .child(
+                                            Button::new("save-binary")
+                                                .primary()
+                                                .label("Save to file…")
+                                                .on_click(cx.listener(Self::save_binary)),
+                                        ),
+                                )
+                            }
                         })
                         .when(self.active_tab == 1, |this| {
                             this.child(

--- a/src/types.rs
+++ b/src/types.rs
@@ -230,10 +230,59 @@ pub struct ResponseData {
     pub status: Option<u16>,
     pub duration_ms: u64,
     pub headers: Vec<(String, String)>,
-    pub body: String,
+    /// Raw response bytes (lossless — preserves binary payloads).
+    pub body: Vec<u8>,
+    /// Whether the body should be shown as text (vs treated as binary).
+    pub is_text: bool,
+}
+
+/// Decide whether a response body should be shown as text.
+///
+/// Uses the `Content-Type` header first (clear text vs clear binary families),
+/// falling back to a UTF-8 validity sniff when the type is missing/ambiguous.
+pub fn is_text_response(headers: &[(String, String)], body: &[u8]) -> bool {
+    let content_type = headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+        .map(|(_, v)| v.split(';').next().unwrap_or("").trim().to_ascii_lowercase());
+
+    if let Some(ct) = content_type.as_deref() {
+        // Clearly text
+        if ct.starts_with("text/")
+            || ct == "application/json"
+            || ct == "application/xml"
+            || ct == "application/javascript"
+            || ct == "application/x-www-form-urlencoded"
+            || ct == "image/svg+xml"
+            || ct.ends_with("+json")
+            || ct.ends_with("+xml")
+        {
+            return true;
+        }
+        // Clearly binary
+        if ct.starts_with("image/")
+            || ct.starts_with("audio/")
+            || ct.starts_with("video/")
+            || ct.starts_with("font/")
+            || ct == "application/octet-stream"
+            || ct == "application/pdf"
+            || ct == "application/zip"
+            || ct == "application/gzip"
+        {
+            return false;
+        }
+        // else: unknown application/* — fall through to UTF-8 sniff
+    }
+
+    std::str::from_utf8(body).is_ok()
 }
 
 impl ResponseData {
+    /// Lossy text view of the body (for display when `is_text`).
+    pub fn body_text(&self) -> std::borrow::Cow<'_, str> {
+        String::from_utf8_lossy(&self.body)
+    }
+
     pub fn status_text(&self) -> &'static str {
         match self.status {
             Some(200) => "OK",
@@ -313,4 +362,39 @@ pub struct HeaderState {
     pub value: String,
     pub header_type: HeaderType,
     pub predefined: Option<PredefinedHeader>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn h(ct: &str) -> Vec<(String, String)> {
+        vec![("Content-Type".to_string(), ct.to_string())]
+    }
+
+    #[test]
+    fn text_content_types_are_text() {
+        assert!(is_text_response(&h("application/json"), b"{}"));
+        assert!(is_text_response(&h("text/html; charset=utf-8"), b"<html>"));
+        assert!(is_text_response(&h("application/xml"), b"<x/>"));
+        assert!(is_text_response(&h("application/problem+json"), b"{}"));
+        assert!(is_text_response(&h("image/svg+xml"), b"<svg/>"));
+    }
+
+    #[test]
+    fn binary_content_types_are_binary() {
+        assert!(!is_text_response(&h("image/png"), &[0x89, 0x50]));
+        assert!(!is_text_response(&h("application/octet-stream"), &[0, 1, 2]));
+        assert!(!is_text_response(&h("application/pdf"), b"%PDF"));
+        assert!(!is_text_response(&h("application/zip"), &[0x50, 0x4b]));
+    }
+
+    #[test]
+    fn unknown_or_missing_type_falls_back_to_utf8_sniff() {
+        assert!(is_text_response(&[], b"plain text"));
+        assert!(!is_text_response(&[], &[0xff, 0xfe, 0x00]));
+        // unknown application/* defers to sniff
+        assert!(is_text_response(&h("application/weird"), b"readable"));
+        assert!(!is_text_response(&h("application/weird"), &[0xff, 0x00]));
+    }
 }


### PR DESCRIPTION
## 问题

响应体一律 `String::from_utf8_lossy`,图片/PDF/zip 等二进制会被损坏成乱码,也没法保存原始字节。

## 方案(MVP)

- `ResponseData.body` 改为 `Vec<u8>`(无损)+ 新增 `is_text` 标志
- `is_text_response(headers, body)`:先看 `Content-Type`(明确文本/明确二进制族),缺失/含糊时回退 UTF-8 合法性嗅探
- 响应区:
  - 文本 → 现状不变(代码区 + JSON 4 空格美化)
  - 二进制 → 「Binary response · <type> · N bytes」面板 + **Save to file…**(`prompt_for_new_path` 写原始字节)
  - 保存建议文件名按 Content-Type 给正确扩展名:常见类型走精选表(`image/jpeg`→`jpg` 等,避开 mime_guess 把 jpeg 给成 `jfif`),冷门回退 mime_guess,再不行 `.bin`

## 验证

- `cargo check` / `cargo check --tests` 干净;新增 `is_text_response` 单测
- Windows 真机:`httpbin.org/image/png`、`image/jpeg` 显示二进制面板、保存为 `response.png` / `response.jpg` 可正常打开;JSON 文本响应不受影响

## 范围外(后续)

图片内联预览、Hex 视图(Tier 2)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)