### PR TITLE
improve: humanized formatting, Arc-shared responses, clippy zero

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -219,12 +219,12 @@ impl PoopmanApp {
         active_id: Option<i64>,
     ) -> std::collections::HashMap<String, String> {
         let mut map = std::collections::HashMap::new();
-        if let Some(id) = active_id {
-            if let Some(env) = environments.iter().find(|e| e.id == id) {
-                for v in &env.variables {
-                    if v.enabled && !v.key.is_empty() {
-                        map.insert(v.key.clone(), v.value.clone());
-                    }
+        if let Some(id) = active_id
+            && let Some(env) = environments.iter().find(|e| e.id == id)
+        {
+            for v in &env.variables {
+                if v.enabled && !v.key.is_empty() {
+                    map.insert(v.key.clone(), v.value.clone());
                 }
             }
         }
@@ -318,16 +318,16 @@ impl PoopmanApp {
                 editor.load_request(&tab.request, window, cx);
 
                 // If we have saved UI state, load it (overrides parsed state from URL)
-                if let Some(params_state) = &tab.params_state {
-                    if !params_state.is_empty() {
-                        editor.load_params_state(params_state, window, cx);
-                    }
+                if let Some(params_state) = &tab.params_state
+                    && !params_state.is_empty()
+                {
+                    editor.load_params_state(params_state, window, cx);
                 }
 
-                if let Some(headers_state) = &tab.headers_state {
-                    if !headers_state.is_empty() {
-                        editor.load_headers_state(headers_state, window, cx);
-                    }
+                if let Some(headers_state) = &tab.headers_state
+                    && !headers_state.is_empty()
+                {
+                    editor.load_headers_state(headers_state, window, cx);
                 }
             });
 

--- a/src/body_editor.rs
+++ b/src/body_editor.rs
@@ -26,13 +26,16 @@ fn get_placeholder_for_subtype(subtype: RawSubtype) -> &'static str {
     }
 }
 
+/// Per-row input entities for a form-data row: (key input, value input, type select).
+type FormDataRowInputs = (Entity<InputState>, Entity<InputState>, Entity<SelectState<Vec<&'static str>>>);
+
 pub struct BodyEditor {
     body_type_index: usize,
     raw_subtype_select: Entity<SelectState<Vec<&'static str>>>,
     raw_body_editor: Entity<InputState>,  // Single editor for all raw types
     current_raw_subtype: RawSubtype,      // Track current subtype
     formdata_rows: Vec<FormDataRow>,
-    formdata_input_states: Vec<(Entity<InputState>, Entity<InputState>, Entity<SelectState<Vec<&'static str>>>)>,
+    formdata_input_states: Vec<FormDataRowInputs>,
     formdata_scroll_handle: ScrollHandle,
     _subscriptions: Vec<Subscription>,
     // Format/validation state
@@ -47,20 +50,19 @@ impl BodyEditor {
         event: &InputChangeEvent,
         cx: &mut Context<Self>,
     ) {
-        if let InputChangeEvent::Change = event {
-            if let Some((index, (key_input, _value_input, _type_select))) = self
+        if let InputChangeEvent::Change = event
+            && let Some((index, (key_input, _value_input, _type_select))) = self
                 .formdata_input_states
                 .iter()
                 .enumerate()
                 .find(|(_, (k, v, _))| k.entity_id() == state_entity.entity_id() || v.entity_id() == state_entity.entity_id())
-            {
-                let is_key = key_input.entity_id() == state_entity.entity_id();
-                let value = state_entity.read(cx).value().to_string();
-                if is_key {
-                    self.update_formdata_key(index, value, cx);
-                } else {
-                    self.update_formdata_value(index, value, cx);
-                }
+        {
+            let is_key = key_input.entity_id() == state_entity.entity_id();
+            let value = state_entity.read(cx).value().to_string();
+            if is_key {
+                self.update_formdata_key(index, value, cx);
+            } else {
+                self.update_formdata_value(index, value, cx);
             }
         }
     }
@@ -512,16 +514,16 @@ impl BodyEditor {
 
         if let Some((_key_input, value_input, _type_select)) = self.formdata_input_states.get(index).cloned() {
             cx.spawn_in(window, async move |_, window| {
-                if let Ok(Ok(Some(paths))) = path.await {
-                    if let Some(selected_path) = paths.iter().next() {
-                        // Store and display the full path (used directly when sending).
-                        let path_str = selected_path.to_string_lossy().to_string();
-                        let _ = window.update(|window, cx| {
-                            value_input.update(cx, |input, cx| {
-                                input.set_value(&path_str, window, cx);
-                            });
+                if let Ok(Ok(Some(paths))) = path.await
+                    && let Some(selected_path) = paths.first()
+                {
+                    // Store and display the full path (used directly when sending).
+                    let path_str = selected_path.to_string_lossy().to_string();
+                    let _ = window.update(|window, cx| {
+                        value_input.update(cx, |input, cx| {
+                            input.set_value(&path_str, window, cx);
                         });
-                    }
+                    });
                 }
             })
             .detach();

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,0 +1,177 @@
+//! Human-readable formatting helpers for UI display (sizes, durations,
+//! relative timestamps). Pure functions so every display rule is unit-tested.
+
+use chrono::{DateTime, Utc};
+
+/// Render a value with at most two decimals, trimming trailing zeros
+/// ("1.50" -> "1.5", "1.00" -> "1").
+fn trim2(value: f64) -> String {
+    let s = format!("{:.2}", value);
+    s.trim_end_matches('0').trim_end_matches('.').to_string()
+}
+
+/// Format a byte count for display: "532 B", "1.5 KB", "5.15 MB", "3 GB".
+/// At most two decimals, trailing zeros trimmed.
+pub fn format_size(bytes: usize) -> String {
+    const KB: f64 = 1024.0;
+    const MB: f64 = KB * 1024.0;
+    const GB: f64 = MB * 1024.0;
+
+    let b = bytes as f64;
+    if b < KB {
+        format!("{} B", bytes)
+    } else if b < MB {
+        format!("{} KB", trim2(b / KB))
+    } else if b < GB {
+        format!("{} MB", trim2(b / MB))
+    } else {
+        format!("{} GB", trim2(b / GB))
+    }
+}
+
+/// Format a duration for display: "245 ms", "1.52 s", "1 m 30 s".
+/// At most two decimals on seconds, trailing zeros trimmed.
+pub fn format_duration_ms(ms: u64) -> String {
+    if ms < 1_000 {
+        format!("{} ms", ms)
+    } else if ms < 60_000 {
+        format!("{} s", trim2(ms as f64 / 1_000.0))
+    } else {
+        let mut minutes = ms / 60_000;
+        let mut seconds = ((ms % 60_000) as f64 / 1_000.0).round() as u64;
+        if seconds == 60 {
+            minutes += 1;
+            seconds = 0;
+        }
+        format!("{} m {} s", minutes, seconds)
+    }
+}
+
+/// Format an RFC 3339 timestamp relative to `now`: "just now", "5 min ago",
+/// "1 hour ago", "3 days ago". Unparseable input is returned unchanged.
+pub fn format_relative_time(timestamp: &str, now: DateTime<Utc>) -> String {
+    let Ok(then) = DateTime::parse_from_rfc3339(timestamp) else {
+        return timestamp.to_string();
+    };
+    let elapsed = now.signed_duration_since(then);
+
+    let plural = |n: i64, unit: &str| {
+        format!("{} {}{} ago", n, unit, if n == 1 { "" } else { "s" })
+    };
+
+    if elapsed.num_seconds() < 60 {
+        "just now".to_string()
+    } else if elapsed.num_minutes() < 60 {
+        format!("{} min ago", elapsed.num_minutes())
+    } else if elapsed.num_hours() < 24 {
+        plural(elapsed.num_hours(), "hour")
+    } else {
+        plural(elapsed.num_days(), "day")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Duration;
+
+    // ===== format_size =====
+
+    #[test]
+    fn size_bytes_shown_plain() {
+        assert_eq!(format_size(0), "0 B");
+        assert_eq!(format_size(532), "532 B");
+        assert_eq!(format_size(1023), "1023 B");
+    }
+
+    #[test]
+    fn size_kilobytes_trim_trailing_zeros() {
+        assert_eq!(format_size(1024), "1 KB");
+        assert_eq!(format_size(1536), "1.5 KB");
+        assert_eq!(format_size(1259), "1.23 KB");
+    }
+
+    #[test]
+    fn size_megabytes_and_gigabytes() {
+        assert_eq!(format_size(1024 * 1024), "1 MB");
+        assert_eq!(format_size(5_400_000), "5.15 MB");
+        assert_eq!(format_size(3 * 1024 * 1024 * 1024), "3 GB");
+    }
+
+    // ===== format_duration_ms =====
+
+    #[test]
+    fn duration_millis_shown_plain() {
+        assert_eq!(format_duration_ms(0), "0 ms");
+        assert_eq!(format_duration_ms(245), "245 ms");
+        assert_eq!(format_duration_ms(999), "999 ms");
+    }
+
+    #[test]
+    fn duration_seconds_trim_trailing_zeros() {
+        assert_eq!(format_duration_ms(1000), "1 s");
+        assert_eq!(format_duration_ms(1520), "1.52 s");
+        assert_eq!(format_duration_ms(30_100), "30.1 s");
+    }
+
+    #[test]
+    fn duration_minutes_with_whole_seconds() {
+        assert_eq!(format_duration_ms(60_000), "1 m 0 s");
+        assert_eq!(format_duration_ms(90_000), "1 m 30 s");
+        assert_eq!(format_duration_ms(61_000), "1 m 1 s");
+    }
+
+    #[test]
+    fn duration_seconds_rounding_carries_into_minutes() {
+        // 119_999 ms would round to "1 m 60 s" without a carry.
+        assert_eq!(format_duration_ms(119_999), "2 m 0 s");
+    }
+
+    // ===== format_relative_time =====
+
+    fn ts(now: DateTime<Utc>, ago: Duration) -> String {
+        (now - ago).to_rfc3339()
+    }
+
+    #[test]
+    fn relative_under_a_minute_is_just_now() {
+        let now = Utc::now();
+        assert_eq!(format_relative_time(&ts(now, Duration::seconds(30)), now), "just now");
+        assert_eq!(format_relative_time(&ts(now, Duration::seconds(0)), now), "just now");
+    }
+
+    #[test]
+    fn relative_future_timestamp_is_just_now() {
+        // Clock skew: a timestamp slightly in the future must not underflow.
+        let now = Utc::now();
+        assert_eq!(format_relative_time(&ts(now, Duration::seconds(-5)), now), "just now");
+    }
+
+    #[test]
+    fn relative_minutes() {
+        let now = Utc::now();
+        assert_eq!(format_relative_time(&ts(now, Duration::minutes(1)), now), "1 min ago");
+        assert_eq!(format_relative_time(&ts(now, Duration::minutes(5)), now), "5 min ago");
+        assert_eq!(format_relative_time(&ts(now, Duration::minutes(59)), now), "59 min ago");
+    }
+
+    #[test]
+    fn relative_hours_pluralized() {
+        let now = Utc::now();
+        assert_eq!(format_relative_time(&ts(now, Duration::minutes(90)), now), "1 hour ago");
+        assert_eq!(format_relative_time(&ts(now, Duration::hours(5)), now), "5 hours ago");
+    }
+
+    #[test]
+    fn relative_days_pluralized() {
+        let now = Utc::now();
+        assert_eq!(format_relative_time(&ts(now, Duration::hours(25)), now), "1 day ago");
+        assert_eq!(format_relative_time(&ts(now, Duration::days(3)), now), "3 days ago");
+    }
+
+    #[test]
+    fn relative_unparseable_returned_unchanged() {
+        let now = Utc::now();
+        assert_eq!(format_relative_time("not-a-date", now), "not-a-date");
+    }
+}

--- a/src/history_panel.rs
+++ b/src/history_panel.rs
@@ -76,25 +76,6 @@ impl HistoryPanel {
         cx.notify();
     }
 
-    fn format_relative_time(timestamp: &str) -> String {
-        if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(timestamp) {
-            let now = chrono::Utc::now();
-            let duration = now.signed_duration_since(dt);
-
-            if duration.num_seconds() < 60 {
-                "just now".to_string()
-            } else if duration.num_minutes() < 60 {
-                format!("{} min ago", duration.num_minutes())
-            } else if duration.num_hours() < 24 {
-                format!("{} hours ago", duration.num_hours())
-            } else {
-                format!("{} days ago", duration.num_days())
-            }
-        } else {
-            timestamp.to_string()
-        }
-    }
-
     fn on_item_click(&mut self, item: &HistoryItem, _window: &mut Window, cx: &mut Context<Self>) {
         self.selected_id = Some(item.id);
         cx.emit(HistoryItemClicked { item: item.clone() });
@@ -197,7 +178,10 @@ impl Render for HistoryPanel {
                             let verb = item.request.method.as_str();
                             let verb_color = crate::theme::method_color(item.request.method, theme);
                             let url = item.request.url.clone();
-                            let time = Self::format_relative_time(&item.timestamp);
+                            let time = crate::format::format_relative_time(
+                                &item.timestamp,
+                                chrono::Utc::now(),
+                            );
                             let item_clone = item.clone();
 
                             h_flex()

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod code_gen;
 mod code_snippet_panel;
 mod db;
 mod environment_manager;
+mod format;
 mod history_panel;
 mod http_client;
 mod menu_bar;

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -12,11 +12,12 @@ use crate::types::{HeaderType, HttpMethod, PredefinedHeader, RequestData, Respon
 use crate::url_params::{self, QueryParam};
 use crate::theme::METHOD_SELECT_WIDTH;
 
-/// Event emitted when a request is sent and response is received
+/// Event emitted when a request is sent and response is received.
+/// The response is `Arc`-shared so subscribers can store it without copying the body.
 #[derive(Clone)]
 pub struct RequestCompleted {
     pub request: RequestData,
-    pub response: ResponseData,
+    pub response: std::sync::Arc<ResponseData>,
 }
 
 /// Event emitted when the user asks to view the request as a code snippet.
@@ -252,8 +253,7 @@ impl RequestEditor {
         let method_index = self
             .method_select
             .read(cx)
-            .selected_index(cx)
-            .and_then(|idx| Some(idx.row))
+            .selected_index(cx).map(|idx| idx.row)
             .unwrap_or(0);
         let method = HttpMethod::all().get(method_index).copied().unwrap_or(HttpMethod::GET);
 
@@ -497,20 +497,20 @@ impl RequestEditor {
         cx: &mut Context<Self>,
     ) {
         // Only allow deletion of custom headers
-        if let Some(header) = self.headers.get(index) {
-            if matches!(header.header_type, HeaderType::Custom) {
-                self.headers.remove(index);
+        if let Some(header) = self.headers.get(index)
+            && matches!(header.header_type, HeaderType::Custom)
+        {
+            self.headers.remove(index);
 
-                // Check if there are any custom headers left
-                let has_custom_headers = self.headers.iter().any(|h| matches!(h.header_type, HeaderType::Custom));
+            // Check if there are any custom headers left
+            let has_custom_headers = self.headers.iter().any(|h| matches!(h.header_type, HeaderType::Custom));
 
-                // If no custom headers remain, add an empty one
-                if !has_custom_headers {
-                    self.add_custom_header_row(window, cx);
-                }
-
-                cx.notify();
+            // If no custom headers remain, add an empty one
+            if !has_custom_headers {
+                self.add_custom_header_row(window, cx);
             }
+
+            cx.notify();
         }
     }
 
@@ -520,13 +520,13 @@ impl RequestEditor {
 
         // Find Content-Length header and update it
         for header in &mut self.headers {
-            if let Some(predefined) = header.predefined {
-                if matches!(predefined, PredefinedHeader::ContentLength) {
-                    header.value_input.update(cx, |input, cx| {
-                        input.set_value(&content_length, window, cx);
-                    });
-                    break;
-                }
+            if let Some(predefined) = header.predefined
+                && matches!(predefined, PredefinedHeader::ContentLength)
+            {
+                header.value_input.update(cx, |input, cx| {
+                    input.set_value(&content_length, window, cx);
+                });
+                break;
             }
         }
     }
@@ -536,17 +536,17 @@ impl RequestEditor {
         // Find Content-Type header and update it
         let new_value = content_type.clone().unwrap_or_default();
         for header in &mut self.headers {
-            if let Some(predefined) = header.predefined {
-                if matches!(predefined, PredefinedHeader::ContentType) {
-                    // Update Content-Type value
-                    let value_to_set = new_value.clone();
-                    header.value_input.update(cx, |input, cx| {
-                        input.set_value(&value_to_set, window, cx);
-                    });
+            if let Some(predefined) = header.predefined
+                && matches!(predefined, PredefinedHeader::ContentType)
+            {
+                // Update Content-Type value
+                let value_to_set = new_value.clone();
+                header.value_input.update(cx, |input, cx| {
+                    input.set_value(&value_to_set, window, cx);
+                });
 
-                    log::debug!("Auto-updated Content-Type header to: {}", new_value);
-                    break;
-                }
+                log::debug!("Auto-updated Content-Type header to: {}", new_value);
+                break;
             }
         }
     }
@@ -955,7 +955,7 @@ impl RequestEditor {
                         this.loading = false;
                         cx.emit(RequestCompleted {
                             request,
-                            response: error_response,
+                            response: std::sync::Arc::new(error_response),
                         });
                         cx.notify();
                     })?;
@@ -983,7 +983,7 @@ impl RequestEditor {
                 this.loading = false;
                 cx.emit(RequestCompleted {
                     request,
-                    response: response_data,
+                    response: std::sync::Arc::new(response_data),
                 });
                 cx.notify();
             })?;

--- a/src/request_tab.rs
+++ b/src/request_tab.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::types::{BodyType, HeaderState, HistoryItem, HttpMethod, ParamState, RequestData, ResponseData};
 
 /// Represents a single request tab
@@ -6,8 +8,8 @@ pub struct RequestTab {
     pub id: usize,
     pub title: String,
     pub request: RequestData,
-    /// Response data for this tab
-    pub response: Option<ResponseData>,
+    /// Response data for this tab (shared, so tab switches never copy the body)
+    pub response: Option<Arc<ResponseData>>,
     // UI state (not persisted to database)
     pub params_state: Option<Vec<ParamState>>,
     pub headers_state: Option<Vec<HeaderState>>,

--- a/src/response_viewer.rs
+++ b/src/response_viewer.rs
@@ -1,6 +1,7 @@
 use gpui::prelude::FluentBuilder as _;
 use gpui::*;
 use gpui_component::{button::*, h_flex, input::*, v_flex, ActiveTheme as _};
+use std::sync::Arc;
 
 use crate::types::ResponseData;
 
@@ -42,7 +43,8 @@ fn extension_for_content_type(ct: &str) -> Option<String> {
 
 /// Response viewer panel
 pub struct ResponseViewer {
-    response: Option<ResponseData>,
+    /// Shared with the owning tab, so setting/reading never copies the body.
+    response: Option<Arc<ResponseData>>,
     body_display: Entity<InputState>,
     active_tab: usize,
     headers_scroll_handle: ScrollHandle,
@@ -69,7 +71,7 @@ impl ResponseViewer {
     /// Set response data
     pub fn set_response(
         &mut self,
-        response: ResponseData,
+        response: Arc<ResponseData>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -96,7 +98,7 @@ impl ResponseViewer {
     }
 
     /// Get current response data
-    pub fn get_response(&self) -> Option<ResponseData> {
+    pub fn get_response(&self) -> Option<Arc<ResponseData>> {
         self.response.clone()
     }
 
@@ -112,10 +114,9 @@ impl ResponseViewer {
 
     /// Save the (binary) response body to a file chosen via the OS dialog.
     fn save_binary(&mut self, _event: &gpui::ClickEvent, window: &mut Window, cx: &mut Context<Self>) {
-        let Some(response) = self.response.as_ref() else {
+        let Some(response) = self.response.clone() else {
             return;
         };
-        let bytes = response.body.clone();
         // Suggest a filename with the right extension based on Content-Type.
         let suggested = response
             .headers
@@ -130,10 +131,10 @@ impl ResponseViewer {
             .unwrap_or_else(|| std::path::PathBuf::from("."));
         let rx = cx.prompt_for_new_path(&dir, Some(&suggested));
         cx.spawn_in(window, async move |_this, _cx| {
-            if let Ok(Ok(Some(path))) = rx.await {
-                if let Err(e) = std::fs::write(&path, &bytes) {
-                    log::error!("Failed to save response to {:?}: {}", path, e);
-                }
+            if let Ok(Ok(Some(path))) = rx.await
+                && let Err(e) = std::fs::write(&path, &response.body)
+            {
+                log::error!("Failed to save response to {:?}: {}", path, e);
             }
         })
         .detach();
@@ -182,13 +183,13 @@ impl ResponseViewer {
                 .child(
                     div()
                         .text_sm()
-                        .child(format!("Time: {} ms", response.duration_ms)),
+                        .child(format!("Time: {}", crate::format::format_duration_ms(response.duration_ms))),
                 )
                 .when(!response.is_network_error(), |this| {
                     this.child(
                         div()
                             .text_sm()
-                            .child(format!("Size: {} bytes", response.body.len())),
+                            .child(format!("Size: {}", crate::format::format_size(response.body.len()))),
                     )
                 })
         } else {
@@ -307,12 +308,12 @@ impl Render for ResponseViewer {
                                 ),
                         )
                         .when(self.active_tab == 0, |this| {
-                            let resp_is_text = self.response.as_ref().map_or(true, |r| r.is_text);
+                            let resp_is_text = self.response.as_ref().is_none_or(|r| r.is_text);
                             if resp_is_text {
                                 let is_error = self
                                     .response
                                     .as_ref()
-                                    .map_or(false, |r| r.is_network_error());
+                                    .is_some_and(|r| r.is_network_error());
                                 this.child(
                                     div()
                                         .flex()
@@ -363,7 +364,11 @@ impl Render for ResponseViewer {
                                             div()
                                                 .text_xs()
                                                 .text_color(theme.muted_foreground)
-                                                .child(format!("{} · {} bytes", content_type, len)),
+                                                .child(format!(
+                                                    "{} · {}",
+                                                    content_type,
+                                                    crate::format::format_size(len)
+                                                )),
                                         )
                                         .child(
                                             Button::new("save-binary")

--- a/src/types.rs
+++ b/src/types.rs
@@ -69,7 +69,12 @@ impl PredefinedHeader {
     }
 }
 
-/// HTTP methods supported by the API client
+/// HTTP methods supported by the API client.
+///
+/// Variant names are all-caps on purpose: they match the wire format and are
+/// serialized by name into the history database, so renaming them would break
+/// previously saved requests.
+#[allow(clippy::upper_case_acronyms)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum HttpMethod {
     GET,
@@ -302,7 +307,7 @@ impl ResponseData {
 
     pub fn is_success(&self) -> bool {
         if let Some(status) = self.status {
-            status >= 200 && status < 300
+            (200..300).contains(&status)
         } else {
             false
         }
@@ -322,12 +327,15 @@ impl ResponseData {
 }
 
 /// History item stored in database
+///
+/// The response is shared via `Arc`: tabs and the viewer all hold the same
+/// allocation, so cloning an item never copies the (potentially large) body.
 #[derive(Debug, Clone)]
 pub struct HistoryItem {
     pub id: i64,
     pub timestamp: String,
     pub request: RequestData,
-    pub response: Option<ResponseData>,
+    pub response: Option<std::sync::Arc<ResponseData>>,
 }
 
 impl HistoryItem {
@@ -335,7 +343,7 @@ impl HistoryItem {
         id: i64,
         timestamp: String,
         request: RequestData,
-        response: Option<ResponseData>,
+        response: Option<std::sync::Arc<ResponseData>>,
     ) -> Self {
         Self {
             id,


### PR DESCRIPTION
## Summary

Three areas of improvement, built test-first (red → green) per TDD:

### UI — humanized display text (new `src/format.rs`, 13 unit tests)
- Response status bar: `Size: 1234567 bytes` → `Size: 1.18 MB`; `Time: 1520 ms` → `Time: 1.52 s` (over a minute: `1 m 30 s`, with rounding carry so `119999 ms` shows `2 m 0 s`, never `1 m 60 s`)
- History panel relative time: fixed `1 hours ago` / `1 days ago` pluralization; unparseable timestamps are shown unchanged; future timestamps (clock skew) render `just now`
- Formatting logic extracted into pure functions taking `now` as a parameter, so it is fully unit-testable

### Perf — stop deep-copying response bodies
- `ResponseData` is now shared via `Arc` end-to-end: `RequestCompleted` event, `RequestTab`, `HistoryItem`, `ResponseViewer`
- Previously every tab switch/save cloned the full response (headers + body `Vec<u8>`, potentially MBs, twice per switch); now it's a refcount bump
- `save_binary` writes the body without an extra copy

### Style — clippy 22 → 0
- Nested `if`s collapsed to let-chains (with hanging indentation from `--fix` manually corrected)
- `map_or`/`and_then` simplified to `is_none_or`/`is_some_and`/`map`, `(200..300).contains(&status)`, `paths.first()`
- `FormDataRowInputs` type alias for the form-data row tuple
- `HttpMethod` keeps all-caps variant names with `#[allow(clippy::upper_case_acronyms)]` — variant names are serialized into the history DB, renaming would break saved data (documented in a comment)

## Test plan

- [x] `cargo test` on Windows: **83 passed, 0 failed** (was 70 before; 13 new)
- [x] `cargo clippy --all-targets`: **0 warnings** (was 22)
- [ ] Visual check on Windows: status bar Size/Time text and history relative-time labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)