### PR TITLE
feat(history): search history by URL + method

### DIFF
--- a/assets/icons/search.svg
+++ b/assets/icons/search.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>

--- a/docs/superpowers/plans/2026-06-26-history-search.md
+++ b/docs/superpowers/plans/2026-06-26-history-search.md
@@ -1,0 +1,378 @@
+# History Search Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an always-visible search box to the History panel that filters stored requests by URL or HTTP method across the entire history.
+
+**Architecture:** A new `Database::search_history` runs a `LIKE` over `url` and `method` for all rows (newest first); the `HistoryPanel` gains a gpui-component `Input`, and on every keystroke re-queries the DB (recent when empty, search when not) and re-renders. The row→`HistoryItem` mapping is extracted into one shared helper so the two queries can't drift.
+
+**Tech Stack:** Rust, rusqlite 0.40 (SQLite), GPUI 0.2.2, gpui-component 0.4.
+
+---
+
+## File Structure
+
+- `src/db.rs` — add `search_history`, extract `row_to_history_item` helper + `escape_like`; add tests. (CSP DB thread; tests run headless, no GPU.)
+- `src/history_panel.rs` — add search `InputState`, query state, subscription, `refresh_list` helper, search-row UI, query-aware empty state.
+- `assets/icons/search.svg` — new magnifier icon for the input prefix (embedded via rust-embed like the existing `code.svg`).
+
+`src/app.rs` is **not** touched: it calls `HistoryPanel::reload(window, cx)`, whose signature is unchanged.
+
+> **WSL2 note:** the GPUI app cannot run here (no GPU). DB tests run normally with `cargo test`. For UI changes, verify with `cargo check`/`cargo build`; visual confirmation requires a native Windows/Linux run.
+
+---
+
+## Task 1: DB search + shared row mapping
+
+**Files:**
+- Modify: `src/db.rs` (extract helper from `load_recent_history` at `src/db.rs:143-184`; add new fn + free fns; add tests in the existing `#[cfg(test)] mod tests`)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these three tests inside `mod tests` in `src/db.rs` (after the existing `history_roundtrip` test). They reference `HttpMethod`, already imported in the test module via `use super::*`:
+
+```rust
+    #[test]
+    fn search_history_matches_url_and_method_newest_first() {
+        let db = mem_db();
+        db.insert_history("GET", "https://api.test/users", "[]", &crate::types::BodyType::None)
+            .unwrap();
+        db.insert_history("POST", "https://api.test/login", "[]", &crate::types::BodyType::None)
+            .unwrap();
+        db.insert_history("DELETE", "https://api.test/orders/1", "[]", &crate::types::BodyType::None)
+            .unwrap();
+
+        // URL substring
+        let r = db.search_history("login", 10).unwrap();
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].request.url, "https://api.test/login");
+
+        // method match, case-insensitive
+        let r = db.search_history("post", 10).unwrap();
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].request.method, HttpMethod::POST);
+
+        // shared substring across all three, newest (last inserted) first
+        let r = db.search_history("api.test", 10).unwrap();
+        assert_eq!(r.len(), 3);
+        assert_eq!(r[0].request.url, "https://api.test/orders/1");
+    }
+
+    #[test]
+    fn search_history_escapes_wildcards() {
+        let db = mem_db();
+        db.insert_history("GET", "https://api.test/a%b", "[]", &crate::types::BodyType::None)
+            .unwrap();
+        db.insert_history("GET", "https://api.test/axb", "[]", &crate::types::BodyType::None)
+            .unwrap();
+
+        // '%' must be treated literally: matches only the URL with a literal '%'
+        let r = db.search_history("a%b", 10).unwrap();
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].request.url, "https://api.test/a%b");
+    }
+
+    #[test]
+    fn search_history_empty_query_matches_all() {
+        let db = mem_db();
+        db.insert_history("GET", "https://api.test/users", "[]", &crate::types::BodyType::None)
+            .unwrap();
+        let r = db.search_history("", 10).unwrap();
+        assert_eq!(r.len(), 1);
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --lib search_history 2>&1 | tail -20`
+Expected: compile error — `no method named 'search_history' found for struct 'Database'`.
+
+- [ ] **Step 3: Add the shared free functions**
+
+At the top of `src/db.rs`, just below the `type Job = ...` line (around `src/db.rs:19`), add the row-mapping helper and the LIKE escaper as private free functions:
+
+```rust
+/// Map a `history` row (id, timestamp, method, url, request_headers, request_body)
+/// into a `HistoryItem`. Shared by `load_recent_history` and `search_history` so
+/// the two queries can never drift in how they decode a row.
+fn row_to_history_item(row: &rusqlite::Row) -> rusqlite::Result<HistoryItem> {
+    let id: i64 = row.get(0)?;
+    let timestamp: String = row.get(1)?;
+    let method: String = row.get(2)?;
+    let url: String = row.get(3)?;
+    let request_headers: String = row.get(4)?;
+    let request_body: String = row.get(5)?;
+
+    let headers: Vec<(String, String)> =
+        serde_json::from_str(&request_headers).unwrap_or_default();
+    let body: crate::types::BodyType =
+        serde_json::from_str(&request_body).unwrap_or_default();
+
+    let request = RequestData {
+        method: HttpMethod::from_str(&method).unwrap_or(HttpMethod::GET),
+        url,
+        headers,
+        body,
+    };
+    Ok(HistoryItem::new(id, timestamp, request, None))
+}
+
+/// Escape a user query so SQLite `LIKE` treats `%`, `_`, and `\` literally.
+/// Paired with `ESCAPE '\'` in the SQL. Backslash must be escaped first.
+fn escape_like(query: &str) -> String {
+    query
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+```
+
+- [ ] **Step 4: Use the helper in `load_recent_history`**
+
+Replace the closure body in `load_recent_history` (`src/db.rs:153-176`) so the whole `query_map` call reads:
+
+```rust
+            let items = stmt.query_map([limit as i64], row_to_history_item)?;
+
+            let mut result = Vec::new();
+            for item in items {
+                result.push(item?);
+            }
+            Ok(result)
+```
+
+(Delete the old inline `|row| { ... Ok(HistoryItem::new(...)) }` closure and its now-duplicated decoding.)
+
+- [ ] **Step 5: Add `search_history`**
+
+Add this method inside `impl Database`, directly after `load_recent_history` (after `src/db.rs:184`):
+
+```rust
+    /// Search history by URL or method (case-insensitive substring), all rows,
+    /// newest first. An empty query matches everything.
+    pub fn search_history(&self, query: &str, limit: usize) -> Result<Vec<HistoryItem>> {
+        let pattern = format!("%{}%", escape_like(query));
+        self.call(move |conn| {
+            let mut stmt = conn.prepare(
+                "SELECT id, timestamp, method, url, request_headers, request_body
+                 FROM history
+                 WHERE url LIKE ?1 ESCAPE '\\' OR method LIKE ?1 ESCAPE '\\'
+                 ORDER BY timestamp DESC, id DESC
+                 LIMIT ?2",
+            )?;
+            let items = stmt.query_map(params![pattern, limit as i64], row_to_history_item)?;
+            let mut result = Vec::new();
+            for item in items {
+                result.push(item?);
+            }
+            Ok(result)
+        })
+    }
+```
+
+Note: the `ORDER BY timestamp DESC, id DESC` tie-breaker makes "newest first" deterministic even when several inserts share a timestamp (the test relies on this).
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cargo test --lib 2>&1 | tail -20`
+Expected: all tests pass, including the existing `history_roundtrip` and `crud_and_active` (confirms the `load_recent_history` refactor didn't regress).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/db.rs
+git commit -m "feat(db): add search_history (LIKE over url+method), share row mapping
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Search icon asset
+
+**Files:**
+- Create: `assets/icons/search.svg`
+
+- [ ] **Step 1: Create the icon**
+
+Write `assets/icons/search.svg` (lucide "search", `currentColor` so it inherits theme color, matching the existing icon style):
+
+```svg
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+```
+
+- [ ] **Step 2: Verify it is picked up by the embed**
+
+Run: `ls assets/icons/search.svg`
+Expected: the path prints (rust-embed embeds `./assets` at compile time, so a rebuild will include it; no code registration needed — same as `code.svg`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add assets/icons/search.svg
+git commit -m "feat(assets): add search icon for history search input
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: History panel search UI + wiring
+
+**Files:**
+- Modify: `src/history_panel.rs` (imports, struct, `new`, add `on_search_change` + `refresh_list`, `reload`, `render`)
+
+This task has no unit test (it is GPUI render wiring); verification is `cargo check` plus a manual native run. Build the whole change, then verify it compiles.
+
+- [ ] **Step 1: Update imports**
+
+Replace the `gpui_component` import block at `src/history_panel.rs:3-6` with:
+
+```rust
+use gpui_component::{
+    button::*, h_flex,
+    input::{Input, InputEvent, InputState},
+    scroll::ScrollableElement as _,
+    v_flex, ActiveTheme as _, Icon, Sizable as _,
+};
+```
+
+- [ ] **Step 2: Add fields to the struct**
+
+In `struct HistoryPanel` (`src/history_panel.rs:19-23`), add the search input and query string:
+
+```rust
+pub struct HistoryPanel {
+    db: Arc<Database>,
+    history: Vec<HistoryItem>,
+    selected_id: Option<i64>,
+    search: Entity<InputState>,
+    query: String,
+}
+```
+
+- [ ] **Step 3: Build the input and subscribe in `new`**
+
+Replace `new` (`src/history_panel.rs:26-35`) with (note `window`/`cx` are now used, no longer `_`-prefixed):
+
+```rust
+    pub fn new(db: Arc<Database>, window: &mut Window, cx: &mut Context<Self>) -> Self {
+        // Load initial history from database
+        let history = db.load_recent_history(100).unwrap_or_default();
+
+        let search = cx.new(|cx| InputState::new(window, cx).placeholder("Search history"));
+        cx.subscribe(&search, Self::on_search_change).detach();
+
+        Self {
+            db,
+            history,
+            selected_id: None,
+            search,
+            query: String::new(),
+        }
+    }
+```
+
+- [ ] **Step 4: Add `on_search_change` and `refresh_list`; update `reload`**
+
+Add these two methods inside `impl HistoryPanel` (e.g. right after `new`), and replace the existing `reload` (`src/history_panel.rs:38-41`) with the version below:
+
+```rust
+    /// Re-query the list to honor the current query: recent when empty,
+    /// search otherwise. Shared by typing and by `reload`.
+    fn refresh_list(&mut self) {
+        let q = self.query.trim();
+        self.history = if q.is_empty() {
+            self.db.load_recent_history(100).unwrap_or_default()
+        } else {
+            self.db.search_history(q, 100).unwrap_or_default()
+        };
+    }
+
+    fn on_search_change(
+        &mut self,
+        _state: Entity<InputState>,
+        event: &InputEvent,
+        cx: &mut Context<Self>,
+    ) {
+        if let InputEvent::Change = event {
+            self.query = self.search.read(cx).value().to_string();
+            self.refresh_list();
+            cx.notify();
+        }
+    }
+
+    /// Reload history from database, honoring the active search query.
+    pub fn reload(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        self.refresh_list();
+        cx.notify();
+    }
+```
+
+- [ ] **Step 5: Render the search row**
+
+In `render`, insert a search row immediately after the header `.child(...)` block (after `src/history_panel.rs:114`, before the `.when(self.history.is_empty(), ...)`):
+
+```rust
+            .child(
+                // Search row (always visible, like Postman)
+                div()
+                    .px_2()
+                    .py_2()
+                    .border_b_1()
+                    .border_color(theme.border)
+                    .child(
+                        Input::new(&self.search)
+                            .small()
+                            .cleanable(true)
+                            .prefix(Icon::empty().path("icons/search.svg")),
+                    ),
+            )
+```
+
+- [ ] **Step 6: Make the empty state query-aware**
+
+Replace the empty-state child text in the `.when(self.history.is_empty(), ...)` block (`src/history_panel.rs:115-127`). Keep the same container styling; only the text becomes dynamic:
+
+```rust
+            .when(self.history.is_empty(), |this| {
+                let msg = if self.query.trim().is_empty() {
+                    "No history yet\n\nSend a request to get started".to_string()
+                } else {
+                    format!("No history matches \"{}\"", self.query.trim())
+                };
+                this.child(
+                    div()
+                        .flex_1()
+                        .flex()
+                        .items_center()
+                        .justify_center()
+                        .text_center()
+                        .text_color(theme.muted_foreground)
+                        .text_sm()
+                        .child(msg),
+                )
+            })
+```
+
+- [ ] **Step 7: Verify it compiles**
+
+Run: `cargo check 2>&1 | tail -20`
+Expected: `Finished` with no errors. (Cannot run the GPUI app under WSL2; compile is the automated gate.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/history_panel.rs
+git commit -m "feat(history): add always-visible search box filtering url+method
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Final verification
+
+- [ ] Run the full test suite: `cargo test 2>&1 | tail -20` — expected: all pass.
+- [ ] Run `cargo check` — expected: clean.
+- [ ] Manual (native host only, optional): launch the app, type in the History search box, confirm the list filters by URL and method, the ✕ clears it, and an unmatched query shows `No history matches "…"`.

--- a/docs/superpowers/specs/2026-06-26-history-search-design.md
+++ b/docs/superpowers/specs/2026-06-26-history-search-design.md
@@ -1,0 +1,112 @@
+# Spec: History search (URL + method, DB-backed LIKE)
+
+Date: 2026-06-26
+Status: Approved
+
+## Goal
+
+Add a search box to the History panel that filters stored requests by **URL or
+HTTP method** across the **entire** history (not just the loaded page), matching
+Postman's always-visible history search.
+
+## Scope decisions (settled during brainstorming)
+
+- **Match fields:** URL + method only. Not request body / headers.
+- **Backend:** DB-backed `LIKE` over all rows. Rejected client-side filtering
+  (only sees the loaded 100) and rejected FTS5 / inverted index as YAGNI:
+  local single-user data is tiny, `LIKE` on two short fields is sub-millisecond,
+  and FTS5 is token-based so it would not even do the substring matching a
+  filter box implies. Revisit FTS5 + trigram only if we later add full-text
+  body/response search over millions of rows with relevance ranking.
+- **UI:** an always-visible search row under the panel header.
+- **Out of scope (v1):** match-source badges (`· body`), substring highlighting,
+  date grouping, retention/pruning, dedup.
+
+## Storage — `src/db.rs`
+
+New method:
+
+```rust
+pub fn search_history(&self, query: &str, limit: usize) -> Result<Vec<HistoryItem>>
+```
+
+SQL:
+
+```sql
+SELECT id, timestamp, method, url, request_headers, request_body
+FROM history
+WHERE url LIKE ?1 ESCAPE '\' OR method LIKE ?1 ESCAPE '\'
+ORDER BY timestamp DESC
+LIMIT ?2
+```
+
+- Bind `?1` = `%{query}%`, escaping the user's `%`, `_`, and `\` so literal
+  wildcards in the query are matched literally (paired with `ESCAPE '\'`).
+- SQLite `LIKE` is case-insensitive for ASCII, so `LOGIN` matches `login`.
+- `limit` binds as `i64` (rusqlite 0.40 dropped `ToSql` for `usize`), matching
+  the existing `load_recent_history`.
+
+**Refactor to avoid drift:** extract the row → `HistoryItem` mapping currently
+inline in `load_recent_history` into one private helper (e.g.
+`fn row_to_history_item(row) -> rusqlite::Result<HistoryItem>`), and have both
+`load_recent_history` and `search_history` use it. This mirrors the existing
+shared-`init_schema` discipline so the two queries can never diverge.
+
+No new index: substring `%query%` cannot use a B-tree index anyway, and full
+scans over this data set are negligible.
+
+## Interaction — `src/history_panel.rs`
+
+State additions:
+- `search: Entity<InputState>` — created with `InputState::new(window, cx)` and
+  `.placeholder("Search history")`.
+- `query: String` — the current trimmed query, kept so empty-state text and
+  `reload()` can read it.
+
+Wiring:
+- In `new(...)`, create the input and `cx.subscribe(&search, Self::on_search_change)`
+  for `InputEvent::Change` (same pattern as `body_editor`).
+- `on_search_change` reads the input value into `self.query`, then refreshes the
+  list (see below) and `cx.notify()`.
+
+List refresh (single helper, e.g. `refresh_list`):
+- If `self.query` is empty → `self.db.load_recent_history(100)`.
+- Else → `self.db.search_history(&self.query, 100)`.
+- Store into `self.history`.
+
+`reload()` (called by `app.rs` after each send) calls the same `refresh_list`
+helper so it respects the active query: a newly sent request appears only if it
+matches the current filter; an empty query behaves exactly as today.
+
+## UI
+
+A new always-visible search row between the existing `History [Clear]` header and
+the list:
+
+```
+History                     [Clear]
+------------------------------------
+[search-icon]  Search history…   (x)
+------------------------------------
+GET    /api/users           2m ago
+POST   /api/login           5m ago
+```
+
+- `Input::new(&self.search).small().cleanable(true).prefix(<search icon>)`.
+- `.cleanable(true)` provides the built-in clear (✕) button when non-empty;
+  clearing resets the list to recent history via the same `Change` path.
+
+## Empty states
+
+- `query` non-empty and zero results → `No history matches "{query}"`.
+- `query` empty and history empty → existing `No history yet …` text, unchanged.
+
+## Testing
+
+Extend `db.rs` tests:
+- Insert a few rows (varied method/URL), assert `search_history` returns only
+  matching rows, newest-first.
+- Case-insensitivity: a lowercase query matches an uppercase method.
+- Wildcard escaping: a query containing `%` matches a URL with a literal `%`
+  and does not match everything.
+- Empty/`limit` behaviour consistent with `load_recent_history`.

--- a/src/db.rs
+++ b/src/db.rs
@@ -18,6 +18,40 @@ use crate::types::{Environment, EnvVar, HistoryItem, HttpMethod, RequestData};
 /// A unit of work executed on the database's owning thread.
 type Job = Box<dyn FnOnce(&mut Connection) + Send>;
 
+/// Map a `history` row (id, timestamp, method, url, request_headers, request_body)
+/// into a `HistoryItem`. Shared by `load_recent_history` and `search_history` so
+/// the two queries can never drift in how they decode a row.
+fn row_to_history_item(row: &rusqlite::Row) -> rusqlite::Result<HistoryItem> {
+    let id: i64 = row.get(0)?;
+    let timestamp: String = row.get(1)?;
+    let method: String = row.get(2)?;
+    let url: String = row.get(3)?;
+    let request_headers: String = row.get(4)?;
+    let request_body: String = row.get(5)?;
+
+    let headers: Vec<(String, String)> =
+        serde_json::from_str(&request_headers).unwrap_or_default();
+    let body: crate::types::BodyType =
+        serde_json::from_str(&request_body).unwrap_or_default();
+
+    let request = RequestData {
+        method: HttpMethod::from_str(&method).unwrap_or(HttpMethod::GET),
+        url,
+        headers,
+        body,
+    };
+    Ok(HistoryItem::new(id, timestamp, request, None))
+}
+
+/// Escape a user query so SQLite `LIKE` treats `%`, `_`, and `\` literally.
+/// Paired with `ESCAPE '\'` in the SQL. Backslash must be escaped first.
+fn escape_like(query: &str) -> String {
+    query
+        .replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
 /// Handle to the database thread. Cloneable senders make this cheap to share
 /// (wrapped in `Arc` by the app); dropping every handle stops the thread.
 pub struct Database {
@@ -150,31 +184,29 @@ impl Database {
             )?;
 
             // rusqlite 0.40 dropped the `ToSql` impl for `usize`; bind as i64.
-            let items = stmt.query_map([limit as i64], |row| {
-                let id: i64 = row.get(0)?;
-                let timestamp: String = row.get(1)?;
-                let method: String = row.get(2)?;
-                let url: String = row.get(3)?;
-                let request_headers: String = row.get(4)?;
-                let request_body: String = row.get(5)?;
+            let items = stmt.query_map([limit as i64], row_to_history_item)?;
 
-                let headers: Vec<(String, String)> =
-                    serde_json::from_str(&request_headers).unwrap_or_default();
+            let mut result = Vec::new();
+            for item in items {
+                result.push(item?);
+            }
+            Ok(result)
+        })
+    }
 
-                // Deserialize body type from JSON, fallback to default if fails
-                let body: crate::types::BodyType =
-                    serde_json::from_str(&request_body).unwrap_or_default();
-
-                let request = RequestData {
-                    method: HttpMethod::from_str(&method).unwrap_or(HttpMethod::GET),
-                    url,
-                    headers,
-                    body,
-                };
-
-                Ok(HistoryItem::new(id, timestamp, request, None))
-            })?;
-
+    /// Search history by URL or method (case-insensitive substring), all rows,
+    /// newest first. An empty query matches everything.
+    pub fn search_history(&self, query: &str, limit: usize) -> Result<Vec<HistoryItem>> {
+        let pattern = format!("%{}%", escape_like(query));
+        self.call(move |conn| {
+            let mut stmt = conn.prepare(
+                "SELECT id, timestamp, method, url, request_headers, request_body
+                 FROM history
+                 WHERE url LIKE ?1 ESCAPE '\\' OR method LIKE ?1 ESCAPE '\\'
+                 ORDER BY timestamp DESC, id DESC
+                 LIMIT ?2",
+            )?;
+            let items = stmt.query_map(params![pattern, limit as i64], row_to_history_item)?;
             let mut result = Vec::new();
             for item in items {
                 result.push(item?);
@@ -378,5 +410,54 @@ mod tests {
         assert_eq!(items[0].request.url, "https://api.test/x");
         db.clear_all_history().unwrap();
         assert!(db.load_recent_history(10).unwrap().is_empty());
+    }
+
+    #[test]
+    fn search_history_matches_url_and_method_newest_first() {
+        let db = mem_db();
+        db.insert_history("GET", "https://api.test/users", "[]", &crate::types::BodyType::None)
+            .unwrap();
+        db.insert_history("POST", "https://api.test/login", "[]", &crate::types::BodyType::None)
+            .unwrap();
+        db.insert_history("DELETE", "https://api.test/orders/1", "[]", &crate::types::BodyType::None)
+            .unwrap();
+
+        // URL substring
+        let r = db.search_history("login", 10).unwrap();
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].request.url, "https://api.test/login");
+
+        // method match, case-insensitive
+        let r = db.search_history("post", 10).unwrap();
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].request.method, HttpMethod::POST);
+
+        // shared substring across all three, newest (last inserted) first
+        let r = db.search_history("api.test", 10).unwrap();
+        assert_eq!(r.len(), 3);
+        assert_eq!(r[0].request.url, "https://api.test/orders/1");
+    }
+
+    #[test]
+    fn search_history_escapes_wildcards() {
+        let db = mem_db();
+        db.insert_history("GET", "https://api.test/a%b", "[]", &crate::types::BodyType::None)
+            .unwrap();
+        db.insert_history("GET", "https://api.test/axb", "[]", &crate::types::BodyType::None)
+            .unwrap();
+
+        // '%' must be treated literally: matches only the URL with a literal '%'
+        let r = db.search_history("a%b", 10).unwrap();
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].request.url, "https://api.test/a%b");
+    }
+
+    #[test]
+    fn search_history_empty_query_matches_all() {
+        let db = mem_db();
+        db.insert_history("GET", "https://api.test/users", "[]", &crate::types::BodyType::None)
+            .unwrap();
+        let r = db.search_history("", 10).unwrap();
+        assert_eq!(r.len(), 1);
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 use std::sync::mpsc::{self, Sender};
 use std::thread;
 
-use crate::types::{Environment, EnvVar, HistoryItem, HttpMethod, RequestData};
+use crate::types::{BodyType, Environment, EnvVar, HistoryItem, HttpMethod, RequestData};
 
 /// A unit of work executed on the database's owning thread.
 type Job = Box<dyn FnOnce(&mut Connection) + Send>;
@@ -31,8 +31,7 @@ fn row_to_history_item(row: &rusqlite::Row) -> rusqlite::Result<HistoryItem> {
 
     let headers: Vec<(String, String)> =
         serde_json::from_str(&request_headers).unwrap_or_default();
-    let body: crate::types::BodyType =
-        serde_json::from_str(&request_body).unwrap_or_default();
+    let body: BodyType = serde_json::from_str(&request_body).unwrap_or_default();
 
     let request = RequestData {
         method: HttpMethod::from_str(&method).unwrap_or(HttpMethod::GET),
@@ -154,7 +153,7 @@ impl Database {
         method: &str,
         url: &str,
         request_headers: &str,
-        request_body: &crate::types::BodyType,
+        request_body: &BodyType,
     ) -> Result<i64> {
         let method = method.to_string();
         let url = url.to_string();
@@ -179,7 +178,7 @@ impl Database {
             let mut stmt = conn.prepare(
                 "SELECT id, timestamp, method, url, request_headers, request_body
                  FROM history
-                 ORDER BY timestamp DESC
+                 ORDER BY timestamp DESC, id DESC
                  LIMIT ?1",
             )?;
 
@@ -194,8 +193,8 @@ impl Database {
         })
     }
 
-    /// Search history by URL or method (case-insensitive substring), all rows,
-    /// newest first. An empty query matches everything.
+    /// Search history by URL or method (case-insensitive substring), newest
+    /// first, up to `limit` rows. An empty query matches everything.
     pub fn search_history(&self, query: &str, limit: usize) -> Result<Vec<HistoryItem>> {
         let pattern = format!("%{}%", escape_like(query));
         self.call(move |conn| {
@@ -443,6 +442,8 @@ mod tests {
         let db = mem_db();
         db.insert_history("GET", "https://api.test/a%b", "[]", &crate::types::BodyType::None)
             .unwrap();
+        db.insert_history("GET", "https://api.test/a_b", "[]", &crate::types::BodyType::None)
+            .unwrap();
         db.insert_history("GET", "https://api.test/axb", "[]", &crate::types::BodyType::None)
             .unwrap();
 
@@ -450,6 +451,12 @@ mod tests {
         let r = db.search_history("a%b", 10).unwrap();
         assert_eq!(r.len(), 1);
         assert_eq!(r[0].request.url, "https://api.test/a%b");
+
+        // '_' must be treated literally: matches only the URL with a literal '_',
+        // not the single-char wildcard that would also match "/axb" and "/a%b".
+        let r = db.search_history("a_b", 10).unwrap();
+        assert_eq!(r.len(), 1);
+        assert_eq!(r[0].request.url, "https://api.test/a_b");
     }
 
     #[test]

--- a/src/history_panel.rs
+++ b/src/history_panel.rs
@@ -11,6 +11,9 @@ use std::sync::Arc;
 use crate::db::Database;
 use crate::types::HistoryItem;
 
+/// Maximum number of history rows loaded/searched at a time.
+const HISTORY_LIMIT: usize = 100;
+
 /// Event emitted when a history item is clicked
 #[derive(Clone)]
 pub struct HistoryItemClicked {
@@ -29,7 +32,7 @@ pub struct HistoryPanel {
 impl HistoryPanel {
     pub fn new(db: Arc<Database>, window: &mut Window, cx: &mut Context<Self>) -> Self {
         // Load initial history from database
-        let history = db.load_recent_history(100).unwrap_or_default();
+        let history = db.load_recent_history(HISTORY_LIMIT).unwrap_or_default();
 
         let search = cx.new(|cx| InputState::new(window, cx).placeholder("Search history"));
         cx.subscribe(&search, Self::on_search_change).detach();
@@ -48,9 +51,9 @@ impl HistoryPanel {
     fn refresh_list(&mut self) {
         let q = self.query.trim();
         self.history = if q.is_empty() {
-            self.db.load_recent_history(100).unwrap_or_default()
+            self.db.load_recent_history(HISTORY_LIMIT).unwrap_or_default()
         } else {
-            self.db.search_history(q, 100).unwrap_or_default()
+            self.db.search_history(q, HISTORY_LIMIT).unwrap_or_default()
         };
     }
 
@@ -60,7 +63,7 @@ impl HistoryPanel {
         event: &InputEvent,
         cx: &mut Context<Self>,
     ) {
-        if let InputEvent::Change = event {
+        if matches!(event, InputEvent::Change) {
             self.query = self.search.read(cx).value().to_string();
             self.refresh_list();
             cx.notify();
@@ -101,7 +104,7 @@ impl HistoryPanel {
     fn clear_history(
         &mut self,
         _event: &gpui::ClickEvent,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         if let Err(e) = self.db.clear_all_history() {
@@ -111,6 +114,9 @@ impl HistoryPanel {
 
         self.history.clear();
         self.selected_id = None;
+        self.query = String::new();
+        self.search
+            .update(cx, |state, cx| state.set_value("", window, cx));
         cx.notify();
     }
 }

--- a/src/history_panel.rs
+++ b/src/history_panel.rs
@@ -1,8 +1,10 @@
 use gpui::prelude::FluentBuilder as _;
 use gpui::*;
 use gpui_component::{
-    button::*, h_flex, scroll::ScrollableElement as _, v_flex, ActiveTheme as _,
-    Sizable as _,
+    button::*, h_flex,
+    input::{Input, InputEvent, InputState},
+    scroll::ScrollableElement as _,
+    v_flex, ActiveTheme as _, Icon, Sizable as _,
 };
 use std::sync::Arc;
 
@@ -20,23 +22,54 @@ pub struct HistoryPanel {
     db: Arc<Database>,
     history: Vec<HistoryItem>,
     selected_id: Option<i64>,
+    search: Entity<InputState>,
+    query: String,
 }
 
 impl HistoryPanel {
-    pub fn new(db: Arc<Database>, _window: &mut Window, _cx: &mut Context<Self>) -> Self {
+    pub fn new(db: Arc<Database>, window: &mut Window, cx: &mut Context<Self>) -> Self {
         // Load initial history from database
         let history = db.load_recent_history(100).unwrap_or_default();
+
+        let search = cx.new(|cx| InputState::new(window, cx).placeholder("Search history"));
+        cx.subscribe(&search, Self::on_search_change).detach();
 
         Self {
             db,
             history,
             selected_id: None,
+            search,
+            query: String::new(),
         }
     }
 
-    /// Reload history from database
+    /// Re-query the list to honor the current query: recent when empty,
+    /// search otherwise. Shared by typing and by `reload`.
+    fn refresh_list(&mut self) {
+        let q = self.query.trim();
+        self.history = if q.is_empty() {
+            self.db.load_recent_history(100).unwrap_or_default()
+        } else {
+            self.db.search_history(q, 100).unwrap_or_default()
+        };
+    }
+
+    fn on_search_change(
+        &mut self,
+        _state: Entity<InputState>,
+        event: &InputEvent,
+        cx: &mut Context<Self>,
+    ) {
+        if let InputEvent::Change = event {
+            self.query = self.search.read(cx).value().to_string();
+            self.refresh_list();
+            cx.notify();
+        }
+    }
+
+    /// Reload history from database, honoring the active search query.
     pub fn reload(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
-        self.history = self.db.load_recent_history(100).unwrap_or_default();
+        self.refresh_list();
         cx.notify();
     }
 
@@ -112,7 +145,26 @@ impl Render for HistoryPanel {
                             .on_click(cx.listener(Self::clear_history)),
                     ),
             )
+            .child(
+                // Search row (always visible, like Postman)
+                div()
+                    .px_2()
+                    .py_2()
+                    .border_b_1()
+                    .border_color(theme.border)
+                    .child(
+                        Input::new(&self.search)
+                            .small()
+                            .cleanable(true)
+                            .prefix(Icon::empty().path("icons/search.svg")),
+                    ),
+            )
             .when(self.history.is_empty(), |this| {
+                let msg = if self.query.trim().is_empty() {
+                    "No history yet\n\nSend a request to get started".to_string()
+                } else {
+                    format!("No history matches \"{}\"", self.query.trim())
+                };
                 this.child(
                     div()
                         .flex_1()
@@ -122,7 +174,7 @@ impl Render for HistoryPanel {
                         .text_center()
                         .text_color(theme.muted_foreground)
                         .text_sm()
-                        .child("No history yet\n\nSend a request to get started"),
+                        .child(msg),
                 )
             })
             .when(!self.history.is_empty(), |this| {


### PR DESCRIPTION
## What

Adds an always-visible search box to the History panel that filters stored requests by **URL or HTTP method** across the entire history (Postman-style).

## How

- **DB (`src/db.rs`):** new `Database::search_history(query, limit)` runs a SQLite `LIKE` over `url` and `method`, newest-first (`ORDER BY timestamp DESC, id DESC`). User input is wildcard-escaped (`%`, `_`, `\`) via `ESCAPE '\'` so typing a `%` matches literally. Extracted a shared `row_to_history_item` decoder reused by `load_recent_history` so the two queries can't drift; also gave `load_recent_history` the same deterministic tie-breaker.
- **Panel (`src/history_panel.rs`):** a search `Input` (`.cleanable(true)` + search-icon prefix) that re-queries on each keystroke via a shared `refresh_list` helper — recent when blank, search otherwise. `reload` now honors the active query, and the empty state is query-aware (`No history matches "…"`). Clear button resets the search box too.
- **Asset:** `assets/icons/search.svg` (lucide search, `currentColor`).

## Design notes

Chose `LIKE` over FTS5 / an inverted index deliberately: this is local single-user data, `LIKE` over two short fields is sub-millisecond, and FTS5 is token-based so it wouldn't do the substring matching a filter box implies. Spec + plan: `docs/superpowers/specs/2026-06-26-history-search-design.md`, `docs/superpowers/plans/2026-06-26-history-search.md` (already on main).

## Testing

- DB unit tests added: URL/method substring match, case-insensitivity, `%`/`_` wildcard escaping, empty-query-matches-all, newest-first ordering.
- Built clean: Windows `cargo build --release` succeeds (whole crate). Note: running the test binary on this WSL2 host needs a libxkbcommon dev-symlink workaround (GPUI links at test time); CI / a native host runs them normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)