### PR TITLE
feat: Environment variables + Figma floating-card UI redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /gpui-component/
 .claude
+.superpowers/

--- a/docs/superpowers/plans/2026-06-23-ui-redesign-floating-cards.md
+++ b/docs/superpowers/plans/2026-06-23-ui-redesign-floating-cards.md
@@ -1,0 +1,994 @@
+# Poopman UI Redesign (Floating Cards + Edit Menu + Env Dialog) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reimplement Poopman's GPUI UI to match the Figma "floating-card" design, move environment switching into an Edit menu in the title bar, and beautify the environment dialog.
+
+**Architecture:** Add two small modules — `src/ui.rs` (shared `card_panel` + segmented-pill-tab helpers) and `src/menu_bar.rs` (the Edit dropdown menu) — then restyle each panel in place to consume the helpers. Environment switching becomes a `PopupMenu` built from a captured `Entity<PoopmanApp>` handle whose item `on_click` closures call back into the app. The existing warm coral theme is retained.
+
+**Tech Stack:** Rust, gpui 0.2.2, gpui-component 0.5.x (`Button::dropdown_menu`, `PopupMenu`, `TitleBar`, `Dialog`, `resizable`), rusqlite.
+
+**Verification note (important):** This is a GPU app that **cannot run in WSL2** and the styling cannot be meaningfully unit-tested headlessly. The automated gate for every task is therefore `cargo check` (compiles fine without a GPU). Final visual confirmation is a manual step performed by the user on Windows/macOS via `cargo run` (Task 9). Each task still ends with a compile gate + commit.
+
+**Conventions:** Match existing code style. Commit messages use `type(scope): Subject` and end with:
+`Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>`
+
+---
+
+## File Structure
+
+- **Create `src/ui.rs`** — shared, callback-free styling helpers: `card_panel`, `segmented_bar`, `segment_pill`. One responsibility: visual primitives reused across panels.
+- **Create `src/menu_bar.rs`** — `edit_menu(...)`: builds the Edit `Button` + `dropdown_menu` (environment list + "Manage Environments…"). One responsibility: the title-bar menu.
+- **Modify `src/main.rs`** — register the two new modules.
+- **Modify `src/app.rs`** — floating-card layout; embed Edit menu in `TitleBar`; remove the old Env toolbar button; add `set_active_environment`; restyle the env dialog wrapper (title + subtitle).
+- **Modify `src/tab_bar.rs`** — pill-style request tabs.
+- **Modify `src/response_viewer.rs`** — segmented pill tabs + status pill.
+- **Modify `src/request_editor.rs`** — segmented pill tabs.
+- **Modify `src/history_panel.rs`** — keep current card rows (already close); minor radius/border polish only.
+- **Modify `src/environment_manager.rs`** — dialog redesign: dashed "New environment" button, dot-activation, remove "Set active" button, card-style variable table, bottom Save footer.
+
+---
+
+## Task 1: Shared UI helpers (`src/ui.rs`)
+
+**Files:**
+- Create: `src/ui.rs`
+- Modify: `src/main.rs:3-17` (module list)
+
+- [ ] **Step 1: Create `src/ui.rs`**
+
+```rust
+//! Shared visual primitives for the floating-card UI: panel cards and
+//! segmented pill tab strips. All helpers are callback-free — callers attach
+//! `.id(...)`/`.on_click(...)` themselves so the helpers stay generic.
+
+use gpui::prelude::FluentBuilder as _;
+use gpui::*;
+use gpui_component::{h_flex, theme::Theme};
+
+/// A floating panel card: white-ish surface, hairline border, large radius,
+/// soft shadow, clipped contents. Wrap a panel's content in this.
+pub fn card_panel(theme: &Theme) -> Div {
+    div()
+        .bg(theme.background)
+        .border_1()
+        .border_color(theme.border)
+        .rounded(theme.radius_lg)
+        .shadow_sm()
+        .overflow_hidden()
+}
+
+/// The container for a segmented pill tab strip (muted rounded track).
+pub fn segmented_bar(theme: &Theme) -> Div {
+    h_flex()
+        .gap_1()
+        .p_0p5()
+        .rounded(theme.radius_lg)
+        .bg(theme.muted)
+}
+
+/// A single segment pill. Caller adds `.id(...)`, `.on_click(...)`, `.child(label)`.
+/// Active pills sit on the card surface with a soft shadow; inactive are muted.
+pub fn segment_pill(theme: &Theme, active: bool) -> Div {
+    div()
+        .px_3()
+        .py_1()
+        .rounded(theme.radius)
+        .text_sm()
+        .cursor_pointer()
+        .when(active, |d| {
+            d.bg(theme.background)
+                .text_color(theme.foreground)
+                .font_weight(FontWeight::SEMIBOLD)
+                .shadow_sm()
+        })
+        .when(!active, |d| d.text_color(theme.muted_foreground))
+}
+```
+
+- [ ] **Step 2: Register the module in `src/main.rs`**
+
+In the `mod` block (currently `src/main.rs:3-17`), add `mod ui;` in alphabetical position (after `mod tab_bar;` / before `mod theme;`):
+
+```rust
+mod tab_bar;
+mod theme;
+mod types;
+mod ui;
+```
+
+(Keep the other `mod` lines unchanged.)
+
+- [ ] **Step 3: Compile gate**
+
+Run: `cargo check`
+Expected: PASS (warnings about unused helpers are fine at this stage).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/ui.rs src/main.rs
+git commit -m "feat(ui): Add shared card_panel + segmented pill tab helpers
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Edit menu in the title bar (`src/menu_bar.rs`, `src/app.rs`)
+
+This adds the functional Edit menu (environment list + manage entry) and removes the old Env toolbar button. After this task, environment switching happens through the menu.
+
+**Files:**
+- Create: `src/menu_bar.rs`
+- Modify: `src/main.rs` (add `mod menu_bar;`)
+- Modify: `src/app.rs` — add `set_active_environment`; embed menu in `TitleBar`; delete the old env selector button block (`src/app.rs:459-485`).
+
+- [ ] **Step 1: Add `set_active_environment` to `PoopmanApp`**
+
+In `src/app.rs`, directly after `open_env_manager` (ends at `src/app.rs:212`), add:
+
+```rust
+    /// Switch the active environment (or clear it) from the Edit menu, then
+    /// reload + refresh the request editor's variable map.
+    fn set_active_environment(&mut self, id: Option<i64>, cx: &mut Context<Self>) {
+        if let Err(e) = self.db.set_active_environment_id(id) {
+            log::error!("Failed to set active environment: {}", e);
+            return;
+        }
+        self.reload_environments(cx);
+    }
+```
+
+(`reload_environments` already calls `cx.notify()` and pushes vars to the editor.)
+
+- [ ] **Step 2: Create `src/menu_bar.rs`**
+
+```rust
+//! The Edit menu shown in the title bar. Houses environment switching (with a
+//! check mark on the active one) and an entry to open the environment dialog.
+//! Item handlers call back into `PoopmanApp` via a captured entity handle.
+
+use gpui::*;
+use gpui_component::{
+    button::{Button, ButtonVariants as _},
+    menu::{DropdownMenu as _, PopupMenuItem},
+    Sizable as _,
+};
+
+use crate::app::PoopmanApp;
+use crate::types::Environment;
+
+/// Build the "Edit" dropdown button for the title bar.
+///
+/// `environments` / `active_id` are a snapshot taken in `PoopmanApp::render`;
+/// `app` is the app's own entity handle used to dispatch actions from menu items.
+pub fn edit_menu(
+    app: Entity<PoopmanApp>,
+    environments: Vec<Environment>,
+    active_id: Option<i64>,
+) -> impl IntoElement {
+    Button::new("edit-menu")
+        .ghost()
+        .small()
+        .label("Edit")
+        .dropdown_menu(move |mut menu, _window, _cx| {
+            menu = menu.label("Environment");
+
+            // One checkable item per environment.
+            for env in &environments {
+                let id = env.id;
+                let app = app.clone();
+                let is_active = active_id == Some(id);
+                menu = menu.item(
+                    PopupMenuItem::new(env.name.clone())
+                        .checked(is_active)
+                        .on_click(move |_, _window, cx| {
+                            app.update(cx, |app, cx| {
+                                app.set_active_environment(Some(id), cx);
+                            });
+                        }),
+                );
+            }
+
+            // Clear-active entry.
+            {
+                let app = app.clone();
+                menu = menu.item(
+                    PopupMenuItem::new("No Environment")
+                        .checked(active_id.is_none())
+                        .on_click(move |_, _window, cx| {
+                            app.update(cx, |app, cx| {
+                                app.set_active_environment(None, cx);
+                            });
+                        }),
+                );
+            }
+
+            menu = menu.separator();
+
+            // Open the management dialog.
+            {
+                let app = app.clone();
+                menu = menu.item(
+                    PopupMenuItem::new("Manage Environments…").on_click(
+                        move |_, window, cx| {
+                            app.update(cx, |app, cx| {
+                                app.open_env_manager(window, cx);
+                            });
+                        },
+                    ),
+                );
+            }
+
+            menu
+        })
+}
+```
+
+NOTE on imports: confirm the exact public paths while implementing — they are re-exported from `gpui_component`. If `menu::DropdownMenu` / `menu::PopupMenuItem` don't resolve, check `gpui_component::{DropdownMenu, PopupMenuItem}` (top-level re-exports) by grepping `gpui_component-0.5.1/src/lib.rs` for `DropdownMenu` and `PopupMenuItem`. `Button` ghost/small come from `button::ButtonVariants` and `Sizable` (already used in `app.rs`). Also make `PoopmanApp::open_env_manager` and `set_active_environment` callable from this module: change both from `fn` to `pub(crate) fn` in `src/app.rs`.
+
+- [ ] **Step 3: Register module in `src/main.rs`**
+
+Insert the single line `mod menu_bar;` into the `mod` block so it sits alphabetically between `mod http_client;` and `mod request_editor;`. The block should read:
+
+```rust
+mod history_panel;
+mod http_client;
+mod menu_bar;
+mod request_editor;
+```
+
+- [ ] **Step 4: Embed the menu in the `TitleBar` and remove the old env selector**
+
+In `src/app.rs render`, replace the current title-bar child (`src/app.rs:425-433`):
+
+```rust
+                // Custom warm title bar (replaces the white native title bar)
+                TitleBar::new().child(
+                    div()
+                        .text_sm()
+                        .font_weight(FontWeight::SEMIBOLD)
+                        .text_color(theme.foreground)
+                        .child("Poopman"),
+                ),
+```
+
+with (capture the app handle + snapshot first; `cx.entity()` gives `Entity<PoopmanApp>`):
+
+```rust
+                // Custom warm title bar: brand + Edit menu (window controls are
+                // added by TitleBar itself, platform-aware: macOS left inset,
+                // Windows controls on the right).
+                TitleBar::new()
+                    .child(
+                        div()
+                            .text_sm()
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .text_color(theme.foreground)
+                            .child("Poopman"),
+                    )
+                    .child(crate::menu_bar::edit_menu(
+                        cx.entity(),
+                        self.environments.clone(),
+                        self.active_environment_id,
+                    )),
+```
+
+Then delete the now-obsolete environment selector. Remove the whole `.child(...)` that builds the env button — currently the second child of the tab-bar `h_flex` at `src/app.rs:464-484` (the `div().flex_shrink_0()...Button::new("env-selector")...` block). After removal the tab-bar row is just:
+
+```rust
+                            .child(
+                                // Tab bar row (env selector moved to the Edit menu)
+                                h_flex()
+                                    .w_full()
+                                    .child(div().flex_1().min_w_0().child(self.tab_bar.clone())),
+                            )
+```
+
+Also delete the now-unused `env_label` local (`src/app.rs:413-419`).
+
+- [ ] **Step 5: Compile gate**
+
+Run: `cargo check`
+Expected: PASS. If `cx.entity()` type inference complains, annotate: `let app_handle: Entity<PoopmanApp> = cx.entity();` and pass `app_handle`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/menu_bar.rs src/main.rs src/app.rs
+git commit -m "feat(env): Move environment switching into a title-bar Edit menu
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Floating-card layout (`src/app.rs`)
+
+**Files:**
+- Modify: `src/app.rs render` (root container + panel wrappers + resize handles)
+
+- [ ] **Step 1: Pad the canvas and separate it from the cards**
+
+In `src/app.rs render`, change the root `v_flex()` so the canvas uses the warmer muted tone and gains padding/gap. Replace:
+
+```rust
+        v_flex()
+            .size_full()
+            .bg(theme.background)
+            .child(
+```
+
+with:
+
+```rust
+        v_flex()
+            .size_full()
+            .bg(theme.muted)
+            .child(
+```
+
+The `TitleBar` stays as the first child (flush, no padding). Wrap the **content area** (the `div().flex_1().min_h_0()...` at `src/app.rs:434-435`) so the cards get outer padding + gaps. Change that wrapper to:
+
+```rust
+            .child(
+                div()
+                    .flex_1()
+                    .min_h_0()
+                    .flex()
+                    .flex_col()
+                    .gap_2p5()
+                    .p_3()
+                    .child(
+```
+
+(Remember to add the matching extra closing `)` for this added `div` at the end of the content block — keep brackets balanced.)
+
+- [ ] **Step 2: Wrap the tab bar in a card**
+
+The tab-bar row child (now `h_flex().w_full().child(...tab_bar...)`) should become its own card. Wrap it:
+
+```rust
+                            .child(
+                                // Tab bar card (its own floating row)
+                                crate::ui::card_panel(theme).child(
+                                    h_flex()
+                                        .w_full()
+                                        .child(div().flex_1().min_w_0().child(self.tab_bar.clone())),
+                                ),
+                            )
+```
+
+Add `use crate::ui;` is unnecessary — call via `crate::ui::card_panel`. `theme` is already bound at the top of `render`.
+
+- [ ] **Step 3: Wrap the sidebar, request, and response panels in cards**
+
+Sidebar panel — change `src/app.rs:442-447` from:
+
+```rust
+                            .child(
+                                div()
+                                    .size_full()
+                                    .on_scroll_wheel(|_, _, cx| cx.stop_propagation())
+                                    .child(self.history_panel.clone()),
+                            ),
+```
+
+to:
+
+```rust
+                            .child(
+                                crate::ui::card_panel(theme)
+                                    .size_full()
+                                    .on_scroll_wheel(|_, _, cx| cx.stop_propagation())
+                                    .child(self.history_panel.clone()),
+                            ),
+```
+
+Request panel — wrap `self.request_editor.clone()` (`src/app.rs:494`):
+
+```rust
+                                            resizable_panel()
+                                                .size(px(REQUEST_INITIAL_HEIGHT))
+                                                .size_range(px(REQUEST_MIN)..px(REQUEST_MAX))
+                                                .child(
+                                                    crate::ui::card_panel(theme)
+                                                        .size_full()
+                                                        .child(self.request_editor.clone()),
+                                                ),
+```
+
+Response panel — replace the bordered wrapper (`src/app.rs:496-505`) with a card (drop the old `.border_t_1()`):
+
+```rust
+                                        .child(
+                                            crate::ui::card_panel(theme)
+                                                .flex_1()
+                                                .min_h(px(200.))
+                                                .child(self.response_viewer.clone())
+                                                .into_any_element(),
+                                        ),
+```
+
+- [ ] **Step 4: Restyle the resize handles**
+
+The `h_resizable`/`v_resizable` handles are styled by gpui-component defaults; to match Figma's thin rounded grabber, set the handle size subtly via the panels' gap (already provided by `.gap_2p5()` between cards). Leave the resizable handle internals as-is (gpui-component renders its own handle). No code change required here beyond the gap; if the handle is visually too wide, this is a polish item for Task 9, not a blocker.
+
+- [ ] **Step 5: Compile gate**
+
+Run: `cargo check`
+Expected: PASS. Watch for unbalanced parentheses from the added wrapper `div` (Step 1) — the compiler will point at the mismatched delimiter; fix by adding/removing one `)` at the end of the content block.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/app.rs
+git commit -m "feat(ui): Float panels as padded cards on a warm canvas
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Pill-style request tabs (`src/tab_bar.rs`)
+
+**Files:**
+- Modify: `src/tab_bar.rs render` (`src/tab_bar.rs:64-156`)
+
+- [ ] **Step 1: Restyle the outer row and tab pills**
+
+Replace the outer `h_flex()` styling (`src/tab_bar.rs:69-76`) — drop the bottom border (the card already frames it) and tighten padding:
+
+```rust
+        h_flex()
+            .gap_1()
+            .items_center()
+            .px_1p5()
+            .py_1()
+            .bg(theme.background)
+```
+
+Replace each tab's container styling (`src/tab_bar.rs:89-98`) so the active tab is a filled pill (no border) and inactive tabs are muted with hover:
+
+```rust
+                        h_flex()
+                            .id(("tab", tab.id))
+                            .gap_1p5()
+                            .items_center()
+                            .px_3()
+                            .py_1()
+                            .rounded(theme.radius)
+                            .bg(if is_active { theme.muted } else { gpui::transparent_black() })
+                            .when(!is_active, |s| s.hover(|s| s.bg(theme.list_hover)))
+                            .cursor_pointer()
+```
+
+(Keep the `.on_click(...)` and the method-label / title / close-button children unchanged. The method label keeps `verb_color`; the title keeps its color logic.)
+
+- [ ] **Step 2: Restyle the "new tab" button to a subtle pill**
+
+Already close; just ensure rounding matches (`src/tab_bar.rs:138-143`):
+
+```rust
+                div()
+                    .id("new-tab-button")
+                    .px_2()
+                    .py_1()
+                    .rounded(theme.radius)
+                    .text_color(theme.muted_foreground)
+                    .cursor_pointer()
+                    .hover(|style| style.bg(theme.list_hover).text_color(theme.foreground))
+```
+
+- [ ] **Step 3: Compile gate**
+
+Run: `cargo check`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/tab_bar.rs
+git commit -m "refactor(ui): Pill-style request tabs in the tab-bar card
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Segmented tabs + status pill (`src/response_viewer.rs`)
+
+**Files:**
+- Modify: `src/response_viewer.rs render` (`src/response_viewer.rs:278-335`), and `render_status_bar` (`src/response_viewer.rs:142-200`).
+
+- [ ] **Step 1: Replace the underline tab row with a segmented pill bar**
+
+Replace the tab-row block (`src/response_viewer.rs:278-335`, the `div().flex().flex_row().gap_5().border_b_1()...` containing `resp-tab-body` and `resp-tab-headers`) with:
+
+```rust
+                        .child(
+                            crate::ui::segmented_bar(theme)
+                                .child(
+                                    crate::ui::segment_pill(theme, self.active_tab == 0)
+                                        .id("resp-tab-body")
+                                        .when(self.active_tab != 0, |s| {
+                                            s.hover(|s| s.text_color(theme.foreground))
+                                        })
+                                        .on_click(cx.listener(
+                                            |this, _event: &gpui::ClickEvent, _window, cx| {
+                                                this.active_tab = 0;
+                                                cx.notify();
+                                            },
+                                        ))
+                                        .child("Body"),
+                                )
+                                .child(
+                                    crate::ui::segment_pill(theme, self.active_tab == 1)
+                                        .id("resp-tab-headers")
+                                        .when(self.active_tab != 1, |s| {
+                                            s.hover(|s| s.text_color(theme.foreground))
+                                        })
+                                        .on_click(cx.listener(
+                                            |this, _event: &gpui::ClickEvent, _window, cx| {
+                                                this.active_tab = 1;
+                                                cx.notify();
+                                            },
+                                        ))
+                                        .child("Headers"),
+                                ),
+                        )
+```
+
+`when` requires `use gpui::prelude::FluentBuilder as _;` — confirm it's imported in this file (add it if missing).
+
+- [ ] **Step 2: Make the status code a coral/semantic pill**
+
+In `render_status_bar` the status text is shown around `src/response_viewer.rs:164-190`. Ensure the status code chip is a rounded filled pill using the existing semantic colors. Read the current block, then wrap the status code element as:
+
+```rust
+                div()
+                    .px_2p5()
+                    .py_0p5()
+                    .rounded(theme.radius)
+                    .text_xs()
+                    .font_weight(FontWeight::BOLD)
+                    .bg(status_color.opacity(0.12))
+                    .text_color(status_color)
+                    .child(format!("{} {}", status, status_text)),
+```
+
+where `status_color` is the semantic color already computed in that function (GET-green for 2xx, etc. — reuse the existing color variable; if none exists, derive from `theme.success`/`theme.warning`/`theme.danger` by status range, mirroring the existing logic). `theme` must be in scope: `render_status_bar` takes `&App`, so add `let theme = cx.theme();` at its top if not present.
+
+- [ ] **Step 3: Compile gate**
+
+Run: `cargo check`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/response_viewer.rs
+git commit -m "refactor(ui): Segmented tabs + status pill in response viewer
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Segmented tabs (`src/request_editor.rs`)
+
+**Files:**
+- Modify: `src/request_editor.rs render` tab strip (`src/request_editor.rs:1047-1129`).
+
+- [ ] **Step 1: Replace the underline tab row with a segmented pill bar**
+
+Replace the tab-row block (`src/request_editor.rs:1047-1129`, the `div().flex().flex_row().gap_5().border_b_1()...` containing `tab-headers`, `tab-params`, `tab-body`) with:
+
+```rust
+                        .child(
+                            crate::ui::segmented_bar(theme)
+                                .child(
+                                    crate::ui::segment_pill(theme, self.active_tab == 0)
+                                        .id("tab-headers")
+                                        .when(self.active_tab != 0, |s| {
+                                            s.hover(|s| s.text_color(theme.foreground))
+                                        })
+                                        .on_click(cx.listener(
+                                            |this, _event: &gpui::ClickEvent, _window, cx| {
+                                                this.active_tab = 0;
+                                                cx.notify();
+                                            },
+                                        ))
+                                        .child("Headers"),
+                                )
+                                .child(
+                                    crate::ui::segment_pill(theme, self.active_tab == 1)
+                                        .id("tab-params")
+                                        .when(self.active_tab != 1, |s| {
+                                            s.hover(|s| s.text_color(theme.foreground))
+                                        })
+                                        .on_click(cx.listener(
+                                            |this, _event: &gpui::ClickEvent, _window, cx| {
+                                                this.active_tab = 1;
+                                                cx.notify();
+                                            },
+                                        ))
+                                        .child("Params"),
+                                )
+                                .child(
+                                    crate::ui::segment_pill(theme, self.active_tab == 2)
+                                        .id("tab-body")
+                                        .when(self.active_tab != 2, |s| {
+                                            s.hover(|s| s.text_color(theme.foreground))
+                                        })
+                                        .on_click(cx.listener(
+                                            |this, _event: &gpui::ClickEvent, _window, cx| {
+                                                this.active_tab = 2;
+                                                cx.notify();
+                                            },
+                                        ))
+                                        .child("Body"),
+                                ),
+                        )
+```
+
+Confirm `use gpui::prelude::FluentBuilder as _;` is imported in this file (it is, given existing `.when(...)` usage at lines 1062+).
+
+- [ ] **Step 2: Compile gate**
+
+Run: `cargo check`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/request_editor.rs
+git commit -m "refactor(ui): Segmented tabs in request editor
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: History rows polish (`src/history_panel.rs`)
+
+The history rows are already card-like. Apply only minor polish so they read as cards on the sidebar surface.
+
+**Files:**
+- Modify: `src/history_panel.rs render` (`src/history_panel.rs:146-166`).
+
+- [ ] **Step 1: Give non-selected rows a subtle card surface on hover and rounded edges**
+
+Replace the row container styling (`src/history_panel.rs:146-166`) so it uses `radius_lg` and a faint border that strengthens on hover:
+
+```rust
+                            h_flex()
+                                .id(("history-item", item_id as u64))
+                                .gap_2()
+                                .items_start()
+                                .w_full()
+                                .px_2p5()
+                                .py_2()
+                                .rounded(theme.radius_lg)
+                                .border_1()
+                                .border_color(if is_selected {
+                                    theme.list_active_border
+                                } else {
+                                    gpui::transparent_black()
+                                })
+                                .bg(if is_selected {
+                                    theme.list_active
+                                } else {
+                                    gpui::transparent_black()
+                                })
+                                .cursor_pointer()
+                                .hover(|s| {
+                                    s.bg(if is_selected { theme.list_active } else { theme.list_hover })
+                                })
+                                .on_click(cx.listener(move |this, _event: &gpui::ClickEvent, window, cx| {
+                                    this.on_item_click(&item_clone, window, cx);
+                                }))
+```
+
+(Children unchanged.)
+
+- [ ] **Step 2: Compile gate**
+
+Run: `cargo check`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/history_panel.rs
+git commit -m "refactor(ui): Polish history rows for the card sidebar
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Environment dialog beautification (`src/environment_manager.rs`, `src/app.rs`)
+
+**Files:**
+- Modify: `src/app.rs open_env_manager` (`src/app.rs:207-212`) — title + subtitle.
+- Modify: `src/environment_manager.rs render` — dashed New button, dot activation, remove "Set active", card variable table, bottom Save footer.
+
+- [ ] **Step 1: Dialog title + subtitle**
+
+Replace `open_env_manager` body (`src/app.rs:209-211`) with a richer title element:
+
+```rust
+        let manager = self.env_manager.clone();
+        window.open_dialog(cx, move |dialog, _window, cx| {
+            let theme = cx.theme();
+            dialog
+                .title(
+                    gpui_component::v_flex()
+                        .gap_0p5()
+                        .child(
+                            div()
+                                .text_lg()
+                                .font_weight(gpui::FontWeight::BOLD)
+                                .text_color(theme.foreground)
+                                .child("Environments"),
+                        )
+                        .child(
+                            div()
+                                .text_xs()
+                                .text_color(theme.muted_foreground)
+                                .child("Define variables like {{base_url}} per environment"),
+                        ),
+                )
+                .w(px(680.))
+                .child(manager.clone())
+        });
+```
+
+Ensure `ActiveTheme` is in scope in `app.rs` (add `use gpui_component::ActiveTheme as _;` if `cx.theme()` doesn't resolve there).
+
+- [ ] **Step 2: Dashed "New environment" button**
+
+In `src/environment_manager.rs`, the add-row is `src/environment_manager.rs:225-259`. Give it a dashed coral border and pill shape — change its styling chain to:
+
+```rust
+                        h_flex()
+                            .id("env-add")
+                            .w_full()
+                            .px_2()
+                            .py_1p5()
+                            .gap_2()
+                            .items_center()
+                            .rounded(theme.radius_lg)
+                            .border_1()
+                            .border_dashed()
+                            .border_color(theme.primary)
+                            .text_color(theme.primary)
+                            .cursor_pointer()
+                            .hover(|s| s.bg(theme.list_active))
+                            .on_click(cx.listener(|this, _, window, cx| {
+                                this.add_environment(window, cx);
+                            }))
+```
+
+(Keep its two children — the centered "+" indicator and the "New environment" label — unchanged.)
+
+- [ ] **Step 3: Make the list dot the activation control + active highlight + ACTIVE tag**
+
+In the env row (`src/environment_manager.rs:270-312`), the indicator-dot child currently only displays active state. Make the **dot clickable to toggle active**, and keep the rest-of-row click for selection. Replace the dot child (`src/environment_manager.rs:284-300`) with:
+
+```rust
+                                    .child(
+                                        // Dot = activation toggle (stops row-select propagation)
+                                        div()
+                                            .id(("env-active-dot", id as u64))
+                                            .w(px(16.))
+                                            .flex_shrink_0()
+                                            .flex()
+                                            .items_center()
+                                            .justify_center()
+                                            .cursor_pointer()
+                                            .on_click(cx.listener(move |this, _, _window, cx| {
+                                                cx.stop_propagation();
+                                                let new = if this.active_id == Some(id) {
+                                                    None
+                                                } else {
+                                                    Some(id)
+                                                };
+                                                this.set_active(new, cx);
+                                            }))
+                                            .child(
+                                                div()
+                                                    .w(px(7.))
+                                                    .h(px(7.))
+                                                    .rounded_full()
+                                                    .when(is_active, |d| d.bg(theme.primary))
+                                                    .when(!is_active, |d| {
+                                                        d.border_1().border_color(theme.muted_foreground)
+                                                    }),
+                                            ),
+                                    )
+```
+
+Add an `ACTIVE` tag at the end of the active row. After the name-label child (`src/environment_manager.rs:301-311`), append:
+
+```rust
+                                    .when(is_active, |row| {
+                                        row.child(
+                                            div()
+                                                .flex_shrink_0()
+                                                .px_1p5()
+                                                .py_0()
+                                                .rounded(theme.radius)
+                                                .text_xs()
+                                                .font_weight(FontWeight::BOLD)
+                                                .bg(theme.primary.opacity(0.12))
+                                                .text_color(theme.primary)
+                                                .child("ACTIVE"),
+                                        )
+                                    })
+```
+
+`set_active` already exists on `EnvironmentManager` (`src/environment_manager.rs:142`) and emits `EnvironmentsChanged`, so the menu and the request editor stay in sync.
+
+- [ ] **Step 4: Remove the "Set active" button from the detail pane**
+
+In the detail name row (`src/environment_manager.rs:322-347`), delete the `.when(active_id != Some(sel_id), |this| { this.child(Button::new("env-set-active")...) })` block entirely. The row keeps only the name `Input` and the `Delete` button.
+
+- [ ] **Step 5: Card-style variable table**
+
+Wrap the column-header row + the var rows in a single bordered card with a header strip and zebra striping. Replace the header-row block (`src/environment_manager.rs:348-360`) and the `v_flex().id("env-vars")...` block (`src/environment_manager.rs:361-395`) with one card:
+
+```rust
+                    .child(
+                        v_flex()
+                            .flex_1()
+                            .min_h_0()
+                            .rounded(theme.radius_lg)
+                            .border_1()
+                            .border_color(theme.border)
+                            .overflow_hidden()
+                            .child(
+                                // header strip
+                                h_flex()
+                                    .w_full()
+                                    .gap_2()
+                                    .items_center()
+                                    .px_3()
+                                    .py_1p5()
+                                    .bg(theme.muted)
+                                    .text_xs()
+                                    .text_color(theme.muted_foreground)
+                                    .child(div().w(px(20.)).flex_shrink_0())
+                                    .child(div().flex_1().child("KEY"))
+                                    .child(div().flex_1().child("VALUE"))
+                                    .child(div().w(px(24.)).flex_shrink_0()),
+                            )
+                            .child(
+                                v_flex()
+                                    .id("env-vars")
+                                    .flex_1()
+                                    .overflow_scroll()
+                                    .children(self.var_rows.iter().enumerate().map(|(index, row)| {
+                                        h_flex()
+                                            .w_full()
+                                            .gap_2()
+                                            .items_center()
+                                            .px_3()
+                                            .py_1p5()
+                                            .when(index % 2 == 1, |r| r.bg(theme.muted.opacity(0.4)))
+                                            .border_t_1()
+                                            .border_color(theme.border)
+                                            .child(
+                                                div().w(px(20.)).flex_shrink_0().flex().justify_center().child(
+                                                    Checkbox::new(("var-check", index))
+                                                        .checked(row.enabled)
+                                                        .on_click(cx.listener(move |this, _, _window, cx| {
+                                                            this.toggle_var(index, cx);
+                                                        })),
+                                                ),
+                                            )
+                                            .child(div().flex_1().min_w_0().child(Input::new(&row.key_input)))
+                                            .child(div().flex_1().min_w_0().child(Input::new(&row.value_input)))
+                                            .child(
+                                                div().w(px(24.)).flex_shrink_0().flex().justify_center().child(
+                                                    Button::new(("var-del", index))
+                                                        .ghost()
+                                                        .xsmall()
+                                                        .label("×")
+                                                        .on_click(cx.listener(move |this, _, _window, cx| {
+                                                            this.remove_var_row(index, cx);
+                                                        })),
+                                                ),
+                                            )
+                                    })),
+                            ),
+                    )
+```
+
+- [ ] **Step 6: Bottom bar: "+ Add variable" (left) and a Save footer (right)**
+
+Replace the final bottom row (`src/environment_manager.rs:396-420`, the `h_flex().justify_between()` with Add variable + Save) with an add-variable button directly under the table, plus a bordered footer holding only a right-aligned Save:
+
+```rust
+                    .child(
+                        Button::new("env-add-var")
+                            .small()
+                            .ghost()
+                            .label("+ Add variable")
+                            .on_click(cx.listener(|this, _, window, cx| {
+                                this.add_var_row(window, cx);
+                            })),
+                    )
+                    .child(
+                        // Footer: only a right-aligned Save (no hint text).
+                        h_flex()
+                            .w_full()
+                            .justify_end()
+                            .pt_2()
+                            .border_t_1()
+                            .border_color(theme.border)
+                            .child(
+                                Button::new("env-save")
+                                    .small()
+                                    .primary()
+                                    .label("Save")
+                                    .on_click(cx.listener(|this, _, _window, cx| {
+                                        this.save_and_notify(cx);
+                                    })),
+                            ),
+                    )
+```
+
+- [ ] **Step 7: Compile gate**
+
+Run: `cargo check`
+Expected: PASS. If `theme.primary.opacity(0.12)` doesn't resolve, use `theme.primary.opacity(0.12)` from gpui's `Hsla::opacity`; it exists (used widely). If `border_dashed()` is missing, it's `gpui::Styled::border_dashed` — confirm by grepping gpui for `fn border_dashed`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/environment_manager.rs src/app.rs
+git commit -m "feat(env): Beautify environment dialog (dot activation, card table, Save footer)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: Final build + manual visual verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full release-mode compile gate**
+
+Run: `cargo build`
+Expected: PASS with no errors. Resolve any remaining warnings about unused imports (e.g. removed `Button`/`Sizable` usages in `app.rs` if the env button removal orphaned an import).
+
+- [ ] **Step 2: Hand off to the user for visual verification on Windows/macOS**
+
+The agent cannot run the GPU app in WSL2. Ask the user to run `cargo run` on their Windows/macOS machine and confirm against the Figma mockups in `.superpowers/brainstorm/`:
+  - Panels float as padded cards with gaps; resize handles still work.
+  - Title bar shows "Poopman" + an "Edit" menu at top-left; window controls render correctly on their platform.
+  - Edit → environment list switches the active env (check mark moves; request variables update); "Manage Environments…" opens the dialog.
+  - Request/Response tab strips are segmented pills; response status is a colored pill.
+  - Env dialog: dashed New button, dot toggles active (+ ACTIVE tag), no "Set active" button, card variable table with header/zebra, Save in a bottom-right footer, no hint text.
+
+- [ ] **Step 3: Address any visual fixes the user reports**, then final commit if changes were made:
+
+```bash
+git add -A
+git commit -m "fix(ui): Visual polish from manual verification
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** floating-card layout → Task 3; Edit menu w/ env list + manage → Task 2; cross-platform title bar → relies on gpui-component `TitleBar` (Task 2 Step 4); env dialog (dashed new, dot activation, no "Set active", card table, Save footer, no hint) → Task 8; segmented pill tabs → Tasks 5–6; pill request tabs → Task 4; history card rows → Task 7; theme retained, shadows via `shadow_sm` helper → Task 1.
+- **Sequencing:** helpers (1) precede consumers (3–8); menu (2) adds `set_active_environment`/`open_env_manager` visibility used nowhere else; dialog title change (8) and manager redesign (8) committed together.
+- **Type consistency:** `card_panel`/`segmented_bar`/`segment_pill` signatures `(theme: &Theme[, active: bool]) -> Div` used identically everywhere; `set_active_environment(Option<i64>)` and `set_active(Option<i64>)` (existing manager method) both take `Option<i64>`; `PopupMenuItem::new(..).checked(..).on_click(..)` matches verified 0.5.1 API.
+- **Known verify-at-implementation points (flagged inline):** exact re-export paths for `DropdownMenu`/`PopupMenuItem`; presence of `border_dashed`; `render_status_bar` semantic color variable name. These are grep-confirmable in seconds and noted at the relevant steps.

--- a/docs/superpowers/specs/2026-06-23-ui-redesign-floating-cards-design.md
+++ b/docs/superpowers/specs/2026-06-23-ui-redesign-floating-cards-design.md
@@ -1,0 +1,115 @@
+# Poopman UI Redesign — Floating Cards, Edit Menu, Env Dialog
+
+**Date:** 2026-06-23
+**Status:** Approved (design)
+**Source design:** Figma export "GUI app design" (React/Tailwind) — coral-orange "Claude Code" inspired API client.
+
+## Goal
+
+Reimplement Poopman's GPUI UI to match the provided Figma design, with three user-driven changes:
+
+1. Adopt the Figma **floating-card layout** (padded canvas; each panel is an independent rounded, bordered, shadowed card with gaps between them).
+2. Move the **Environment control** out of the toolbar and into an **Edit menu** integrated at the top-left of the title bar (like VS Code / modern desktop apps), cross-platform on macOS and Windows.
+3. **Beautify the Environment dialog** in the same floating-card / coral style, with a refined activation interaction.
+
+The existing warm coral "Claude paper" theme in `theme.rs` already matches the Figma palette and is largely retained — this is primarily a structural + styling pass, not a rewrite of behavior or data flow.
+
+## Non-Goals (YAGNI)
+
+- No new View/Help menus (Edit only for now; structure leaves room to add later).
+- No changes to HTTP logic, DB schema, request/response data flow, or URL/params sync.
+- No dark mode work.
+- No pixel-for-pixel cloning — match the design language (rounded cards, segmented pill tabs, card-style rows, coral accents), not exact Tailwind values.
+
+## Constraints
+
+- **WSL2 cannot run GPUI** (GPU requirement). Verification in this environment is limited to `cargo check` / `cargo build`. Visual confirmation is done by the user running `cargo run` on Windows/macOS.
+- Cross-platform title bar: rely on gpui-component `TitleBar`'s platform-aware control placement (macOS traffic-light inset on the left; Windows window controls on the right). The menu sits left-aligned, immediately after the "Poopman" brand, after any platform inset.
+- Stack: gpui 0.2.2, gpui-component 0.5.x. Menu uses `Button::dropdown_menu(...)` + `PopupMenu` (`.label`, `.menu_with_check`, `.separator`, item `on_click`), all confirmed present in 0.5.1.
+
+## Approach
+
+Introduce small shared UI helpers rather than inlining styles per panel (consistent with the project's "reuse over reinvent" rule):
+
+- **`src/ui.rs` (new):** shared building blocks —
+  - `card_panel()` → a container with `bg(card) + border_1 + border_color(border) + rounded_lg + shadow_sm + overflow_hidden`, used to wrap each floating panel.
+  - segmented pill tab strip helper → `bg(muted)` rounded container holding pills; active pill is `bg(card) + shadow_sm + foreground`, inactive is `muted_foreground` with hover. Reused by Request and Response tab bars.
+- **`src/menu_bar.rs` (new):** the Edit menu (a `Button` with `dropdown_menu`) intended to be embedded as a child of `TitleBar`.
+- Existing panels are restyled in place to consume these helpers.
+
+Alternative considered: inline all styling directly into each panel. Rejected — more scattered, higher risk of visual drift between panels, and against the codebase's reuse guidance.
+
+## Component-Level Design
+
+### 1. Floating-card layout — `app.rs` (render)
+
+- Root: `v_flex().size_full().bg(background)`, with `p_3` padding and `gap` between stacked sections (≈ Tailwind `gap-2.5`).
+- `TitleBar` stays flush at the very top (brand + Edit menu + window controls); it is **not** wrapped in a card.
+- Below the title bar, content is composed of card-wrapped panels:
+  - **Tab bar card** — its own full-width row (`card_panel`), containing the request tabs + "new tab" button. The current Env selector at the row's end is **removed**.
+  - **Main split** (`h_resizable`): left **Sidebar card** + right column.
+  - Right column (`v_resizable`): **Request card** above, **Response card** below.
+  - Each panel content is wrapped with `card_panel()`.
+- **Resize handles** restyled to match Figma: a thin, short, rounded `bg(border)` bar centered in the handle track; on hover → `primary` at reduced opacity. Applies to both the horizontal (sidebar/main) and vertical (request/response) handles.
+
+### 2. Edit menu — `menu_bar.rs` (new) + `app.rs` + actions
+
+- A `Button::new("edit-menu").ghost()` labeled "Edit", placed as a `TitleBar` child immediately right of the "Poopman" brand label.
+- `.dropdown_menu(|menu, _, _| ...)` builds a `PopupMenu`:
+  - `.label("Environment")` — group header.
+  - One entry per environment: `.menu_with_check(env.name, is_active, action_or_onclick)` — clicking switches the active environment (check mark indicates current).
+  - A `"No Environment"` entry to clear the active selection (checked when none active).
+  - `.separator()`.
+  - `"Manage Environments…"` — opens the (beautified) environment dialog.
+- Wiring: define gpui actions (e.g. `SwitchEnvironment { id: i64 }`, `ClearEnvironment`, `OpenEnvManager`) or equivalent item `on_click` closures dispatched to `PoopmanApp`. Handlers reuse existing `set_active(...)` and `open_env_manager(...)` logic. Switching active env continues to emit/refresh request-editor variables exactly as today.
+- `PopupMenu::init(cx)` is invoked at startup if not already (alongside `gpui_component::init`).
+
+### 3. Environment dialog beautification — `environment_manager.rs` + dialog wrapper in `app.rs`
+
+Behavior is preserved (create / select / activate / delete environments; add / edit / toggle / delete variables; immediate DB writes; `EnvironmentsChanged` emission). Visual + one interaction change:
+
+- **Dialog frame:** larger corner radius, soft shadow. Header shows title **"Environments"** plus a one-line subtitle: *"Define variables like `{{base_url}}` per environment."* Close (✕) affordance consistent with the style.
+- **Left list:**
+  - `"+ New environment"` rendered as a **dashed coral button**.
+  - Environment rows: the **left dot is the activation control** — clicking the dot toggles active (filled coral = active; empty = inactive). Clicking the rest of the row selects it for editing (decoupled from activation, so a non-active env can be edited without switching). Active row gets a coral-wash background + an `ACTIVE` tag.
+  - The detail pane's **"Set active" button is removed** (activation now lives on the dot).
+- **Right detail pane:**
+  - Name input + `Delete` (ghost/danger) on one row.
+  - Variables rendered as a **card table**: a header row (Key / Value), zebra-striped rows, checkbox with coral fill when enabled, a thin vertical separator between key and value, and a delete affordance revealed on hover.
+  - `"+ Add variable"` as a coral text button.
+- **Footer:** the *"改动即时写入数据库"* hint is **removed**. Footer keeps only a right-aligned primary **`Save`** button.
+
+### 4. Theme touch-ups — `theme.rs`
+
+The existing coral palette is retained. Add/confirm only what the card style needs:
+
+- A subtle `shadow_sm` value for cards (via gpui shadow on the `card_panel` helper, not necessarily a theme field).
+- Segmented pill tabs: active pill on white (`card`) surface; segment container on `muted`.
+- HTTP method colors keep the existing semantic mapping in `method_color(...)`.
+
+## Data Flow (unchanged)
+
+Request configuration → send → `RequestCompleted` → app saves to DB, updates `ResponseViewer`, reloads `HistoryPanel`. Environment switching (now via the Edit menu) → `set_active` → `EnvironmentsChanged` → app reloads environments and refreshes the request editor's variable map. No flow changes; only the *entry points* for environment switching/management move into the menu.
+
+## Files Touched
+
+- `src/ui.rs` — **new** (shared card + segmented-tab helpers).
+- `src/menu_bar.rs` — **new** (Edit menu).
+- `src/app.rs` — floating-card layout, title-bar menu embedding, action handling, dialog wrapper styling; remove old Env toolbar button.
+- `src/environment_manager.rs` — dialog visual redesign + dot-activation interaction; remove "Set active" button.
+- `src/request_editor.rs` — segmented pill tabs, card-style key/value rows, rounded inputs.
+- `src/response_viewer.rs` — segmented pill tabs, status pill, card-style headers/body.
+- `src/history_panel.rs` — card-style history rows matching Figma.
+- `src/tab_bar.rs` — pill-style request tabs inside the tab-bar card.
+- `src/theme.rs` — minor shadow / segment surface additions if needed.
+- `src/main.rs` — register new modules; ensure `PopupMenu::init` if required.
+
+## Testing / Verification
+
+- `cargo check` and `cargo build` must pass in this environment (primary automated gate).
+- Manual visual verification performed by the user on Windows/macOS via `cargo run`, checked against the Figma mockups in `.superpowers/brainstorm/`.
+- Spot-check behavior parity: environment switch from menu updates active env + request variables; dialog create/edit/activate/delete still persist; request/response panels still send and render.
+
+## Open Items
+
+None blocking. View/Help menus and any further polish are deferred.

--- a/src/app.rs
+++ b/src/app.rs
@@ -239,6 +239,10 @@ impl PoopmanApp {
             return;
         }
         self.reload_environments(cx);
+        self.env_manager.update(cx, |mgr, cx| {
+            mgr.reload();
+            cx.notify();
+        });
     }
 
     /// Save current editor state to active tab

--- a/src/app.rs
+++ b/src/app.rs
@@ -152,6 +152,13 @@ impl PoopmanApp {
             },
         );
 
+        // Push the initial tab into the tab bar so the first request shows as a
+        // tab immediately (the TabBar entity starts empty; without this the bar
+        // would show only the "+" until the first tab action).
+        tab_bar.update(cx, |bar, cx| {
+            bar.update_tabs(request_tabs.clone(), active_tab_index, cx);
+        });
+
         Self {
             db,
             history_panel,

--- a/src/app.rs
+++ b/src/app.rs
@@ -448,20 +448,27 @@ impl Render for PoopmanApp {
             .size_full()
             .bg(theme.muted)
             .child(
-                // Custom warm title bar (replaces the white native title bar)
-                TitleBar::new()
-                    .child(
-                        div()
-                            .text_sm()
-                            .font_weight(FontWeight::SEMIBOLD)
-                            .text_color(theme.foreground)
-                            .child("Poopman"),
-                    )
-                    .child(crate::menu_bar::edit_menu(
-                        cx.entity(),
-                        self.environments.clone(),
-                        self.active_environment_id,
-                    )),
+                // Custom warm title bar (replaces the white native title bar).
+                // Brand + Edit menu are grouped in one child so the TitleBar's
+                // justify_between row keeps them together at the left (otherwise
+                // two children get pushed to opposite ends).
+                TitleBar::new().child(
+                    h_flex()
+                        .items_center()
+                        .gap_2()
+                        .child(
+                            div()
+                                .text_sm()
+                                .font_weight(FontWeight::SEMIBOLD)
+                                .text_color(theme.foreground)
+                                .child("Poopman"),
+                        )
+                        .child(crate::menu_bar::edit_menu(
+                            cx.entity(),
+                            self.environments.clone(),
+                            self.active_environment_id,
+                        )),
+                ),
             )
             .child(
                 div()
@@ -469,7 +476,6 @@ impl Render for PoopmanApp {
                     .min_h_0()
                     .flex()
                     .flex_col()
-                    .gap(px(10.))
                     .p_3()
                     .child(
                         h_resizable("history-main-splitter")
@@ -486,12 +492,17 @@ impl Render for PoopmanApp {
                                     ),
                             )
                             .child(
-                                // Right: Tab bar + Request editor and response viewer
+                                // Right: Tab bar + Request editor and response viewer.
+                                // gap = space between the tab-bar card and the
+                                // request/response area; ml = gap from the sidebar
+                                // card (the resizable handle itself is only 1px).
                                 div()
                                     .flex_1()
                                     .h_full()
                                     .flex()
                                     .flex_col()
+                                    .gap(px(10.))
+                                    .ml(px(10.))
                                     .overflow_hidden() // Prevent content overflow
                                     .on_scroll_wheel(|_, _, cx| cx.stop_propagation()) // Isolate scroll events
                                     .child(
@@ -517,9 +528,12 @@ impl Render for PoopmanApp {
                                                         ),
                                                 )
                                                 .child(
+                                                    // mt = gap from the request card
+                                                    // (the v_resizable handle is only 1px).
                                                     crate::ui::card_panel(theme)
                                                         .flex_1()
                                                         .min_h(px(200.))
+                                                        .mt(px(10.))
                                                         .child(self.response_viewer.clone())
                                                         .into_any_element(),
                                                 ),

--- a/src/app.rs
+++ b/src/app.rs
@@ -206,8 +206,28 @@ impl PoopmanApp {
     /// Open the environment management dialog.
     pub(crate) fn open_env_manager(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let manager = self.env_manager.clone();
-        window.open_dialog(cx, move |dialog, _window, _cx| {
-            dialog.title("Environments").w(px(720.)).child(manager.clone())
+        window.open_dialog(cx, move |dialog, _window, cx| {
+            let theme = cx.theme();
+            dialog
+                .title(
+                    v_flex()
+                        .gap_0p5()
+                        .child(
+                            div()
+                                .text_lg()
+                                .font_weight(gpui::FontWeight::BOLD)
+                                .text_color(theme.foreground)
+                                .child("Environments"),
+                        )
+                        .child(
+                            div()
+                                .text_xs()
+                                .text_color(theme.muted_foreground)
+                                .child("Define variables like {{base_url}} per environment"),
+                        ),
+                )
+                .w(px(680.))
+                .child(manager.clone())
         });
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -448,63 +448,62 @@ impl Render for PoopmanApp {
                     .gap(px(10.))
                     .p_3()
                     .child(
-                h_resizable("history-main-splitter")
-                    .child(
-                        // Left: History panel with resizable width
-                        resizable_panel()
-                            .size(px(SIDEBAR_WIDTH))
-                            .size_range(px(SIDEBAR_MIN)..px(SIDEBAR_MAX))
+                        h_resizable("history-main-splitter")
                             .child(
-                                crate::ui::card_panel(theme)
-                                    .size_full()
-                                    .on_scroll_wheel(|_, _, cx| cx.stop_propagation())
-                                    .child(self.history_panel.clone()),
-                            ),
-                    )
-                    .child(
-                        // Right: Tab bar + Request editor and response viewer
-                        div()
-                            .flex_1()
-                            .h_full()
-                            .flex()
-                            .flex_col()
-                            .overflow_hidden() // Prevent content overflow
-                            .bg(theme.background) // Capture mouse events, prevent passthrough
-                            .on_scroll_wheel(|_, _, cx| cx.stop_propagation()) // Isolate scroll events
-                            .child(
-                                // Tab bar card (its own floating row)
-                                crate::ui::card_panel(theme).child(
-                                    h_flex()
-                                        .w_full()
-                                        .child(div().flex_1().min_w_0().child(self.tab_bar.clone())),
-                                ),
+                                // Left: History panel with resizable width
+                                resizable_panel()
+                                    .size(px(SIDEBAR_WIDTH))
+                                    .size_range(px(SIDEBAR_MIN)..px(SIDEBAR_MAX))
+                                    .child(
+                                        crate::ui::card_panel(theme)
+                                            .size_full()
+                                            .on_scroll_wheel(|_, _, cx| cx.stop_propagation())
+                                            .child(self.history_panel.clone()),
+                                    ),
                             )
                             .child(
-                                // Request editor and response viewer with resizable splitter
-                                div().flex_1().overflow_hidden().child(
-                                    v_resizable("request-response-splitter")
-                                        .child(
-                                            resizable_panel()
-                                                .size(px(REQUEST_INITIAL_HEIGHT))
-                                                .size_range(px(REQUEST_MIN)..px(REQUEST_MAX))
+                                // Right: Tab bar + Request editor and response viewer
+                                div()
+                                    .flex_1()
+                                    .h_full()
+                                    .flex()
+                                    .flex_col()
+                                    .overflow_hidden() // Prevent content overflow
+                                    .on_scroll_wheel(|_, _, cx| cx.stop_propagation()) // Isolate scroll events
+                                    .child(
+                                        // Tab bar card (its own floating row)
+                                        crate::ui::card_panel(theme).child(
+                                            h_flex()
+                                                .w_full()
+                                                .child(div().flex_1().min_w_0().child(self.tab_bar.clone())),
+                                        ),
+                                    )
+                                    .child(
+                                        // Request editor and response viewer with resizable splitter
+                                        div().flex_1().overflow_hidden().child(
+                                            v_resizable("request-response-splitter")
+                                                .child(
+                                                    resizable_panel()
+                                                        .size(px(REQUEST_INITIAL_HEIGHT))
+                                                        .size_range(px(REQUEST_MIN)..px(REQUEST_MAX))
+                                                        .child(
+                                                            crate::ui::card_panel(theme)
+                                                                .size_full()
+                                                                .child(self.request_editor.clone()),
+                                                        ),
+                                                )
                                                 .child(
                                                     crate::ui::card_panel(theme)
-                                                        .size_full()
-                                                        .child(self.request_editor.clone()),
+                                                        .flex_1()
+                                                        .min_h(px(200.))
+                                                        .child(self.response_viewer.clone())
+                                                        .into_any_element(),
                                                 ),
-                                        )
-                                        .child(
-                                            crate::ui::card_panel(theme)
-                                                .flex_1()
-                                                .min_h(px(200.))
-                                                .child(self.response_viewer.clone())
-                                                .into_any_element(),
                                         ),
-                                ),
-                            )
-                            .into_any_element(),
+                                    )
+                                    .into_any_element(),
+                            ),
                     ),
-            ),
             )
             // gpui-component dialogs/modals are stored on Root but must be rendered
             // by the app's root view; embed the dialog overlay here.

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use gpui::*;
 use gpui_component::{
-    button::*, h_flex, v_flex, ActiveTheme as _, Root, Sizable as _, TitleBar, WindowExt,
+    h_flex, v_flex, ActiveTheme as _, Root, TitleBar, WindowExt,
     resizable::{h_resizable, resizable_panel, v_resizable},
 };
 use gpui::px;
@@ -204,11 +204,21 @@ impl PoopmanApp {
     }
 
     /// Open the environment management dialog.
-    fn open_env_manager(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    pub(crate) fn open_env_manager(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let manager = self.env_manager.clone();
         window.open_dialog(cx, move |dialog, _window, _cx| {
             dialog.title("Environments").w(px(720.)).child(manager.clone())
         });
+    }
+
+    /// Switch the active environment (or clear it) from the Edit menu, then
+    /// reload + refresh the request editor's variable map.
+    pub(crate) fn set_active_environment(&mut self, id: Option<i64>, cx: &mut Context<Self>) {
+        if let Err(e) = self.db.set_active_environment_id(id) {
+            log::error!("Failed to set active environment: {}", e);
+            return;
+        }
+        self.reload_environments(cx);
     }
 
     /// Save current editor state to active tab
@@ -410,26 +420,24 @@ impl Render for PoopmanApp {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
 
-        let env_label = format!(
-            "Env: {}",
-            self.active_environment_id
-                .and_then(|id| self.environments.iter().find(|e| e.id == id))
-                .map(|e| e.name.clone())
-                .unwrap_or_else(|| "No Environment".to_string())
-        );
-
         v_flex()
             .size_full()
             .bg(theme.background)
             .child(
                 // Custom warm title bar (replaces the white native title bar)
-                TitleBar::new().child(
-                    div()
-                        .text_sm()
-                        .font_weight(FontWeight::SEMIBOLD)
-                        .text_color(theme.foreground)
-                        .child("Poopman"),
-                ),
+                TitleBar::new()
+                    .child(
+                        div()
+                            .text_sm()
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .text_color(theme.foreground)
+                            .child("Poopman"),
+                    )
+                    .child(crate::menu_bar::edit_menu(
+                        cx.entity(),
+                        self.environments.clone(),
+                        self.active_environment_id,
+                    )),
             )
             .child(
                 div().flex_1().min_h_0().child(
@@ -457,31 +465,10 @@ impl Render for PoopmanApp {
                             .bg(theme.background) // Capture mouse events, prevent passthrough
                             .on_scroll_wheel(|_, _, cx| cx.stop_propagation()) // Isolate scroll events
                             .child(
-                                // Tab bar row with the environment selector at the right end
+                                // Tab bar row (env selector moved to the Edit menu)
                                 h_flex()
                                     .w_full()
-                                    .child(div().flex_1().min_w_0().child(self.tab_bar.clone()))
-                                    .child(
-                                        div()
-                                            .flex_shrink_0()
-                                            .flex()
-                                            .items_center()
-                                            .px_2()
-                                            .bg(theme.background)
-                                            .border_b_1()
-                                            .border_color(theme.border)
-                                            .child(
-                                                Button::new("env-selector")
-                                                    .ghost()
-                                                    .small()
-                                                    .label(env_label)
-                                                    .on_click(cx.listener(
-                                                        |this, _, window, cx| {
-                                                            this.open_env_manager(window, cx);
-                                                        },
-                                                    )),
-                                            ),
-                                    ),
+                                    .child(div().flex_1().min_w_0().child(self.tab_bar.clone())),
                             )
                             .child(
                                 // Request editor and response viewer with resizable splitter

--- a/src/app.rs
+++ b/src/app.rs
@@ -422,7 +422,7 @@ impl Render for PoopmanApp {
 
         v_flex()
             .size_full()
-            .bg(theme.background)
+            .bg(theme.muted)
             .child(
                 // Custom warm title bar (replaces the white native title bar)
                 TitleBar::new()
@@ -440,7 +440,14 @@ impl Render for PoopmanApp {
                     )),
             )
             .child(
-                div().flex_1().min_h_0().child(
+                div()
+                    .flex_1()
+                    .min_h_0()
+                    .flex()
+                    .flex_col()
+                    .gap(px(10.))
+                    .p_3()
+                    .child(
                 h_resizable("history-main-splitter")
                     .child(
                         // Left: History panel with resizable width
@@ -448,9 +455,9 @@ impl Render for PoopmanApp {
                             .size(px(SIDEBAR_WIDTH))
                             .size_range(px(SIDEBAR_MIN)..px(SIDEBAR_MAX))
                             .child(
-                                div()
+                                crate::ui::card_panel(theme)
                                     .size_full()
-                                    .on_scroll_wheel(|_, _, cx| cx.stop_propagation()) // Isolate scroll events
+                                    .on_scroll_wheel(|_, _, cx| cx.stop_propagation())
                                     .child(self.history_panel.clone()),
                             ),
                     )
@@ -465,10 +472,12 @@ impl Render for PoopmanApp {
                             .bg(theme.background) // Capture mouse events, prevent passthrough
                             .on_scroll_wheel(|_, _, cx| cx.stop_propagation()) // Isolate scroll events
                             .child(
-                                // Tab bar row (env selector moved to the Edit menu)
-                                h_flex()
-                                    .w_full()
-                                    .child(div().flex_1().min_w_0().child(self.tab_bar.clone())),
+                                // Tab bar card (its own floating row)
+                                crate::ui::card_panel(theme).child(
+                                    h_flex()
+                                        .w_full()
+                                        .child(div().flex_1().min_w_0().child(self.tab_bar.clone())),
+                                ),
                             )
                             .child(
                                 // Request editor and response viewer with resizable splitter
@@ -478,15 +487,16 @@ impl Render for PoopmanApp {
                                             resizable_panel()
                                                 .size(px(REQUEST_INITIAL_HEIGHT))
                                                 .size_range(px(REQUEST_MIN)..px(REQUEST_MAX))
-                                                .child(self.request_editor.clone()),
+                                                .child(
+                                                    crate::ui::card_panel(theme)
+                                                        .size_full()
+                                                        .child(self.request_editor.clone()),
+                                                ),
                                         )
                                         .child(
-                                            div()
+                                            crate::ui::card_panel(theme)
                                                 .flex_1()
-                                                .min_h(px(200.)) // Minimum height to prevent collapse
-                                                .overflow_hidden() // Prevent content overflow
-                                                .border_t_1()
-                                                .border_color(theme.border)
+                                                .min_h(px(200.))
                                                 .child(self.response_viewer.clone())
                                                 .into_any_element(),
                                         ),

--- a/src/environment_manager.rs
+++ b/src/environment_manager.rs
@@ -53,7 +53,7 @@ impl EnvironmentManager {
         this
     }
 
-    fn reload(&mut self) {
+    pub(crate) fn reload(&mut self) {
         self.environments = self.db.load_environments().unwrap_or_default();
         self.active_id = self.db.get_active_environment_id().unwrap_or(None);
     }

--- a/src/environment_manager.rs
+++ b/src/environment_manager.rs
@@ -230,9 +230,12 @@ impl Render for EnvironmentManager {
                             .py_1p5()
                             .gap_2()
                             .items_center()
-                            .rounded(theme.radius)
+                            .rounded(theme.radius_lg)
+                            .border_1()
+                            .border_dashed()
+                            .border_color(theme.primary)
                             .cursor_pointer()
-                            .hover(|s| s.bg(theme.list_hover))
+                            .hover(|s| s.bg(theme.list_active))
                             .on_click(cx.listener(|this, _, window, cx| {
                                 this.add_environment(window, cx);
                             }))
@@ -282,20 +285,33 @@ impl Render for EnvironmentManager {
                                         this.select(id, window, cx);
                                     }))
                                     .child(
-                                        // indicator column (centered dot), matches the
-                                        // "+" column on the add row so they align.
+                                        // Dot = activation toggle (stops row-select propagation)
                                         div()
-                                            .w(px(14.))
+                                            .id(("env-active-dot", id as u64))
+                                            .w(px(16.))
                                             .flex_shrink_0()
                                             .flex()
                                             .items_center()
                                             .justify_center()
+                                            .cursor_pointer()
+                                            .on_click(cx.listener(move |this, _, _window, cx| {
+                                                cx.stop_propagation();
+                                                let new = if this.active_id == Some(id) {
+                                                    None
+                                                } else {
+                                                    Some(id)
+                                                };
+                                                this.set_active(new, cx);
+                                            }))
                                             .child(
                                                 div()
-                                                    .w(px(6.))
-                                                    .h(px(6.))
+                                                    .w(px(7.))
+                                                    .h(px(7.))
                                                     .rounded_full()
-                                                    .when(is_active, |d| d.bg(theme.primary)),
+                                                    .when(is_active, |d| d.bg(theme.primary))
+                                                    .when(!is_active, |d| {
+                                                        d.border_1().border_color(theme.muted_foreground)
+                                                    }),
                                             ),
                                     )
                                     .child(
@@ -309,6 +325,19 @@ impl Render for EnvironmentManager {
                                             .text_color(theme.foreground)
                                             .child(env.name.clone()),
                                     )
+                                    .when(is_active, |row| {
+                                        row.child(
+                                            div()
+                                                .flex_shrink_0()
+                                                .px_1p5()
+                                                .rounded(theme.radius)
+                                                .text_xs()
+                                                .font_weight(FontWeight::BOLD)
+                                                .bg(theme.primary.opacity(0.12))
+                                                .text_color(theme.primary)
+                                                .child("ACTIVE"),
+                                        )
+                                    })
                             })),
                     ),
             )
@@ -325,16 +354,6 @@ impl Render for EnvironmentManager {
                             .gap_2()
                             .items_center()
                             .child(div().flex_1().min_w_0().child(Input::new(&self.name_input)))
-                            .when(active_id != Some(sel_id), |this| {
-                                this.child(
-                                    Button::new("env-set-active")
-                                        .small()
-                                        .label("Set active")
-                                        .on_click(cx.listener(move |this, _, _window, cx| {
-                                            this.set_active(Some(sel_id), cx);
-                                        })),
-                                )
-                            })
                             .child(
                                 Button::new("env-delete")
                                     .small()
@@ -346,68 +365,86 @@ impl Render for EnvironmentManager {
                             ),
                     )
                     .child(
-                        // column headers
-                        h_flex()
-                            .w_full()
-                            .gap_2()
-                            .items_center()
-                            .text_xs()
-                            .text_color(theme.muted_foreground)
-                            .child(div().w(px(20.)).flex_shrink_0())
-                            .child(div().flex_1().child("Key"))
-                            .child(div().flex_1().child("Value"))
-                            .child(div().w(px(24.)).flex_shrink_0()),
-                    )
-                    .child(
                         v_flex()
-                            .id("env-vars")
                             .flex_1()
-                            .gap_1()
-                            .overflow_scroll()
-                            .children(self.var_rows.iter().enumerate().map(|(index, row)| {
+                            .min_h_0()
+                            .rounded(theme.radius_lg)
+                            .border_1()
+                            .border_color(theme.border)
+                            .overflow_hidden()
+                            .child(
+                                // header strip
                                 h_flex()
                                     .w_full()
                                     .gap_2()
                                     .items_center()
-                                    .child(
-                                        div().w(px(20.)).flex_shrink_0().flex().justify_center().child(
-                                            Checkbox::new(("var-check", index))
-                                                .checked(row.enabled)
-                                                .on_click(cx.listener(move |this, _, _window, cx| {
-                                                    this.toggle_var(index, cx);
-                                                })),
-                                        ),
-                                    )
-                                    .child(div().flex_1().min_w_0().child(Input::new(&row.key_input)))
-                                    .child(div().flex_1().min_w_0().child(Input::new(&row.value_input)))
-                                    .child(
-                                        div().w(px(24.)).flex_shrink_0().flex().justify_center().child(
-                                            Button::new(("var-del", index))
-                                                .ghost()
-                                                .xsmall()
-                                                .label("×")
-                                                .on_click(cx.listener(move |this, _, _window, cx| {
-                                                    this.remove_var_row(index, cx);
-                                                })),
-                                        ),
-                                    )
+                                    .px_3()
+                                    .py_1p5()
+                                    .bg(theme.muted)
+                                    .text_xs()
+                                    .text_color(theme.muted_foreground)
+                                    .child(div().w(px(20.)).flex_shrink_0())
+                                    .child(div().flex_1().child("KEY"))
+                                    .child(div().flex_1().child("VALUE"))
+                                    .child(div().w(px(24.)).flex_shrink_0()),
+                            )
+                            .child(
+                                v_flex()
+                                    .id("env-vars")
+                                    .flex_1()
+                                    .overflow_scroll()
+                                    .children(self.var_rows.iter().enumerate().map(|(index, row)| {
+                                        h_flex()
+                                            .w_full()
+                                            .gap_2()
+                                            .items_center()
+                                            .px_3()
+                                            .py_1p5()
+                                            .when(index % 2 == 1, |r| r.bg(theme.muted.opacity(0.4)))
+                                            .border_t_1()
+                                            .border_color(theme.border)
+                                            .child(
+                                                div().w(px(20.)).flex_shrink_0().flex().justify_center().child(
+                                                    Checkbox::new(("var-check", index))
+                                                        .checked(row.enabled)
+                                                        .on_click(cx.listener(move |this, _, _window, cx| {
+                                                            this.toggle_var(index, cx);
+                                                        })),
+                                                ),
+                                            )
+                                            .child(div().flex_1().min_w_0().child(Input::new(&row.key_input)))
+                                            .child(div().flex_1().min_w_0().child(Input::new(&row.value_input)))
+                                            .child(
+                                                div().w(px(24.)).flex_shrink_0().flex().justify_center().child(
+                                                    Button::new(("var-del", index))
+                                                        .ghost()
+                                                        .xsmall()
+                                                        .label("×")
+                                                        .on_click(cx.listener(move |this, _, _window, cx| {
+                                                            this.remove_var_row(index, cx);
+                                                        })),
+                                                ),
+                                            )
+                                    })),
+                            ),
+                    )
+                    .child(
+                        Button::new("env-add-var")
+                            .small()
+                            .ghost()
+                            .label("+ Add variable")
+                            .on_click(cx.listener(|this, _, window, cx| {
+                                this.add_var_row(window, cx);
                             })),
                     )
                     .child(
+                        // Footer: only a right-aligned Save (no hint text).
                         h_flex()
                             .w_full()
-                            .gap_2()
-                            .items_center()
-                            .justify_between()
-                            .child(
-                                Button::new("env-add-var")
-                                    .small()
-                                    .ghost()
-                                    .label("+ Add variable")
-                                    .on_click(cx.listener(|this, _, window, cx| {
-                                        this.add_var_row(window, cx);
-                                    })),
-                            )
+                            .justify_end()
+                            .pt_2()
+                            .border_t_1()
+                            .border_color(theme.border)
                             .child(
                                 Button::new("env-save")
                                     .small()

--- a/src/environment_manager.rs
+++ b/src/environment_manager.rs
@@ -242,7 +242,7 @@ impl Render for EnvironmentManager {
                             .child(
                                 // indicator column (centered "+"), same width as env rows
                                 div()
-                                    .w(px(14.))
+                                    .w(px(16.))
                                     .flex_shrink_0()
                                     .flex()
                                     .items_center()
@@ -365,6 +365,7 @@ impl Render for EnvironmentManager {
                             ),
                     )
                     .child(
+                        // Inline card (no shadow/bg) — it sits inside the dialog surface, so card_panel's elevation would be wrong here.
                         v_flex()
                             .flex_1()
                             .min_h_0()
@@ -401,8 +402,7 @@ impl Render for EnvironmentManager {
                                             .px_3()
                                             .py_1p5()
                                             .when(index % 2 == 1, |r| r.bg(theme.muted.opacity(0.4)))
-                                            .border_t_1()
-                                            .border_color(theme.border)
+                                            .when(index > 0, |r| r.border_t_1().border_color(theme.border))
                                             .child(
                                                 div().w(px(20.)).flex_shrink_0().flex().justify_center().child(
                                                     Checkbox::new(("var-check", index))

--- a/src/history_panel.rs
+++ b/src/history_panel.rs
@@ -90,7 +90,6 @@ impl Render for HistoryPanel {
 
         v_flex()
             .size_full()
-            .bg(theme.background)
             .child(
                 // Header
                 h_flex()

--- a/src/history_panel.rs
+++ b/src/history_panel.rs
@@ -149,8 +149,8 @@ impl Render for HistoryPanel {
                                 .items_start()
                                 .w_full()
                                 .px_2p5()
-                                .py_1p5()
-                                .rounded(theme.radius)
+                                .py_2()
+                                .rounded(theme.radius_lg)
                                 .border_1()
                                 .border_color(if is_selected {
                                     theme.list_active_border

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod db;
 mod environment_manager;
 mod history_panel;
 mod http_client;
+mod menu_bar;
 mod request_editor;
 mod request_tab;
 mod response_viewer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod response_viewer;
 mod tab_bar;
 mod theme;
 mod types;
+mod ui;
 mod variables;
 mod url_params;
 

--- a/src/menu_bar.rs
+++ b/src/menu_bar.rs
@@ -1,0 +1,73 @@
+//! The Edit menu shown in the title bar. Houses environment switching (with a
+//! check mark on the active one) and an entry to open the environment dialog.
+//! Item handlers call back into `PoopmanApp` via a captured entity handle.
+
+use gpui::*;
+use gpui_component::{
+    button::{Button, ButtonVariants as _},
+    menu::{DropdownMenu as _, PopupMenuItem},
+    Sizable as _,
+};
+
+use crate::app::PoopmanApp;
+use crate::types::Environment;
+
+/// Build the "Edit" dropdown button for the title bar.
+pub fn edit_menu(
+    app: Entity<PoopmanApp>,
+    environments: Vec<Environment>,
+    active_id: Option<i64>,
+) -> impl IntoElement {
+    Button::new("edit-menu")
+        .ghost()
+        .small()
+        .label("Edit")
+        .dropdown_menu(move |menu, _window, _cx| {
+            let mut menu = menu.label("Environment");
+
+            for env in &environments {
+                let id = env.id;
+                let app = app.clone();
+                let is_active = active_id == Some(id);
+                menu = menu.item(
+                    PopupMenuItem::new(env.name.clone())
+                        .checked(is_active)
+                        .on_click(move |_, _window, cx| {
+                            app.update(cx, |app, cx| {
+                                app.set_active_environment(Some(id), cx);
+                            });
+                        }),
+                );
+            }
+
+            {
+                let app = app.clone();
+                menu = menu.item(
+                    PopupMenuItem::new("No Environment")
+                        .checked(active_id.is_none())
+                        .on_click(move |_, _window, cx| {
+                            app.update(cx, |app, cx| {
+                                app.set_active_environment(None, cx);
+                            });
+                        }),
+                );
+            }
+
+            menu = menu.separator();
+
+            {
+                let app = app.clone();
+                menu = menu.item(
+                    PopupMenuItem::new("Manage Environments\u{2026}").on_click(
+                        move |_, window, cx| {
+                            app.update(cx, |app, cx| {
+                                app.open_env_manager(window, cx);
+                            });
+                        },
+                    ),
+                );
+            }
+
+            menu
+        })
+}

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -1045,28 +1045,12 @@ impl Render for RequestEditor {
                         .flex_1()
                         .min_h_0()  // Critical for scrolling to work
                         .child(
-                            div()
-                                .flex()
-                                .flex_row()
-                                .gap_5()
-                                .border_b_1()
-                                .border_color(theme.border)
+                            crate::ui::segmented_bar(theme)
                                 .child(
-                                    div()
+                                    crate::ui::segment_pill(theme, self.active_tab == 0)
                                         .id("tab-headers")
-                                        .px_0p5()
-                                        .pb_2()
-                                        .text_sm()
-                                        .cursor_pointer()
-                                        .border_b_2()
-                                        .when(self.active_tab == 0, |this| {
-                                            this.border_color(theme.primary)
-                                                .text_color(theme.primary)
-                                                .font_weight(FontWeight::SEMIBOLD)
-                                        })
-                                        .when(self.active_tab != 0, |this| {
-                                            this.border_color(gpui::transparent_black())
-                                                .text_color(theme.muted_foreground)
+                                        .when(self.active_tab != 0, |s| {
+                                            s.hover(|s| s.text_color(theme.foreground))
                                         })
                                         .on_click(cx.listener(
                                             |this, _event: &gpui::ClickEvent, _window, cx| {
@@ -1077,21 +1061,10 @@ impl Render for RequestEditor {
                                         .child("Headers"),
                                 )
                                 .child(
-                                    div()
+                                    crate::ui::segment_pill(theme, self.active_tab == 1)
                                         .id("tab-params")
-                                        .px_0p5()
-                                        .pb_2()
-                                        .text_sm()
-                                        .cursor_pointer()
-                                        .border_b_2()
-                                        .when(self.active_tab == 1, |this| {
-                                            this.border_color(theme.primary)
-                                                .text_color(theme.primary)
-                                                .font_weight(FontWeight::SEMIBOLD)
-                                        })
-                                        .when(self.active_tab != 1, |this| {
-                                            this.border_color(gpui::transparent_black())
-                                                .text_color(theme.muted_foreground)
+                                        .when(self.active_tab != 1, |s| {
+                                            s.hover(|s| s.text_color(theme.foreground))
                                         })
                                         .on_click(cx.listener(
                                             |this, _event: &gpui::ClickEvent, _window, cx| {
@@ -1102,21 +1075,10 @@ impl Render for RequestEditor {
                                         .child("Params"),
                                 )
                                 .child(
-                                    div()
+                                    crate::ui::segment_pill(theme, self.active_tab == 2)
                                         .id("tab-body")
-                                        .px_0p5()
-                                        .pb_2()
-                                        .text_sm()
-                                        .cursor_pointer()
-                                        .border_b_2()
-                                        .when(self.active_tab == 2, |this| {
-                                            this.border_color(theme.primary)
-                                                .text_color(theme.primary)
-                                                .font_weight(FontWeight::SEMIBOLD)
-                                        })
-                                        .when(self.active_tab != 2, |this| {
-                                            this.border_color(gpui::transparent_black())
-                                                .text_color(theme.muted_foreground)
+                                        .when(self.active_tab != 2, |s| {
+                                            s.hover(|s| s.text_color(theme.foreground))
                                         })
                                         .on_click(cx.listener(
                                             |this, _event: &gpui::ClickEvent, _window, cx| {

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -990,7 +990,7 @@ impl Render for RequestEditor {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
 
-        div().id("request-editor-root").flex().flex_col().w_full().h_full().bg(theme.background).on_click(cx.listener(|_, _, _, cx| cx.stop_propagation())).child(
+        div().id("request-editor-root").flex().flex_col().w_full().h_full().on_click(cx.listener(|_, _, _, cx| cx.stop_propagation())).child(
             // Request section with header
             div()
                 .flex()

--- a/src/response_viewer.rs
+++ b/src/response_viewer.rs
@@ -257,7 +257,6 @@ impl Render for ResponseViewer {
             .w_full()
             .h_full()
             .overflow_hidden() // Prevent content overflow
-            .bg(theme.background)
             .on_click(cx.listener(|_, _, _, cx| cx.stop_propagation())) // Prevent click events from propagating
             .child(
                 // Response status bar (self-styled with its own padding + bottom border)

--- a/src/response_viewer.rs
+++ b/src/response_viewer.rs
@@ -170,12 +170,13 @@ impl ResponseViewer {
                 .border_color(cx.theme().border)
                 .child(
                     div()
-                        .px_2()
-                        .py_1()
+                        .px_2p5()
+                        .py_0p5()
                         .rounded(cx.theme().radius)
-                        .bg(status_color)
-                        .text_color(gpui::white())
-                        .text_sm()
+                        .text_xs()
+                        .font_weight(FontWeight::BOLD)
+                        .bg(status_color.opacity(0.12))
+                        .text_color(status_color)
                         .child(status_text),
                 )
                 .child(
@@ -276,28 +277,12 @@ impl Render for ResponseViewer {
                         .p_4()
                         .w_full()
                         .child(
-                            div()
-                                .flex()
-                                .flex_row()
-                                .gap_5()
-                                .border_b_1()
-                                .border_color(theme.border)
+                            crate::ui::segmented_bar(theme)
                                 .child(
-                                    div()
+                                    crate::ui::segment_pill(theme, self.active_tab == 0)
                                         .id("resp-tab-body")
-                                        .px_0p5()
-                                        .pb_2()
-                                        .text_sm()
-                                        .cursor_pointer()
-                                        .border_b_2()
-                                        .when(self.active_tab == 0, |this| {
-                                            this.border_color(theme.primary)
-                                                .text_color(theme.primary)
-                                                .font_weight(FontWeight::SEMIBOLD)
-                                        })
-                                        .when(self.active_tab != 0, |this| {
-                                            this.border_color(gpui::transparent_black())
-                                                .text_color(theme.muted_foreground)
+                                        .when(self.active_tab != 0, |s| {
+                                            s.hover(|s| s.text_color(theme.foreground))
                                         })
                                         .on_click(cx.listener(
                                             |this, _event: &gpui::ClickEvent, _window, cx| {
@@ -308,21 +293,10 @@ impl Render for ResponseViewer {
                                         .child("Body"),
                                 )
                                 .child(
-                                    div()
+                                    crate::ui::segment_pill(theme, self.active_tab == 1)
                                         .id("resp-tab-headers")
-                                        .px_0p5()
-                                        .pb_2()
-                                        .text_sm()
-                                        .cursor_pointer()
-                                        .border_b_2()
-                                        .when(self.active_tab == 1, |this| {
-                                            this.border_color(theme.primary)
-                                                .text_color(theme.primary)
-                                                .font_weight(FontWeight::SEMIBOLD)
-                                        })
-                                        .when(self.active_tab != 1, |this| {
-                                            this.border_color(gpui::transparent_black())
-                                                .text_color(theme.muted_foreground)
+                                        .when(self.active_tab != 1, |s| {
+                                            s.hover(|s| s.text_color(theme.foreground))
                                         })
                                         .on_click(cx.listener(
                                             |this, _event: &gpui::ClickEvent, _window, cx| {

--- a/src/tab_bar.rs
+++ b/src/tab_bar.rs
@@ -1,5 +1,6 @@
 use gpui::*;
 use gpui::px;
+use gpui::prelude::FluentBuilder as _;
 use gpui_component::{h_flex, ActiveTheme as _};
 
 use crate::request_tab::RequestTab;
@@ -69,11 +70,9 @@ impl Render for TabBar {
         h_flex()
             .gap_1()
             .items_center()
-            .px_2()
+            .px_1p5()
             .py_1()
             .bg(theme.background)
-            .border_b_1()
-            .border_color(theme.border)
             .child(
                 // Render all tabs
                 h_flex()
@@ -88,14 +87,13 @@ impl Render for TabBar {
 
                         h_flex()
                             .id(("tab", tab.id))
-                            .gap_2()
+                            .gap_1p5()
                             .items_center()
                             .px_3()
-                            .py_1p5()
-                            .rounded_sm()
-                            .border_1()
-                            .border_color(if is_active { theme.border } else { gpui::transparent_black() })
-                            .bg(if is_active { theme.tab_active } else { theme.background })
+                            .py_1()
+                            .rounded(theme.radius)
+                            .bg(if is_active { theme.muted } else { gpui::transparent_black() })
+                            .when(!is_active, |s| s.hover(|s| s.bg(theme.list_hover)))
                             .cursor_pointer()
                             .on_click(cx.listener(move |this, event, window, cx| {
                                 this.on_tab_click(tab_index, event, window, cx);
@@ -139,7 +137,7 @@ impl Render for TabBar {
                     .id("new-tab-button")
                     .px_2()
                     .py_1()
-                    .rounded_sm()
+                    .rounded(theme.radius)
                     .text_color(theme.muted_foreground)
                     .cursor_pointer()
                     .hover(|style| style.bg(theme.list_hover).text_color(theme.foreground))

--- a/src/tab_bar.rs
+++ b/src/tab_bar.rs
@@ -72,7 +72,6 @@ impl Render for TabBar {
             .items_center()
             .px_1p5()
             .py_1()
-            .bg(theme.background)
             .child(
                 // Render all tabs
                 h_flex()

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -61,8 +61,8 @@ pub fn method_color(method: HttpMethod, theme: &Theme) -> Hsla {
 pub fn apply_theme(cx: &mut App) {
     let theme = Theme::global_mut(cx);
     theme.mode = ThemeMode::Light;
-    theme.radius = px(6.);
-    theme.radius_lg = px(8.);
+    theme.radius = px(8.);
+    theme.radius_lg = px(12.);
 
     // Surfaces & text
     theme.background = c(BACKGROUND);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,0 +1,46 @@
+//! Shared visual primitives for the floating-card UI: panel cards and
+//! segmented pill tab strips. All helpers are callback-free — callers attach
+//! `.id(...)`/`.on_click(...)` themselves so the helpers stay generic.
+
+use gpui::prelude::FluentBuilder as _;
+use gpui::*;
+use gpui_component::{h_flex, Theme};
+
+/// A floating panel card: white-ish surface, hairline border, large radius,
+/// soft shadow, clipped contents. Wrap a panel's content in this.
+pub fn card_panel(theme: &Theme) -> Div {
+    div()
+        .bg(theme.background)
+        .border_1()
+        .border_color(theme.border)
+        .rounded(theme.radius_lg)
+        .shadow_sm()
+        .overflow_hidden()
+}
+
+/// The container for a segmented pill tab strip (muted rounded track).
+pub fn segmented_bar(theme: &Theme) -> Div {
+    h_flex()
+        .gap_1()
+        .p_0p5()
+        .rounded(theme.radius_lg)
+        .bg(theme.muted)
+}
+
+/// A single segment pill. Caller adds `.id(...)`, `.on_click(...)`, `.child(label)`.
+/// Active pills sit on the card surface with a soft shadow; inactive are muted.
+pub fn segment_pill(theme: &Theme, active: bool) -> Div {
+    div()
+        .px_3()
+        .py_1()
+        .rounded(theme.radius)
+        .text_sm()
+        .cursor_pointer()
+        .when(active, |d| {
+            d.bg(theme.background)
+                .text_color(theme.foreground)
+                .font_weight(FontWeight::SEMIBOLD)
+                .shadow_sm()
+        })
+        .when(!active, |d| d.text_color(theme.muted_foreground))
+}


### PR DESCRIPTION
## Summary

Two bodies of work on this branch:

**Environment variables**
- `{{variable}}` substitution engine; substitution applied at send time (before scheme-normalization)
- `Environment` / `EnvVar` models, persisted in SQLite with an active-selection
- App-level environment state + management dialog

**Figma floating-card UI redesign**
- Shared `card_panel` + segmented-pill-tab helpers (`src/ui.rs`); panels float as rounded, bordered, shadowed cards on a warm muted canvas with uniform gaps
- Environment switching moved into a title-bar **Edit menu** (✓ on active, "Manage Environments…"), grouped left of the brand; old toolbar selector removed
- Segmented pill tabs in request editor & response viewer; pill request tabs; colored status pill
- Beautified environment dialog: title+subtitle, dashed "New" button, dot-as-activation toggle, card variable table, Save footer; live-syncs when switching via the menu
- Rounder corners (`radius_lg` 12px) and clean rounded card corners (dropped redundant panel root fills that defeated gpui's rectangular overflow clip)

## Test Plan

- [x] `cargo check` passes (0 errors)
- [x] Manually verified on Windows (`cargo build --release`): floating cards with gaps, Edit menu at top-left, segmented tabs, env dialog, rounded corners, initial tab visible on launch
- [ ] Reviewer: verify env switching from the menu refreshes request variables; dialog create/edit/activate/delete persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)