### PR TITLE
refactor: code-review fixes, CSP database layer, env auto-save

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,103 +1,118 @@
-# Poopman - API Client
+# Poopman — API Client
 
-A Postman-like API client built with GPUI Component library.
+A Postman-like desktop API client built in Rust with the [GPUI](https://www.gpui.rs/)
+framework and the `gpui-component` library. Classic Postman layout: history on the
+left, request editor on the top-right, response viewer on the bottom-right.
 
 ## Features
 
-- ✅ **HTTP Requests**: Send GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS requests
-- ✅ **Request Configuration**:
-  - URL input with autocomplete
-  - HTTP method selection (GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS)
-  - Query parameters editor with bidirectional URL synchronization
-  - Headers management (predefined + custom headers)
-  - Request body editor supporting multiple formats (JSON, XML, Text, JavaScript, Form-data)
-- ✅ **Response Viewer**:
-  - Status code, duration, and size display
-  - JSON response with syntax highlighting and formatting
-  - Response headers view
-- ✅ **History**:
-  - SQLite database storage
-  - Click to reload previous requests
-  - Clear history option
-- ✅ **Postman Classic Layout**:
-  - Left panel: History list
-  - Right panel: Request editor (top) + Response viewer (bottom)
-  - Resizable panels
+- **HTTP requests** — GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS.
+- **Request editor**
+  - Method selector + URL input.
+  - **Query params** with bidirectional URL ↔ params synchronization.
+  - **Headers** — predefined (toggleable) and custom (deletable); `Content-Type`
+    and `Content-Length` are kept in sync with the body automatically.
+  - **Body** — Raw (JSON / XML / Text / JavaScript, with syntax highlighting and a
+    Beautify action) and **multipart Form-data** (text and file fields).
+- **Response viewer** — status / duration / size, pretty-printed JSON, response
+  headers, and a **binary response** path that previews type/size and saves to disk.
+- **Environments & variables** — define `{{variable}}` sets per environment, pick the
+  active one from the Edit menu, and have them resolved at send time (and in code export).
+- **Code snippet export** — turn the current request into runnable code via the `</>`
+  button: **cURL, Rust (reqwest), Python (Requests), JavaScript (Fetch), NodeJS (Axios),
+  Go (net/http)**, with Copy.
+- **Tabs** — work on multiple requests at once.
+- **History** — every sent request is stored in SQLite; click to reload, or clear all.
 
 ## Requirements
 
-- Rust 1.70+ (2021 edition)
-- GPU-capable environment (GPUI requires GPU acceleration)
-- **Note**: Not supported in WSL2 environments
+- Rust (2024 edition).
+- A GPU-capable environment — GPUI requires GPU acceleration.
+- **Not supported under WSL2** (no GPU surface). Build/test there is fine; run the app
+  on native Linux / macOS / Windows.
 
-## Running
-
-```bash
-cargo run
-```
-
-Build release version:
+## Build & Run
 
 ```bash
-cargo build --release
+cargo run                 # debug
+cargo build --release     # optimized binary at target/release/poopman[.exe]
+cargo test                # unit tests (pure modules: code_gen, variables, url_params, db, …)
 ```
 
 ## Usage
 
-1. **Make a Request**:
-   - Select HTTP method (default: GET)
-   - Enter URL (e.g., `https://api.github.com/zen`)
-   - (Optional) Configure query parameters in Params tab (automatically syncs with URL)
-   - (Optional) Add headers in Headers tab
-   - (Optional) Configure request body in Body tab (supports JSON, XML, Text, JavaScript, Form-data)
-   - Click "Send" button or press Ctrl/Cmd+Enter
-
-2. **View Response**:
-   - See status code, duration, and size in the status bar
-   - View formatted JSON response in Body tab
-   - Check response headers in Headers tab
-
-3. **History**:
-   - All requests are automatically saved
-   - Click any history item to reload it in the editor
-   - Click "Clear" to delete all history
+1. **Send a request** — pick a method, enter a URL (e.g. `https://api.github.com/zen`),
+   optionally set Params / Headers / Body, then click **Send**.
+2. **View the response** — status, time, and size in the status bar; formatted body and
+   headers in their tabs; binary payloads can be saved to a file.
+3. **Environments** — open **Edit → Manage Environments…** to create environments and
+   variables, then select the active one from the Edit menu. Reference them anywhere as
+   `{{name}}`.
+4. **Export code** — click the `</>` button next to Send, choose a language, and Copy.
+5. **History** — sent requests are saved automatically; click one to reload it, or Clear.
 
 ## Data Storage
 
-History is stored in SQLite database at:
-- Linux/macOS: `~/.poopman/history.db`
+History and environments live in a SQLite database at:
+
+- Linux / macOS: `~/.poopman/history.db`
 - Windows: `%USERPROFILE%\.poopman\history.db`
 
 ## Architecture
 
+GPUI's entity-component system with a pub/sub event model. `PoopmanApp` composes the
+panels and wires events (`RequestCompleted`, `HistoryItemClicked`, `EnvironmentsChanged`,
+`OpenCodeSnippet`, tab events) between them.
+
 ```
 src/
-├── main.rs              # Application entry point
-├── app.rs               # Main layout and component composition
-├── types.rs             # Data structures (Request, Response, etc.)
-├── db.rs                # SQLite database manager
-├── request_editor.rs    # Request editing panel
-├── response_viewer.rs   # Response display panel
-└── history_panel.rs     # History list panel
+├── main.rs                # Entry point, embedded SVG assets, logging
+├── app.rs                 # Root layout, tabs, dialogs, event wiring
+├── types.rs               # Core data types (RequestData, ResponseData, BodyType, …)
+├── db.rs                  # SQLite access — CSP style (see note below)
+├── http_client.rs         # reqwest wrapper: shared client + shared tokio runtime
+├── request_editor.rs      # Method / URL / params / headers, send logic
+├── body_editor.rs         # Request body (Raw + multipart Form-data)
+├── response_viewer.rs     # Response display (text / binary / headers)
+├── history_panel.rs       # History list
+├── environment_manager.rs # Environment CRUD dialog
+├── variables.rs           # Pure {{variable}} substitution
+├── code_gen.rs            # Pure code-snippet generation (6 targets)
+├── code_snippet_panel.rs  # Code snippet dialog (language select + Copy)
+├── tab_bar.rs             # Request tab strip
+├── request_tab.rs         # Per-tab model
+├── menu_bar.rs            # Edit menu (environment switching)
+├── url_params.rs          # Pure URL / query-param helpers
+├── code_formatter.rs      # Pure JSON / XML formatting & validation
+├── ui.rs                  # Shared visual primitives (cards, segmented pills)
+└── theme.rs               # Warm-light theme + layout dimensions
 ```
 
-## Technologies
+### Concurrency notes
 
-- **GPUI 0.2.2**: GPU-accelerated UI framework (Zed editor's UI layer)
-- **gpui-component 0.4**: UI component library providing buttons, inputs, selects, tabs, etc.
-- **rusqlite 0.32**: SQLite database with bundled feature
-- **reqwest 0.12**: HTTP client with json, multipart, and stream features
-- **tokio**: Async runtime for HTTP operations
-- **Tree Sitter**: Syntax highlighting for JSON, XML, JavaScript
+- **Database (CSP):** the SQLite `Connection` is owned by a single background thread.
+  Callers don't share it behind a `Mutex`; they send jobs over a channel and receive
+  results back over a per-call reply channel — "share memory by communicating." One
+  owner means no data races and no lock to poison.
+- **HTTP:** a single `reqwest::Client` (connection pool) is shared across requests, and
+  all requests run on one shared multi-threaded tokio runtime, bridged to GPUI's async.
+- **Pure modules** (`code_gen`, `variables`, `url_params`, `code_formatter`, parts of
+  `types`) are side-effect-free and unit-tested directly.
 
-## Future Enhancements
+## Key Technologies
 
-- [ ] Environment variables support
-- [ ] Request collections/folders
-- [ ] Authentication presets (Bearer token, Basic auth, OAuth)
-- [ ] Request/response body format options (HTML, etc.)
-- [ ] Export/import collections (Postman format)
-- [ ] Dark/Light theme toggle
-- [ ] Search/filter in history
-- [ ] Request duplication
-- [ ] Response download/save to file
+- **GPUI 0.2** — GPU-accelerated UI framework (Zed's UI layer).
+- **gpui-component 0.5** — buttons, inputs, selects, tabs, dialogs, code editor.
+- **rusqlite** — bundled SQLite.
+- **reqwest** — HTTP client (json, multipart, stream).
+- **tokio** — async runtime for HTTP.
+- **tree-sitter** — syntax highlighting (JSON, Rust, Python, Go, JavaScript, …).
+- **rust-embed** — embeds SVG icons into the binary.
+
+## Possible Future Enhancements
+
+- [ ] Form-data export in code snippets (currently Raw/None bodies only).
+- [ ] Request collections / folders.
+- [ ] Authentication presets (Bearer, Basic, OAuth).
+- [ ] Export / import collections (Postman format).
+- [ ] Search / filter in history.

--- a/src/body_editor.rs
+++ b/src/body_editor.rs
@@ -163,21 +163,23 @@ impl BodyEditor {
                 }
             }
             2 => {
-                // Form-data
-                // Update formdata_rows with current input values
-                let mut updated_formdata_rows = Vec::new();
-                for (index, row) in self.formdata_rows.iter().enumerate() {
-                    let (key_input, value_input, _type_select) = &self.formdata_input_states[index];
-                    let mut updated_row = row.clone();
-
-                    updated_row.key = key_input.read(cx).value().to_string();
-                    let value = value_input.read(cx).value().to_string();
-                    updated_row.value = match &row.value {
-                        FormDataValue::Text(_) => FormDataValue::Text(value),
-                        FormDataValue::File { .. } => FormDataValue::File { path: value },
-                    };
-                    updated_formdata_rows.push(updated_row);
-                }
+                // Form-data: read current input values. Zip rows with their input
+                // states so a length mismatch can never panic (it just stops early).
+                let updated_formdata_rows = self
+                    .formdata_rows
+                    .iter()
+                    .zip(self.formdata_input_states.iter())
+                    .map(|(row, (key_input, value_input, _type_select))| {
+                        let mut updated_row = row.clone();
+                        updated_row.key = key_input.read(cx).value().to_string();
+                        let value = value_input.read(cx).value().to_string();
+                        updated_row.value = match &row.value {
+                            FormDataValue::Text(_) => FormDataValue::Text(value),
+                            FormDataValue::File { .. } => FormDataValue::File { path: value },
+                        };
+                        updated_row
+                    })
+                    .collect();
                 BodyType::FormData(updated_formdata_rows)
             }
             _ => BodyType::None,
@@ -251,9 +253,11 @@ impl BodyEditor {
                         cx.subscribe(&value_input, Self::handle_input_event)
                     );
 
-                    // Subscribe to type selector changes
+                    // Subscribe to type selector changes (subscribe_in for `window`,
+                    // so the value field's placeholder updates on Text <-> File).
+                    let value_input_for_type = value_input.clone();
                     self._subscriptions.push(
-                        cx.subscribe(&type_select, move |this, _entity, event: &SelectEvent<Vec<&'static str>>, cx| {
+                        cx.subscribe_in(&type_select, window, move |this, _entity, event: &SelectEvent<Vec<&'static str>>, window, cx| {
                             if let SelectEvent::Confirm(Some(selected_value)) = event {
                                 let should_be_file = *selected_value == "File";
                                 let current_is_file = matches!(
@@ -261,14 +265,19 @@ impl BodyEditor {
                                     Some(FormDataValue::File { .. })
                                 );
                                 if should_be_file != current_is_file {
-                                    // We need window here but subscribe doesn't provide it
-                                    // So we'll just update the data model, the UI will react
                                     if let Some(row) = this.formdata_rows.get_mut(row_index) {
                                         row.value = match &row.value {
                                             FormDataValue::Text(text) => FormDataValue::File { path: text.clone() },
                                             FormDataValue::File { path } => FormDataValue::Text(path.clone()),
                                         };
                                     }
+                                    value_input_for_type.update(cx, |input, cx| {
+                                        input.set_placeholder(
+                                            if should_be_file { "File Path" } else { "Value" },
+                                            window,
+                                            cx,
+                                        );
+                                    });
                                     cx.notify();
                                 }
                             }
@@ -391,9 +400,11 @@ impl BodyEditor {
         self._subscriptions
             .push(cx.subscribe(&value_input, Self::handle_input_event));
 
-        // Subscribe to type selector changes
+        // Subscribe to type selector changes (subscribe_in so we have `window` to
+        // refresh the value field's placeholder when toggling Text <-> File).
+        let value_input_for_type = value_input.clone();
         self._subscriptions.push(
-            cx.subscribe(&type_select, move |this, _entity, event: &SelectEvent<Vec<&'static str>>, cx| {
+            cx.subscribe_in(&type_select, window, move |this, _entity, event: &SelectEvent<Vec<&'static str>>, window, cx| {
                 if let SelectEvent::Confirm(Some(selected_value)) = event {
                     let should_be_file = *selected_value == "File";
                     let current_is_file = matches!(
@@ -408,6 +419,13 @@ impl BodyEditor {
                                 FormDataValue::File { path } => FormDataValue::Text(path.clone()),
                             };
                         }
+                        value_input_for_type.update(cx, |input, cx| {
+                            input.set_placeholder(
+                                if should_be_file { "File Path" } else { "Value" },
+                                window,
+                                cx,
+                            );
+                        });
                         cx.notify();
                     }
                 }
@@ -431,25 +449,6 @@ impl BodyEditor {
     fn toggle_formdata_row(&mut self, index: usize, cx: &mut Context<Self>) {
         if let Some(row) = self.formdata_rows.get_mut(index) {
             row.enabled = !row.enabled;
-            cx.notify();
-        }
-    }
-
-    fn toggle_formdata_type(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
-        if let Some(row) = self.formdata_rows.get_mut(index) {
-            row.value = match &row.value {
-                FormDataValue::Text(text) => FormDataValue::File { path: text.clone() },
-                FormDataValue::File { path } => FormDataValue::Text(path.clone()),
-            };
-            let (_, value_input, _type_select) = &self.formdata_input_states[index];
-            let is_file = matches!(row.value, FormDataValue::File { .. });
-            value_input.update(cx, |input, cx| {
-                input.set_placeholder(
-                    if is_file { "File Path" } else { "Value" },
-                    window,
-                    cx,
-                );
-            });
             cx.notify();
         }
     }
@@ -515,7 +514,7 @@ impl BodyEditor {
             cx.spawn_in(window, async move |_, window| {
                 if let Ok(Ok(Some(paths))) = path.await {
                     if let Some(selected_path) = paths.iter().next() {
-                        // Store full path but display only filename
+                        // Store and display the full path (used directly when sending).
                         let path_str = selected_path.to_string_lossy().to_string();
                         let _ = window.update(|window, cx| {
                             value_input.update(cx, |input, cx| {

--- a/src/code_snippet_panel.rs
+++ b/src/code_snippet_panel.rs
@@ -3,6 +3,9 @@
 //! action. Owned by `PoopmanApp` and shown inside a dialog opened from the
 //! request editor's `</>` button.
 
+use std::time::Duration;
+
+use gpui::prelude::FluentBuilder as _;
 use gpui::*;
 use gpui_component::{
     button::*, input::*, select::*, h_flex, v_flex, ActiveTheme as _, IndexPath, Sizable as _,
@@ -21,6 +24,8 @@ pub struct CodeSnippetPanel {
     code: String,
     language_select: Entity<SelectState<Vec<&'static str>>>,
     code_display: Entity<InputState>,
+    /// True briefly after a Copy click, to show "Copied ✓" feedback.
+    copied: bool,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -54,6 +59,7 @@ impl CodeSnippetPanel {
             code: String::new(),
             language_select,
             code_display,
+            copied: false,
             _subscriptions: vec![sub],
         }
     }
@@ -83,12 +89,26 @@ impl CodeSnippetPanel {
             None => String::new(),
         };
         self.code = code.clone();
+        self.copied = false; // new code => clear any stale "Copied" state
         self.code_display.update(cx, |input, cx| input.set_value(&code, window, cx));
         cx.notify();
     }
 
-    fn copy(&mut self, _e: &gpui::ClickEvent, _window: &mut Window, cx: &mut Context<Self>) {
+    fn copy(&mut self, _e: &gpui::ClickEvent, window: &mut Window, cx: &mut Context<Self>) {
         cx.write_to_clipboard(ClipboardItem::new_string(self.code.clone()));
+        self.copied = true;
+        cx.notify();
+        // Revert the "Copied ✓" label after a short delay.
+        cx.spawn_in(window, async move |this, cx| {
+            cx.background_executor()
+                .timer(Duration::from_millis(1500))
+                .await;
+            let _ = this.update(cx, |this, cx| {
+                this.copied = false;
+                cx.notify();
+            });
+        })
+        .detach();
     }
 }
 
@@ -110,7 +130,8 @@ impl Render for CodeSnippetPanel {
                     .child(
                         Button::new("code-copy")
                             .small()
-                            .label("Copy")
+                            .when(self.copied, |b| b.success())
+                            .label(if self.copied { "Copied ✓" } else { "Copy" })
                             .on_click(cx.listener(Self::copy)),
                     ),
             )

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,17 +1,31 @@
-use anyhow::Result;
+//! Database access for Poopman, implemented CSP-style.
+//!
+//! The SQLite `Connection` is **owned by a single background thread**. Callers
+//! never touch it directly and there is no `Mutex`; instead each operation is
+//! sent to that thread as a job over a channel, and the result comes back over a
+//! per-call reply channel. This is the "share memory by communicating" model —
+//! the connection has exactly one owner, so data races are impossible by
+//! construction and a panic inside one query can't poison a lock for the others.
+
+use anyhow::{anyhow, Result};
 use rusqlite::{params, Connection, OptionalExtension};
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::mpsc::{self, Sender};
+use std::thread;
 
 use crate::types::{Environment, EnvVar, HistoryItem, HttpMethod, RequestData};
 
-/// Database manager for Poopman
+/// A unit of work executed on the database's owning thread.
+type Job = Box<dyn FnOnce(&mut Connection) + Send>;
+
+/// Handle to the database thread. Cloneable senders make this cheap to share
+/// (wrapped in `Arc` by the app); dropping every handle stops the thread.
 pub struct Database {
-    conn: Arc<Mutex<Connection>>,
+    tx: Sender<Job>,
 }
 
 impl Database {
-    /// Create a new database connection
+    /// Open (or create) the on-disk database and start its owning thread.
     pub fn new() -> Result<Self> {
         let db_path = Self::get_db_path()?;
 
@@ -21,69 +35,82 @@ impl Database {
         }
 
         let conn = Connection::open(&db_path)?;
+        Self::init_schema(&conn)?;
+        Ok(Self::spawn(conn))
+    }
 
-        // Foreign keys are off per-connection by default in SQLite.
-        conn.execute_batch("PRAGMA foreign_keys = ON;")?;
+    /// Move an initialized connection onto its owning thread and return a handle.
+    fn spawn(mut conn: Connection) -> Self {
+        let (tx, rx) = mpsc::channel::<Job>();
+        thread::spawn(move || {
+            // Run jobs until every handle (and thus every Sender) is dropped, at
+            // which point recv() errors and the thread exits cleanly.
+            while let Ok(job) = rx.recv() {
+                job(&mut conn);
+            }
+        });
+        Self { tx }
+    }
 
-        // Initialize schema
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS history (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                timestamp TEXT NOT NULL,
-                method TEXT NOT NULL,
-                url TEXT NOT NULL,
-                request_headers TEXT,
-                request_body TEXT,
-                status_code INTEGER,
-                duration_ms INTEGER,
-                response_headers TEXT,
-                response_body TEXT
-            )",
-            [],
+    /// Send `f` to the owning thread and block until it returns a result.
+    fn call<T, F>(&self, f: F) -> Result<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(&mut Connection) -> Result<T> + Send + 'static,
+    {
+        let (reply_tx, reply_rx) = mpsc::channel();
+        self.tx
+            .send(Box::new(move |conn| {
+                let _ = reply_tx.send(f(conn));
+            }))
+            .map_err(|_| anyhow!("database thread is not running"))?;
+        reply_rx
+            .recv()
+            .map_err(|_| anyhow!("database thread dropped the response"))?
+    }
+
+    /// Create all tables + indexes if missing. Shared by the real DB and tests
+    /// so the two schemas can never drift.
+    fn init_schema(conn: &Connection) -> Result<()> {
+        conn.execute_batch(
+            "PRAGMA foreign_keys = ON;
+             CREATE TABLE IF NOT EXISTS history (
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 timestamp TEXT NOT NULL,
+                 method TEXT NOT NULL,
+                 url TEXT NOT NULL,
+                 request_headers TEXT,
+                 request_body TEXT,
+                 status_code INTEGER,
+                 duration_ms INTEGER,
+                 response_headers TEXT,
+                 response_body TEXT
+             );
+             CREATE INDEX IF NOT EXISTS idx_timestamp ON history(timestamp DESC);
+             CREATE TABLE IF NOT EXISTS environments (
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 name TEXT NOT NULL,
+                 position INTEGER NOT NULL DEFAULT 0
+             );
+             CREATE TABLE IF NOT EXISTS env_variables (
+                 id INTEGER PRIMARY KEY AUTOINCREMENT,
+                 environment_id INTEGER NOT NULL REFERENCES environments(id) ON DELETE CASCADE,
+                 enabled INTEGER NOT NULL DEFAULT 1,
+                 key TEXT NOT NULL,
+                 value TEXT NOT NULL,
+                 position INTEGER NOT NULL DEFAULT 0
+             );
+             CREATE TABLE IF NOT EXISTS app_meta (
+                 key TEXT PRIMARY KEY,
+                 value TEXT NOT NULL
+             );",
         )?;
-
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_timestamp ON history(timestamp DESC)",
-            [],
-        )?;
-
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS environments (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                name TEXT NOT NULL,
-                position INTEGER NOT NULL DEFAULT 0
-            )",
-            [],
-        )?;
-
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS env_variables (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                environment_id INTEGER NOT NULL REFERENCES environments(id) ON DELETE CASCADE,
-                enabled INTEGER NOT NULL DEFAULT 1,
-                key TEXT NOT NULL,
-                value TEXT NOT NULL,
-                position INTEGER NOT NULL DEFAULT 0
-            )",
-            [],
-        )?;
-
-        conn.execute(
-            "CREATE TABLE IF NOT EXISTS app_meta (
-                key TEXT PRIMARY KEY,
-                value TEXT NOT NULL
-            )",
-            [],
-        )?;
-
-        Ok(Self {
-            conn: Arc::new(Mutex::new(conn)),
-        })
+        Ok(())
     }
 
     /// Get the database file path
     fn get_db_path() -> Result<PathBuf> {
-        let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Cannot find home directory"))?;
+        let home = dirs::home_dir().ok_or_else(|| anyhow!("Cannot find home directory"))?;
         Ok(home.join(".poopman").join("history.db"))
     }
 
@@ -95,200 +122,206 @@ impl Database {
         request_headers: &str,
         request_body: &crate::types::BodyType,
     ) -> Result<i64> {
-        let conn = self.conn.lock().unwrap();
-
-        let timestamp = chrono::Utc::now().to_rfc3339();
-
-        // Serialize body type to JSON
+        let method = method.to_string();
+        let url = url.to_string();
+        let request_headers = request_headers.to_string();
+        // Serialize body type to JSON before crossing the channel.
         let body_json = serde_json::to_string(request_body).unwrap_or_default();
 
-        conn.execute(
-            "INSERT INTO history (timestamp, method, url, request_headers, request_body)
-             VALUES (?1, ?2, ?3, ?4, ?5)",
-            params![
-                timestamp,
-                method,
-                url,
-                request_headers,
-                body_json,
-            ],
-        )?;
-
-        Ok(conn.last_insert_rowid())
+        self.call(move |conn| {
+            let timestamp = chrono::Utc::now().to_rfc3339();
+            conn.execute(
+                "INSERT INTO history (timestamp, method, url, request_headers, request_body)
+                 VALUES (?1, ?2, ?3, ?4, ?5)",
+                params![timestamp, method, url, request_headers, body_json],
+            )?;
+            Ok(conn.last_insert_rowid())
+        })
     }
 
     /// Load recent history items (request only, no response - aligned with Postman)
     pub fn load_recent_history(&self, limit: usize) -> Result<Vec<HistoryItem>> {
-        let conn = self.conn.lock().unwrap();
+        self.call(move |conn| {
+            let mut stmt = conn.prepare(
+                "SELECT id, timestamp, method, url, request_headers, request_body
+                 FROM history
+                 ORDER BY timestamp DESC
+                 LIMIT ?1",
+            )?;
 
-        let mut stmt = conn.prepare(
-            "SELECT id, timestamp, method, url, request_headers, request_body
-             FROM history
-             ORDER BY timestamp DESC
-             LIMIT ?1",
-        )?;
+            // rusqlite 0.40 dropped the `ToSql` impl for `usize`; bind as i64.
+            let items = stmt.query_map([limit as i64], |row| {
+                let id: i64 = row.get(0)?;
+                let timestamp: String = row.get(1)?;
+                let method: String = row.get(2)?;
+                let url: String = row.get(3)?;
+                let request_headers: String = row.get(4)?;
+                let request_body: String = row.get(5)?;
 
-        // rusqlite 0.40 dropped the `ToSql` impl for `usize`; bind as i64.
-        let items = stmt.query_map([limit as i64], |row| {
-            let id: i64 = row.get(0)?;
-            let timestamp: String = row.get(1)?;
-            let method: String = row.get(2)?;
-            let url: String = row.get(3)?;
-            let request_headers: String = row.get(4)?;
-            let request_body: String = row.get(5)?;
+                let headers: Vec<(String, String)> =
+                    serde_json::from_str(&request_headers).unwrap_or_default();
 
-            let headers: Vec<(String, String)> =
-                serde_json::from_str(&request_headers).unwrap_or_default();
+                // Deserialize body type from JSON, fallback to default if fails
+                let body: crate::types::BodyType =
+                    serde_json::from_str(&request_body).unwrap_or_default();
 
-            // Deserialize body type from JSON, fallback to default if fails
-            let body: crate::types::BodyType =
-                serde_json::from_str(&request_body).unwrap_or_default();
+                let request = RequestData {
+                    method: HttpMethod::from_str(&method).unwrap_or(HttpMethod::GET),
+                    url,
+                    headers,
+                    body,
+                };
 
-            let request = RequestData {
-                method: HttpMethod::from_str(&method).unwrap_or(HttpMethod::GET),
-                url,
-                headers,
-                body,
-            };
+                Ok(HistoryItem::new(id, timestamp, request, None))
+            })?;
 
-            Ok(HistoryItem::new(id, timestamp, request, None))
-        })?;
-
-        let mut result = Vec::new();
-        for item in items {
-            result.push(item?);
-        }
-
-        Ok(result)
+            let mut result = Vec::new();
+            for item in items {
+                result.push(item?);
+            }
+            Ok(result)
+        })
     }
 
     /// Delete a history item by ID
     #[allow(dead_code)]
     pub fn delete_history(&self, id: i64) -> Result<()> {
-        let conn = self.conn.lock().unwrap();
-        conn.execute("DELETE FROM history WHERE id = ?1", params![id])?;
-        Ok(())
+        self.call(move |conn| {
+            conn.execute("DELETE FROM history WHERE id = ?1", params![id])?;
+            Ok(())
+        })
     }
 
     /// Clear all history
     pub fn clear_all_history(&self) -> Result<()> {
-        let conn = self.conn.lock().unwrap();
-        conn.execute("DELETE FROM history", [])?;
-        Ok(())
+        self.call(|conn| {
+            conn.execute("DELETE FROM history", [])?;
+            Ok(())
+        })
     }
 
     /// Get total history count
     #[allow(dead_code)]
     pub fn get_history_count(&self) -> Result<usize> {
-        let conn = self.conn.lock().unwrap();
-        let count: i64 = conn.query_row("SELECT COUNT(*) FROM history", [], |row| row.get(0))?;
-        Ok(count as usize)
+        self.call(|conn| {
+            let count: i64 = conn.query_row("SELECT COUNT(*) FROM history", [], |row| row.get(0))?;
+            Ok(count as usize)
+        })
     }
 
     // ===== Environments =====
 
     /// Load all environments (with their variables), ordered by position.
     pub fn load_environments(&self) -> Result<Vec<Environment>> {
-        let conn = self.conn.lock().unwrap();
-
-        let mut stmt =
-            conn.prepare("SELECT id, name FROM environments ORDER BY position, id")?;
-        let env_rows: Vec<(i64, String)> = stmt
-            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
-            .collect::<rusqlite::Result<Vec<_>>>()?;
-        drop(stmt);
-
-        let mut result = Vec::with_capacity(env_rows.len());
-        for (id, name) in env_rows {
-            let mut vstmt = conn.prepare(
-                "SELECT enabled, key, value FROM env_variables
-                 WHERE environment_id = ?1 ORDER BY position, id",
-            )?;
-            let variables = vstmt
-                .query_map([id], |row| {
-                    Ok(EnvVar {
-                        enabled: row.get::<_, i64>(0)? != 0,
-                        key: row.get(1)?,
-                        value: row.get(2)?,
-                    })
-                })?
+        self.call(|conn| {
+            let mut stmt =
+                conn.prepare("SELECT id, name FROM environments ORDER BY position, id")?;
+            let env_rows: Vec<(i64, String)> = stmt
+                .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
                 .collect::<rusqlite::Result<Vec<_>>>()?;
-            result.push(Environment { id, name, variables });
-        }
-        Ok(result)
+            drop(stmt);
+
+            let mut result = Vec::with_capacity(env_rows.len());
+            for (id, name) in env_rows {
+                let mut vstmt = conn.prepare(
+                    "SELECT enabled, key, value FROM env_variables
+                     WHERE environment_id = ?1 ORDER BY position, id",
+                )?;
+                let variables = vstmt
+                    .query_map([id], |row| {
+                        Ok(EnvVar {
+                            enabled: row.get::<_, i64>(0)? != 0,
+                            key: row.get(1)?,
+                            value: row.get(2)?,
+                        })
+                    })?
+                    .collect::<rusqlite::Result<Vec<_>>>()?;
+                result.push(Environment { id, name, variables });
+            }
+            Ok(result)
+        })
     }
 
     /// Create a new (empty) environment, returning its id.
     pub fn create_environment(&self, name: &str) -> Result<i64> {
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "INSERT INTO environments (name, position)
-             VALUES (?1, (SELECT COALESCE(MAX(position), 0) + 1 FROM environments))",
-            params![name],
-        )?;
-        Ok(conn.last_insert_rowid())
+        let name = name.to_string();
+        self.call(move |conn| {
+            conn.execute(
+                "INSERT INTO environments (name, position)
+                 VALUES (?1, (SELECT COALESCE(MAX(position), 0) + 1 FROM environments))",
+                params![name],
+            )?;
+            Ok(conn.last_insert_rowid())
+        })
     }
 
     pub fn rename_environment(&self, id: i64, name: &str) -> Result<()> {
-        let conn = self.conn.lock().unwrap();
-        conn.execute("UPDATE environments SET name = ?1 WHERE id = ?2", params![name, id])?;
-        Ok(())
+        let name = name.to_string();
+        self.call(move |conn| {
+            conn.execute("UPDATE environments SET name = ?1 WHERE id = ?2", params![name, id])?;
+            Ok(())
+        })
     }
 
     pub fn delete_environment(&self, id: i64) -> Result<()> {
-        let conn = self.conn.lock().unwrap();
-        // env_variables rows are removed by ON DELETE CASCADE (foreign_keys = ON).
-        conn.execute("DELETE FROM environments WHERE id = ?1", params![id])?;
-        Ok(())
+        self.call(move |conn| {
+            // env_variables rows are removed by ON DELETE CASCADE (foreign_keys = ON).
+            conn.execute("DELETE FROM environments WHERE id = ?1", params![id])?;
+            Ok(())
+        })
     }
 
     /// Replace all variables of an environment in a single transaction.
     pub fn replace_variables(&self, environment_id: i64, vars: &[EnvVar]) -> Result<()> {
-        let mut conn = self.conn.lock().unwrap();
-        let tx = conn.transaction()?;
-        tx.execute(
-            "DELETE FROM env_variables WHERE environment_id = ?1",
-            params![environment_id],
-        )?;
-        for (position, v) in vars.iter().enumerate() {
+        let vars = vars.to_vec();
+        self.call(move |conn| {
+            let tx = conn.transaction()?;
             tx.execute(
-                "INSERT INTO env_variables (environment_id, enabled, key, value, position)
-                 VALUES (?1, ?2, ?3, ?4, ?5)",
-                params![environment_id, v.enabled as i64, v.key, v.value, position as i64],
+                "DELETE FROM env_variables WHERE environment_id = ?1",
+                params![environment_id],
             )?;
-        }
-        tx.commit()?;
-        Ok(())
+            for (position, v) in vars.iter().enumerate() {
+                tx.execute(
+                    "INSERT INTO env_variables (environment_id, enabled, key, value, position)
+                     VALUES (?1, ?2, ?3, ?4, ?5)",
+                    params![environment_id, v.enabled as i64, v.key, v.value, position as i64],
+                )?;
+            }
+            tx.commit()?;
+            Ok(())
+        })
     }
 
     /// Active environment id, or None for "No Environment".
     pub fn get_active_environment_id(&self) -> Result<Option<i64>> {
-        let conn = self.conn.lock().unwrap();
-        let value: Option<String> = conn
-            .query_row(
-                "SELECT value FROM app_meta WHERE key = 'active_environment_id'",
-                [],
-                |row| row.get(0),
-            )
-            .optional()?;
-        Ok(value.and_then(|s| s.parse::<i64>().ok()))
+        self.call(|conn| {
+            let value: Option<String> = conn
+                .query_row(
+                    "SELECT value FROM app_meta WHERE key = 'active_environment_id'",
+                    [],
+                    |row| row.get(0),
+                )
+                .optional()?;
+            Ok(value.and_then(|s| s.parse::<i64>().ok()))
+        })
     }
 
     pub fn set_active_environment_id(&self, id: Option<i64>) -> Result<()> {
-        let conn = self.conn.lock().unwrap();
-        match id {
-            Some(id) => {
-                conn.execute(
-                    "INSERT INTO app_meta (key, value) VALUES ('active_environment_id', ?1)
-                     ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-                    params![id.to_string()],
-                )?;
+        self.call(move |conn| {
+            match id {
+                Some(id) => {
+                    conn.execute(
+                        "INSERT INTO app_meta (key, value) VALUES ('active_environment_id', ?1)
+                         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                        params![id.to_string()],
+                    )?;
+                }
+                None => {
+                    conn.execute("DELETE FROM app_meta WHERE key = 'active_environment_id'", [])?;
+                }
             }
-            None => {
-                conn.execute("DELETE FROM app_meta WHERE key = 'active_environment_id'", [])?;
-            }
-        }
-        Ok(())
+            Ok(())
+        })
     }
 }
 
@@ -298,20 +331,8 @@ mod tests {
 
     fn mem_db() -> Database {
         let conn = Connection::open_in_memory().unwrap();
-        conn.execute_batch("PRAGMA foreign_keys = ON;").unwrap();
-        conn.execute(
-            "CREATE TABLE environments (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, position INTEGER NOT NULL DEFAULT 0)",
-            [],
-        ).unwrap();
-        conn.execute(
-            "CREATE TABLE env_variables (id INTEGER PRIMARY KEY AUTOINCREMENT, environment_id INTEGER NOT NULL REFERENCES environments(id) ON DELETE CASCADE, enabled INTEGER NOT NULL DEFAULT 1, key TEXT NOT NULL, value TEXT NOT NULL, position INTEGER NOT NULL DEFAULT 0)",
-            [],
-        ).unwrap();
-        conn.execute(
-            "CREATE TABLE app_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
-            [],
-        ).unwrap();
-        Database { conn: Arc::new(Mutex::new(conn)) }
+        Database::init_schema(&conn).unwrap();
+        Database::spawn(conn)
     }
 
     #[test]
@@ -345,5 +366,17 @@ mod tests {
 
         db.delete_environment(id).unwrap();
         assert!(db.load_environments().unwrap().is_empty());
+    }
+
+    #[test]
+    fn history_roundtrip() {
+        let db = mem_db();
+        db.insert_history("GET", "https://api.test/x", "[]", &crate::types::BodyType::None)
+            .unwrap();
+        let items = db.load_recent_history(10).unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].request.url, "https://api.test/x");
+        db.clear_all_history().unwrap();
+        assert!(db.load_recent_history(10).unwrap().is_empty());
     }
 }

--- a/src/environment_manager.rs
+++ b/src/environment_manager.rs
@@ -104,8 +104,10 @@ impl EnvironmentManager {
     }
 
     fn select(&mut self, id: i64, window: &mut Window, cx: &mut Context<Self>) {
-        // Persist current edits before switching away.
+        // Persist current edits before switching away, then reload so the list
+        // reflects a just-saved rename (otherwise the old name lingers).
         self.save(cx);
+        self.reload();
         self.selected_id = Some(id);
         self.load_selected_into_editor(window, cx);
         cx.notify();

--- a/src/environment_manager.rs
+++ b/src/environment_manager.rs
@@ -8,6 +8,7 @@ use gpui::*;
 use gpui_component::{
     button::*, checkbox::Checkbox, h_flex, input::*, v_flex, ActiveTheme as _, Sizable as _,
 };
+use gpui_component::input::InputEvent;
 use std::sync::Arc;
 
 use crate::db::Database;
@@ -30,6 +31,11 @@ pub struct EnvironmentManager {
     selected_id: Option<i64>,
     name_input: Entity<InputState>,
     var_rows: Vec<VarRow>,
+    /// True while programmatically loading inputs, so their `Change` events don't
+    /// trigger an auto-save of values we just set.
+    suspend_autosave: bool,
+    /// Live input-change subscriptions (name + each var row), rewired on load.
+    _subs: Vec<Subscription>,
 }
 
 impl EventEmitter<EnvironmentsChanged> for EnvironmentManager {}
@@ -48,9 +54,37 @@ impl EnvironmentManager {
             selected_id,
             name_input,
             var_rows: vec![],
+            suspend_autosave: false,
+            _subs: vec![],
         };
         this.load_selected_into_editor(window, cx);
         this
+    }
+
+    /// (Re)subscribe to the name + variable inputs so any edit auto-saves.
+    fn wire_inputs(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let name = self.name_input.clone();
+        let inputs: Vec<Entity<InputState>> = self
+            .var_rows
+            .iter()
+            .flat_map(|r| [r.key_input.clone(), r.value_input.clone()])
+            .collect();
+
+        let mut subs = Vec::with_capacity(inputs.len() + 1);
+        subs.push(cx.subscribe_in(&name, window, |this, _, ev: &InputEvent, _w, cx| {
+            if matches!(ev, InputEvent::Change) && !this.suspend_autosave {
+                this.commit(cx);
+            }
+        }));
+        for input in &inputs {
+            subs.push(cx.subscribe_in(input, window, |this, _, ev: &InputEvent, _w, cx| {
+                if matches!(ev, InputEvent::Change) && !this.suspend_autosave {
+                    this.commit(cx);
+                }
+            }));
+        }
+        // Assigning drops the previous subscriptions (unsubscribing stale inputs).
+        self._subs = subs;
     }
 
     pub(crate) fn reload(&mut self) {
@@ -65,6 +99,10 @@ impl EnvironmentManager {
             .and_then(|id| self.environments.iter().find(|e| e.id == id))
             .cloned();
 
+        // Programmatic set_value below would otherwise auto-save the values we're
+        // loading; suspend autosave for the duration.
+        self.suspend_autosave = true;
+
         let name = selected.as_ref().map(|e| e.name.clone()).unwrap_or_default();
         self.name_input.update(cx, |input, cx| {
             input.set_value(&name, window, cx);
@@ -76,6 +114,9 @@ impl EnvironmentManager {
                 self.var_rows.push(self.make_var_row(v.enabled, &v.key, &v.value, window, cx));
             }
         }
+
+        self.wire_inputs(window, cx);
+        self.suspend_autosave = false;
     }
 
     fn make_var_row(
@@ -104,9 +145,7 @@ impl EnvironmentManager {
     }
 
     fn select(&mut self, id: i64, window: &mut Window, cx: &mut Context<Self>) {
-        // Persist current edits before switching away, then reload so the list
-        // reflects a just-saved rename (otherwise the old name lingers).
-        self.save(cx);
+        // Edits auto-save as they happen, so switching just reloads + reselects.
         self.reload();
         self.selected_id = Some(id);
         self.load_selected_into_editor(window, cx);
@@ -114,7 +153,6 @@ impl EnvironmentManager {
     }
 
     fn add_environment(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        self.save(cx);
         match self.db.create_environment("New Environment") {
             Ok(id) => {
                 self.reload();
@@ -173,7 +211,10 @@ impl EnvironmentManager {
         let _ = self.db.replace_variables(id, &vars);
     }
 
-    fn save_and_notify(&mut self, cx: &mut Context<Self>) {
+    /// Persist the selected environment + reload + broadcast so the rest of the
+    /// app (request editor's `{{var}}` map, the list) reflects the change. This is
+    /// the single auto-save entry point.
+    fn commit(&mut self, cx: &mut Context<Self>) {
         self.save(cx);
         self.reload();
         cx.emit(EnvironmentsChanged);
@@ -183,20 +224,23 @@ impl EnvironmentManager {
     fn add_var_row(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let row = self.make_var_row(true, "", "", window, cx);
         self.var_rows.push(row);
+        // The new row is empty (not yet persisted), but its inputs need change
+        // subscriptions so typing into them auto-saves.
+        self.wire_inputs(window, cx);
         cx.notify();
     }
 
     fn remove_var_row(&mut self, index: usize, cx: &mut Context<Self>) {
         if index < self.var_rows.len() {
             self.var_rows.remove(index);
-            cx.notify();
+            self.commit(cx);
         }
     }
 
     fn toggle_var(&mut self, index: usize, cx: &mut Context<Self>) {
         if let Some(row) = self.var_rows.get_mut(index) {
             row.enabled = !row.enabled;
-            cx.notify();
+            self.commit(cx);
         }
     }
 }
@@ -438,24 +482,6 @@ impl Render for EnvironmentManager {
                             .on_click(cx.listener(|this, _, window, cx| {
                                 this.add_var_row(window, cx);
                             })),
-                    )
-                    .child(
-                        // Footer: only a right-aligned Save (no hint text).
-                        h_flex()
-                            .w_full()
-                            .justify_end()
-                            .pt_2()
-                            .border_t_1()
-                            .border_color(theme.border)
-                            .child(
-                                Button::new("env-save")
-                                    .small()
-                                    .primary()
-                                    .label("Save")
-                                    .on_click(cx.listener(|this, _, _window, cx| {
-                                        this.save_and_notify(cx);
-                                    })),
-                            ),
                     )
                     .into_any_element()
             } else {

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -5,6 +5,10 @@ use tokio::runtime::Runtime;
 use crate::types::{BodyType, FormDataValue, HttpMethod};
 
 static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+/// Shared reqwest client. A `Client` owns the connection pool and is internally
+/// reference-counted, so one instance is reused across all requests (keep-alive
+/// / pooling / TLS setup are amortized) and cloning is cheap.
+static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
 
 /// A fully-read HTTP response. The body is collected on the tokio runtime
 /// (reqwest's body stream requires its reactor), so callers can use it freely.
@@ -22,9 +26,13 @@ pub struct HttpClient {
 
 impl HttpClient {
     pub fn new() -> Self {
-        let client = reqwest::Client::builder()
-            .build()
-            .expect("Failed to initialize HTTP client");
+        let client = CLIENT
+            .get_or_init(|| {
+                reqwest::Client::builder()
+                    .build()
+                    .expect("Failed to initialize HTTP client")
+            })
+            .clone();
 
         Self { client }
     }

--- a/src/request_tab.rs
+++ b/src/request_tab.rs
@@ -47,19 +47,6 @@ impl RequestTab {
         }
     }
 
-    /// Create a request tab from request data
-    pub fn from_request(id: usize, request: RequestData) -> Self {
-        Self {
-            id,
-            title: Self::generate_title(&request),
-            request,
-            response: None,
-            params_state: None,
-            headers_state: None,
-            history_id: None,
-        }
-    }
-
     /// Generate a display title from request data
     fn generate_title(request: &RequestData) -> String {
         if request.url.is_empty() {


### PR DESCRIPTION
## Summary

Follow-up to the full-repo code review. Addresses the findings, refactors the database layer to a CSP design, adds Copy feedback, and switches the environment editor to auto-save.

## Changes

**Database — CSP ("share memory by communicating")**
- The SQLite `Connection` is now owned by a single background thread; callers send jobs over a channel and get results back over a per-call reply channel. Removes `Arc<Mutex<Connection>>` and lock-poisoning.
- Shared `Database::init_schema()` so the test and production schemas can't drift.

**Performance**
- Reuse one shared `reqwest::Client` (connection pool) instead of building one per request.

**Environment editor — auto-save**
- Removed the explicit Save button. Editing name/variables, toggling, or adding/removing a row writes to the DB and broadcasts `EnvironmentsChanged` immediately (live `{{var}}` refresh). Closing the dialog can no longer lose edits. A suspend flag prevents programmatic `set_value` (during load) from triggering spurious saves.

**Code snippet**
- Copy now shows `Copied ✓` feedback for ~1.5s (was silent).

**Review fixes**
- `body_editor::get_body` zips rows with input states (no index panic); Text↔File switch refreshes the value placeholder; removed dead `toggle_formdata_type`.
- Removed dead `RequestTab::from_request`.
- Fixed a stale file-path comment.

**Docs**
- Rewrote `README.md` (environments, code export, tabs, binary responses, edition 2024, concurrency model).

## Test Plan

- [x] `cargo test` — 67 passing (incl. new DB CSP + history round-trip tests).
- [x] `cargo build --release` clean (only pre-existing style lints remain).
- [x] Manual (Windows): requests still work; environment edits persist live and survive closing the dialog; Copy shows feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)