### PR TITLE
chore: sync crate version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4440,7 +4440,7 @@ checksum = "5da3b0203fd7ee5720aa0b5e790b591aa5d3f41c3ed2c34a3a393382198af2f7"
 
 [[package]]
 name = "poopman"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ edition = "2024"
 name = "poopman"
 description = "A Postman-like API client built with GPUI Component."
 publish = false
-version = "0.1.0"
+version = "0.3.0"
 
 [dependencies]
 anyhow = "1"
@@ -34,7 +34,7 @@ winresource = "0.1"
 name = "Poopman"
 identifier = "com.poopman.app"
 icon = ["assets/icons/logo.ico"]
-version = "0.1.0"
+version = "0.3.0"
 copyright = "Copyright (c) 2024"
 category = "Utility"
 short_description = "A Postman-like API client"


### PR DESCRIPTION
## Summary

`Cargo.toml` had been sitting at `version = "0.1.0"` since the beginning while release tags moved on to v0.3.0. This syncs both `[package].version` and `[package.metadata.bundle].version` to **0.3.0** (plus the corresponding `Cargo.lock` entry), so bundle metadata and anything reading the crate version now match the published release.

Going forward: bump these two fields as part of each release (before pushing the `v*` tag).

## Test plan

- [x] `cargo check` — clean, lockfile updated
- No code changes; nothing to verify visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)