### PR TITLE
feat: form-data body support in code snippet export

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ left, request editor on the top-right, response viewer on the bottom-right.
   active one from the Edit menu, and have them resolved at send time (and in code export).
 - **Code snippet export** — turn the current request into runnable code via the `</>`
   button: **cURL, Rust (reqwest), Python (Requests), JavaScript (Fetch), NodeJS (Axios),
-  Go (net/http)**, with Copy.
+  Go (net/http)**, with Copy. Raw and multipart form-data bodies both export.
 - **Tabs** — work on multiple requests at once.
 - **History** — every sent request is stored in SQLite; click to reload, or clear all.
 
@@ -111,7 +111,6 @@ src/
 
 ## Possible Future Enhancements
 
-- [ ] Form-data export in code snippets (currently Raw/None bodies only).
 - [ ] Request collections / folders.
 - [ ] Authentication presets (Bearer, Basic, OAuth).
 - [ ] Export / import collections (Postman format).

--- a/docs/superpowers/plans/2026-07-14-formdata-code-export.md
+++ b/docs/superpowers/plans/2026-07-14-formdata-code-export.md
@@ -1,0 +1,902 @@
+# Form-data Code Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** All six code-export targets (cURL, Rust, Python, JS Fetch, Node Axios, Go) generate real multipart form-data code instead of the current "not yet supported" NOTE comment, per `docs/superpowers/specs/2026-07-14-formdata-code-export-design.md`.
+
+**Architecture:** Everything happens in the pure module `src/code_gen.rs` (no UI/send-path changes). Two shared helpers (`form_rows`, `export_headers`) feed six per-target emitters. `export_headers` drops `Content-Type` whenever the body is `BodyType::FormData` — the pinned `multipart/form-data; boundary=<auto>` UI header must never be exported because each target's library generates its own boundary.
+
+**Tech Stack:** Rust; tests are plain `#[test]` in `code_gen::tests`.
+
+**Environment constraints (from CLAUDE.md/memory):**
+- WSL2 can run `cargo check` / `cargo clippy` but CANNOT link/test the crate.
+- Test gate (run from WSL): `pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test code_gen"` — expected: all tests pass.
+- Work on branch `feat/formdata-code-export` in the existing checkout `/mnt/e/code/poopman`. Do NOT use a git worktree: the Windows-side test command is hard-wired to `E:\code\poopman`.
+
+**Existing code you'll touch (read these spans first):**
+- `src/code_gen.rs:64-82` — `raw_body` / `form_data_present` (the latter gets deleted at the end)
+- `src/code_gen.rs:84-92` — `headers()` (deleted at the end, replaced by `export_headers`)
+- `src/code_gen.rs:158-349` — the six `gen_*` functions
+- `src/code_gen.rs:351-513` — tests (`get_req`/`post_json_req` fixture style)
+- Top-of-file imports: extend the existing `use crate::types::…` to include `FormDataRow, FormDataValue`.
+
+---
+
+### Task 1: Branch, shared helpers, cURL emitter
+
+**Files:**
+- Modify: `src/code_gen.rs` (imports, helpers, `gen_curl`, tests)
+
+- [ ] **Step 1: Create the branch**
+
+```bash
+cd /mnt/e/code/poopman
+git checkout -b feat/formdata-code-export
+```
+
+- [ ] **Step 2: Add the shared test fixture and failing cURL tests**
+
+In `code_gen::tests`, next to `post_json_req()`:
+
+```rust
+    /// POST with one text row, one file row, one disabled row, and the
+    /// UI-pinned multipart Content-Type header that must NOT be exported.
+    fn form_req() -> RequestData {
+        RequestData {
+            method: HttpMethod::POST,
+            url: "https://api.example.com/upload".to_string(),
+            headers: vec![
+                ("Accept".to_string(), "application/json".to_string()),
+                (
+                    "Content-Type".to_string(),
+                    "multipart/form-data; boundary=<auto>".to_string(),
+                ),
+            ],
+            body: BodyType::FormData(vec![
+                FormDataRow {
+                    enabled: true,
+                    key: "note".to_string(),
+                    value: FormDataValue::Text("hello world".to_string()),
+                },
+                FormDataRow {
+                    enabled: true,
+                    key: "avatar".to_string(),
+                    value: FormDataValue::File { path: "C:\\pics\\me.png".to_string() },
+                },
+                FormDataRow {
+                    enabled: false,
+                    key: "skipme".to_string(),
+                    value: FormDataValue::Text("nope".to_string()),
+                },
+            ]),
+        }
+    }
+
+    #[test]
+    fn curl_form_data_uses_form_flags() {
+        let out = generate(CodeTarget::Curl, &form_req());
+        assert!(out.contains("--form-string 'note=hello world'"));
+        assert!(out.contains("--form 'avatar=@\"C:\\pics\\me.png\"'"));
+        assert!(!out.contains("skipme"));
+        assert!(!out.contains("not yet supported"));
+        assert!(!out.contains("Content-Type"), "boundary header must not export");
+        assert!(out.contains("--header 'Accept: application/json'"));
+        assert!(!out.contains("--data"));
+    }
+
+    #[test]
+    fn curl_form_text_leading_at_stays_literal() {
+        // --form-string never does curl's @file / <file expansion.
+        let mut req = form_req();
+        req.body = BodyType::FormData(vec![FormDataRow {
+            enabled: true,
+            key: "handle".to_string(),
+            value: FormDataValue::Text("@ada".to_string()),
+        }]);
+        let out = generate(CodeTarget::Curl, &req);
+        assert!(out.contains("--form-string 'handle=@ada'"));
+    }
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test code_gen"`
+Expected: the two new tests FAIL (output still contains the NOTE line, no `--form`).
+
+- [ ] **Step 4: Implement helpers + cURL**
+
+Top-of-file: extend the types import to
+`use crate::types::{BodyType, FormDataRow, FormDataValue, RequestData};`
+(keep whatever else is already imported there).
+
+Replace `form_data_present` (keep it for now — other generators still call it; it goes away in Task 7) by ADDING these two helpers next to it:
+
+```rust
+/// Enabled, non-blank-key form-data rows — the rows that export.
+fn form_rows(req: &RequestData) -> Vec<&FormDataRow> {
+    match &req.body {
+        BodyType::FormData(rows) => rows
+            .iter()
+            .filter(|r| r.enabled && !r.key.trim().is_empty())
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Headers to export: non-blank keys, minus Content-Type for form-data
+/// bodies — the UI pins `multipart/form-data; boundary=<auto>` on such
+/// requests, and each target's library must generate its own boundary.
+fn export_headers(req: &RequestData) -> Vec<(&str, &str)> {
+    let skip_content_type = matches!(&req.body, BodyType::FormData(_));
+    req.headers
+        .iter()
+        .filter(|(k, _)| !k.trim().is_empty())
+        .filter(|(k, _)| !(skip_content_type && k.eq_ignore_ascii_case("content-type")))
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect()
+}
+```
+
+Replace `gen_curl` entirely:
+
+```rust
+fn gen_curl(req: &RequestData) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    lines.push(format!(
+        "curl --location --request {} '{}'",
+        req.method.as_str(),
+        shell_single(&req.url)
+    ));
+    for (k, v) in export_headers(req) {
+        lines.push(format!("  --header '{}: {}'", shell_single(k), shell_single(v)));
+    }
+    for row in form_rows(req) {
+        match &row.value {
+            FormDataValue::Text(v) => lines.push(format!(
+                "  --form-string '{}={}'",
+                shell_single(&row.key),
+                shell_single(v)
+            )),
+            FormDataValue::File { path } => lines.push(format!(
+                "  --form '{}=@\"{}\"'",
+                shell_single(&row.key),
+                shell_single(path)
+            )),
+        }
+    }
+    if let Some(body) = raw_body(req) {
+        lines.push(format!("  --data '{}'", shell_single(&body)));
+    }
+    lines.join(" \\\n")
+}
+```
+
+- [ ] **Step 5: Compile-check in WSL, then run the Windows test gate**
+
+Run: `cargo check 2>&1 | tail -5`
+Expected: no errors (warnings about the still-unused helpers are OK only if none — `form_rows`/`export_headers` are already used by gen_curl, `headers`/`form_data_present` still used by other generators, so expect a clean check).
+
+Run: `pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test code_gen"`
+Expected: ALL tests pass, including the two new ones (existing `curl_*` tests must stay green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/code_gen.rs
+git commit -m "feat(export): multipart form-data in cURL snippets
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Rust (reqwest) emitter
+
+**Files:**
+- Modify: `src/code_gen.rs` (`gen_rust`, tests)
+
+- [ ] **Step 1: Add the failing test**
+
+```rust
+    #[test]
+    fn rust_form_data_builds_multipart() {
+        let out = generate(CodeTarget::RustReqwest, &form_req());
+        assert!(out.contains("use reqwest::blocking::multipart;"));
+        assert!(out.contains(".text(\"note\", \"hello world\")"));
+        assert!(out.contains(".file(\"avatar\", \"C:\\\\pics\\\\me.png\")?"));
+        assert!(out.contains(".multipart(form)"));
+        assert!(!out.contains(".body("));
+        assert!(!out.contains("skipme"));
+        assert!(!out.contains("Content-Type"));
+        assert!(!out.contains("not yet supported"));
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test code_gen"`
+Expected: `rust_form_data_builds_multipart` FAILS.
+
+- [ ] **Step 3: Replace `gen_rust`**
+
+```rust
+fn gen_rust(req: &RequestData) -> String {
+    let form = form_rows(req);
+    let mut s = String::new();
+    s.push_str("use reqwest::blocking::Client;\n");
+    if !form.is_empty() {
+        s.push_str("use reqwest::blocking::multipart;\n");
+    }
+    s.push_str("use reqwest::header::{HeaderMap, HeaderValue};\n\n");
+    s.push_str("fn main() -> Result<(), Box<dyn std::error::Error>> {\n");
+    s.push_str("    let client = Client::new();\n\n");
+    s.push_str("    let mut headers = HeaderMap::new();\n");
+    for (k, v) in export_headers(req) {
+        s.push_str(&format!(
+            "    headers.insert(\"{}\", HeaderValue::from_str(\"{}\")?);\n",
+            dq(k),
+            dq(v)
+        ));
+    }
+    s.push('\n');
+    if !form.is_empty() {
+        let mut chain: Vec<String> = vec!["    let form = multipart::Form::new()".to_string()];
+        for row in &form {
+            match &row.value {
+                FormDataValue::Text(v) => chain.push(format!(
+                    "        .text(\"{}\", \"{}\")",
+                    dq(&row.key),
+                    dq(v)
+                )),
+                // .file() reads the file at send time; `?` bubbles its io::Result.
+                FormDataValue::File { path } => chain.push(format!(
+                    "        .file(\"{}\", \"{}\")?",
+                    dq(&row.key),
+                    dq(path)
+                )),
+            }
+        }
+        s.push_str(&chain.join("\n"));
+        s.push_str(";\n\n");
+    }
+    s.push_str(&format!(
+        "    let response = client\n        .request(reqwest::Method::{}, \"{}\")\n        .headers(headers)\n",
+        req.method.as_str(),
+        dq(&req.url)
+    ));
+    if !form.is_empty() {
+        s.push_str("        .multipart(form)\n");
+    } else if let Some(body) = raw_body(req) {
+        s.push_str(&format!("        .body({})\n", rust_raw(&body)));
+    }
+    s.push_str("        .send()?;\n\n");
+    s.push_str("    println!(\"{}\", response.text()?);\n");
+    s.push_str("    Ok(())\n");
+    s.push_str("}\n");
+    s
+}
+```
+
+- [ ] **Step 4: Run the test gate**
+
+Run: `pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test code_gen"`
+Expected: ALL pass (existing `rust_generates_blocking_client_and_escaped_body` and `multiline_body_stays_readable_not_escaped` stay green — raw-body path is untouched).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/code_gen.rs
+git commit -m "feat(export): multipart form-data in Rust reqwest snippets
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Python (Requests) emitter
+
+**Files:**
+- Modify: `src/code_gen.rs` (`gen_python`, tests — REPLACES the old NOTE test)
+
+- [ ] **Step 1: Replace the old NOTE test and add the new ones**
+
+DELETE the test `form_data_adds_note_comment` (it asserts the NOTE that this task removes). ADD:
+
+```rust
+    #[test]
+    fn python_form_data_uses_files_dict() {
+        let out = generate(CodeTarget::PythonRequests, &form_req());
+        assert!(out.contains("\"note\": (None, \"hello world\"),"));
+        assert!(out.contains("\"avatar\": open(\"C:\\\\pics\\\\me.png\", \"rb\"),"));
+        assert!(out.contains("files=files"));
+        assert!(!out.contains("data="));
+        assert!(!out.contains("skipme"));
+        assert!(!out.contains("Content-Type"));
+        assert!(!out.contains("not yet supported"));
+    }
+
+    #[test]
+    fn python_all_text_form_still_multipart() {
+        // Without files=, requests would send urlencoded — the (None, value)
+        // tuple form forces a real multipart body even for text-only forms.
+        let mut req = form_req();
+        req.body = BodyType::FormData(vec![FormDataRow {
+            enabled: true,
+            key: "a".to_string(),
+            value: FormDataValue::Text("1".to_string()),
+        }]);
+        let out = generate(CodeTarget::PythonRequests, &req);
+        assert!(out.contains("files = {"));
+        assert!(out.contains("\"a\": (None, \"1\"),"));
+        assert!(out.contains("files=files"));
+        assert!(!out.contains("payload"));
+    }
+```
+
+- [ ] **Step 2: Run to verify the new tests fail**
+
+Run: `pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test code_gen"`
+Expected: both new tests FAIL; everything else passes.
+
+- [ ] **Step 3: Replace `gen_python`**
+
+```rust
+fn gen_python(req: &RequestData) -> String {
+    let form = form_rows(req);
+    let mut s = String::new();
+    s.push_str("import requests\n\n");
+    s.push_str(&format!("url = \"{}\"\n\n", dq(&req.url)));
+    let hs = export_headers(req);
+    if hs.is_empty() {
+        s.push_str("headers = {}\n");
+    } else {
+        s.push_str("headers = {\n");
+        for (k, v) in hs {
+            s.push_str(&format!("    \"{}\": \"{}\",\n", dq(k), dq(v)));
+        }
+        s.push_str("}\n");
+    }
+    let body = raw_body(req);
+    if let Some(b) = &body {
+        s.push_str(&format!("payload = {}\n", py_string(b)));
+    }
+    if !form.is_empty() {
+        // (None, value) tuples force multipart encoding even for text-only
+        // forms; a bare data= dict would send x-www-form-urlencoded instead.
+        s.push_str("files = {\n");
+        for row in &form {
+            match &row.value {
+                FormDataValue::Text(v) => s.push_str(&format!(
+                    "    \"{}\": (None, \"{}\"),\n",
+                    dq(&row.key),
+                    dq(v)
+                )),
+                FormDataValue::File { path } => s.push_str(&format!(
+                    "    \"{}\": open(\"{}\", \"rb\"),\n",
+                    dq(&row.key),
+                    dq(path)
+                )),
+            }
+        }
+        s.push_str("}\n");
+    }
+    s.push('\n');
+    if !form.is_empty() {
+        s.push_str(&format!(
+            "response = requests.request(\"{}\", url, headers=headers, files=files)\n",
+            req.method.as_str()
+        ));
+    } else if body.is_some() {
+        s.push_str(&format!(
+            "response = requests.request(\"{}\", url, headers=headers, data=payload)\n",
+            req.method.as_str()
+        ));
+    } else {
+        s.push_str(&format!(
+            "response = requests.request(\"{}\", url, headers=headers)\n",
+            req.method.as_str()
+        ));
+    }
+    s.push_str("print(response.text)\n");
+    s
+}
+```
+
+- [ ] **Step 4: Run the test gate**
+
+Run: `pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test code_gen"`
+Expected: ALL pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/code_gen.rs
+git commit -m "feat(export): multipart form-data in Python Requests snippets
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: JavaScript (Fetch) emitter + `file_basename` helper
+
+**Files:**
+- Modify: `src/code_gen.rs` (`gen_fetch`, new helper, tests)
+
+- [ ] **Step 1: Add the failing tests**
+
+```rust
+    #[test]
+    fn fetch_form_data_appends_fields() {
+        let out = generate(CodeTarget::JavaScriptFetch, &form_req());
+        assert!(out.contains("const formdata = new FormData();"));
+        assert!(out.contains("formdata.append(\"note\", \"hello world\");"));
+        // Browsers can't open local paths — the file row is a commented hint
+        // that carries the field name and the file's basename.
+        assert!(out.contains("// formdata.append(\"avatar\", fileInput.files[0], \"me.png\");"));
+        assert!(out.contains("body: formdata,"));
+        assert!(!out.contains("skipme"));
+        assert!(!out.contains("Content-Type"));
+        assert!(!out.contains("not yet supported"));
+    }
+
+    #[test]
+    fn file_basename_handles_both_separators() {
+        assert_eq!(file_basename("C:\\pics\\me.png"), "me.png");
+        assert_eq!(file_basename("/home/u/me.png"), "me.png");
+        assert_eq!(file_basename("me.png"), "me.png");
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test code_gen"`
+Expected: both FAIL (`file_basename` doesn't compile yet — that's the expected "fails because it doesn't exist" state; comment out the second test if it blocks compilation of the rest, then restore it in Step 3).
+
+- [ ] **Step 3: Implement**
+
+Helper next to `py_string`/`js_string`:
+
+```rust
+/// Final path component of a local file path, tolerating / and \ separators
+/// (paths come from the form-data UI and may be Windows- or POSIX-style).
+fn file_basename(path: &str) -> &str {
+    path.rsplit(['/', '\\']).next().unwrap_or(path)
+}
+```
+
+Replace `gen_fetch`:
+
+```rust
+fn gen_fetch(req: &RequestData) -> String {
+    let form = form_rows(req);
+    let mut s = String::new();
+    s.push_str("const myHeaders = new Headers();\n");
+    for (k, v) in export_headers(req) {
+        s.push_str(&format!("myHeaders.append(\"{}\", \"{}\");\n", dq(k), dq(v)));
+    }
+    if !form.is_empty() {
+        s.push_str("\nconst formdata = new FormData();\n");
+        for row in &form {
+            match &row.value {
+                FormDataValue::Text(v) => s.push_str(&format!(
+                    "formdata.append(\"{}\", \"{}\");\n",
+                    dq(&row.key),
+                    dq(v)
+                )),
+                FormDataValue::File { path } => s.push_str(&format!(
+                    "// Browsers can't read local paths — wire this to an <input type=\"file\">:\n// formdata.append(\"{}\", fileInput.files[0], \"{}\");\n",
+                    dq(&row.key),
+                    dq(file_basename(path))
+                )),
+            }
+        }
+    }
+    s.push_str("\nconst requestOptions = {\n");
+    s.push_str(&format!("  method: \"{}\",\n", req.method.as_str()));
+    s.push_str("  headers: myHeaders,\n");
+    if !form.is_empty() {
+        s.push_str("  body: formdata,\n");
+    } else if let Some(b) = raw_body(req) {
+        s.push_str(&format!("  body: {},\n", js_string(&b)));
+    }
+    s.push_str("  redirect: \"follow\",\n");
+    s.push_str("};\n\n");
+    s.push_str(&format!("fetch(\"{}\", requestOptions)\n", dq(&req.url)));
+    s.push_str("  .then((response) => response.text())\n");
+    s.push_str("  .then((result) => console.log(result))\n");
+    s.push_str("  .catch((error) => console.error(error));\n");
+    s
+}
+```
+
+- [ ] **Step 4: Run the test gate**
+
+Run: `pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test code_gen"`
+Expected: ALL pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/code_gen.rs
+git commit -m "feat(export): multipart form-data in JS fetch snippets
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: NodeJS (Axios) emitter
+
+**Files:**
+- Modify: `src/code_gen.rs` (`gen_axios`, tests)
+
+- [ ] **Step 1: Add the failing test**
+
+```rust
+    #[test]
+    fn axios_form_data_uses_form_data_package() {
+        let out = generate(CodeTarget::NodeAxios, &form_req());
+        assert!(out.contains("const FormData = require(\"form-data\");"));
+        assert!(out.contains("const fs = require(\"fs\");"));
+        assert!(out.contains("formdata.append(\"note\", \"hello world\");"));
+        assert!(out.contains(
+            "formdata.append(\"avatar\", fs.createReadStream(\"C:\\\\pics\\\\me.png\"));"
+        ));
+        assert!(out.contains("...formdata.getHeaders(),"));
+        assert!(out.contains("data: formdata,"));
+        assert!(!out.contains("skipme"));
+        assert!(!out.contains("\"Content-Type\""));
+        assert!(!out.contains("not yet supported"));
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test code_gen"`
+Expected: the new test FAILS.
+
+- [ ] **Step 3: Replace `gen_axios`**
+
+```rust
+fn gen_axios(req: &RequestData) -> String {
+    let form = form_rows(req);
+    let has_file = form
+        .iter()
+        .any(|r| matches!(r.value, FormDataValue::File { .. }));
+    let mut s = String::new();
+    s.push_str("const axios = require(\"axios\");\n");
+    if !form.is_empty() {
+        s.push_str("const FormData = require(\"form-data\");\n");
+        if has_file {
+            s.push_str("const fs = require(\"fs\");\n");
+        }
+        s.push_str("\nconst formdata = new FormData();\n");
+        for row in &form {
+            match &row.value {
+                FormDataValue::Text(v) => s.push_str(&format!(
+                    "formdata.append(\"{}\", \"{}\");\n",
+                    dq(&row.key),
+                    dq(v)
+                )),
+                FormDataValue::File { path } => s.push_str(&format!(
+                    "formdata.append(\"{}\", fs.createReadStream(\"{}\"));\n",
+                    dq(&row.key),
+                    dq(path)
+                )),
+            }
+        }
+    }
+    s.push('\n');
+    s.push_str("const config = {\n");
+    s.push_str(&format!("  method: \"{}\",\n", req.method.as_str().to_lowercase()));
+    s.push_str(&format!("  url: \"{}\",\n", dq(&req.url)));
+    let hs = export_headers(req);
+    if !form.is_empty() {
+        // form-data's getHeaders() provides the multipart Content-Type with
+        // the generated boundary; exported headers merge after it.
+        s.push_str("  headers: {\n    ...formdata.getHeaders(),\n");
+        for (k, v) in hs {
+            s.push_str(&format!("    \"{}\": \"{}\",\n", dq(k), dq(v)));
+        }
+        s.push_str("  },\n");
+    } else if hs.is_empty() {
+        s.push_str("  headers: {},\n");
+    } else {
+        s.push_str("  headers: {\n");
+        for (k, v) in hs {
+            s.push_str(&format!("    \"{}\": \"{}\",\n", dq(k), dq(v)));
+        }
+        s.push_str("  },\n");
+    }
+    if !form.is_empty() {
+        s.push_str("  data: formdata,\n");
+    } else if let Some(b) = raw_body(req) {
+        s.push_str(&format!("  data: {},\n", js_string(&b)));
+    }
+    s.push_str("};\n\n");
+    s.push_str("axios(config)\n");
+    s.push_str("  .then((response) => {\n");
+    s.push_str("    console.log(JSON.stringify(response.data));\n");
+    s.push_str("  })\n");
+    s.push_str("  .catch((error) => {\n");
+    s.push_str("    console.log(error);\n");
+    s.push_str("  });\n");
+    s
+}
+```
+
+Note the emission-order change: the old version printed `const axios = ...` then a blank line immediately; the new version prints the form block between them, then one blank line before `const config`. The old no-form output shape stays byte-identical (`const axios...` + `\n` + blank + `const config`), keeping the existing `axios_lowercases_method` test green.
+
+- [ ] **Step 4: Run the test gate**
+
+Run: `pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test code_gen"`
+Expected: ALL pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/code_gen.rs
+git commit -m "feat(export): multipart form-data in Node axios snippets
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Go (net/http) emitter
+
+**Files:**
+- Modify: `src/code_gen.rs` (`gen_go`, tests)
+
+- [ ] **Step 1: Add the failing test**
+
+```rust
+    #[test]
+    fn go_form_data_uses_multipart_writer() {
+        let out = generate(CodeTarget::GoNetHttp, &form_req());
+        assert!(out.contains("\"bytes\""));
+        assert!(out.contains("\"mime/multipart\""));
+        assert!(out.contains("\"os\""));
+        assert!(out.contains("\"path/filepath\""));
+        assert!(out.contains("writer := multipart.NewWriter(payload)"));
+        assert!(out.contains("_ = writer.WriteField(\"note\", \"hello world\")"));
+        assert!(out.contains("file0, err := os.Open(\"C:\\\\pics\\\\me.png\")"));
+        assert!(out.contains(
+            "part0, err := writer.CreateFormFile(\"avatar\", filepath.Base(\"C:\\\\pics\\\\me.png\"))"
+        ));
+        assert!(out.contains("req.Header.Set(\"Content-Type\", writer.FormDataContentType())"));
+        assert!(out.contains("http.NewRequest(method, url, payload)"));
+        assert!(!out.contains("skipme"));
+        assert!(!out.contains("req.Header.Add(\"Content-Type\""));
+        assert!(!out.contains("not yet supported"));
+        assert!(!out.contains("\"strings\""));
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test code_gen"`
+Expected: the new test FAILS.
+
+- [ ] **Step 3: Replace `gen_go`**
+
+```rust
+fn gen_go(req: &RequestData) -> String {
+    let form = form_rows(req);
+    let has_file = form
+        .iter()
+        .any(|r| matches!(r.value, FormDataValue::File { .. }));
+    let body = raw_body(req);
+    let mut s = String::new();
+    s.push_str("package main\n\n");
+    s.push_str("import (\n");
+    if !form.is_empty() {
+        s.push_str("\t\"bytes\"\n");
+    }
+    s.push_str("\t\"fmt\"\n");
+    s.push_str("\t\"io\"\n");
+    if !form.is_empty() {
+        s.push_str("\t\"mime/multipart\"\n");
+    }
+    s.push_str("\t\"net/http\"\n");
+    if has_file {
+        s.push_str("\t\"os\"\n");
+        s.push_str("\t\"path/filepath\"\n");
+    }
+    if form.is_empty() && body.is_some() {
+        s.push_str("\t\"strings\"\n");
+    }
+    s.push_str(")\n\n");
+    s.push_str("func main() {\n");
+    s.push_str(&format!("\turl := \"{}\"\n", dq(&req.url)));
+    s.push_str(&format!("\tmethod := \"{}\"\n\n", req.method.as_str()));
+    if !form.is_empty() {
+        s.push_str("\tpayload := &bytes.Buffer{}\n");
+        s.push_str("\twriter := multipart.NewWriter(payload)\n");
+        let mut file_idx = 0usize;
+        for row in &form {
+            match &row.value {
+                FormDataValue::Text(v) => s.push_str(&format!(
+                    "\t_ = writer.WriteField(\"{}\", \"{}\")\n",
+                    dq(&row.key),
+                    dq(v)
+                )),
+                FormDataValue::File { path } => {
+                    s.push_str(&format!(
+                        "\tfile{i}, err := os.Open(\"{p}\")\n\tif err != nil {{\n\t\tfmt.Println(err)\n\t\treturn\n\t}}\n",
+                        i = file_idx,
+                        p = dq(path)
+                    ));
+                    s.push_str(&format!(
+                        "\tpart{i}, err := writer.CreateFormFile(\"{k}\", filepath.Base(\"{p}\"))\n\tif err != nil {{\n\t\tfmt.Println(err)\n\t\treturn\n\t}}\n",
+                        i = file_idx,
+                        k = dq(&row.key),
+                        p = dq(path)
+                    ));
+                    s.push_str(&format!(
+                        "\t_, err = io.Copy(part{i}, file{i})\n\tfile{i}.Close()\n\tif err != nil {{\n\t\tfmt.Println(err)\n\t\treturn\n\t}}\n",
+                        i = file_idx
+                    ));
+                    file_idx += 1;
+                }
+            }
+        }
+        s.push_str("\tif err := writer.Close(); err != nil {\n\t\tfmt.Println(err)\n\t\treturn\n\t}\n\n");
+        s.push_str("\tclient := &http.Client{}\n");
+        s.push_str("\treq, err := http.NewRequest(method, url, payload)\n");
+    } else if let Some(b) = &body {
+        // Go raw string literal in backticks; backticks can't be escaped, so fall
+        // back to a quoted Go string if the body itself contains a backtick.
+        if b.contains('`') {
+            s.push_str(&format!("\tpayload := strings.NewReader(\"{}\")\n\n", dq(b)));
+        } else {
+            s.push_str(&format!("\tpayload := strings.NewReader(`{}`)\n\n", b));
+        }
+        s.push_str("\tclient := &http.Client{}\n");
+        s.push_str("\treq, err := http.NewRequest(method, url, payload)\n");
+    } else {
+        s.push_str("\tclient := &http.Client{}\n");
+        s.push_str("\treq, err := http.NewRequest(method, url, nil)\n");
+    }
+    s.push_str("\tif err != nil {\n\t\tfmt.Println(err)\n\t\treturn\n\t}\n");
+    for (k, v) in export_headers(req) {
+        s.push_str(&format!("\treq.Header.Add(\"{}\", \"{}\")\n", dq(k), dq(v)));
+    }
+    if !form.is_empty() {
+        s.push_str("\treq.Header.Set(\"Content-Type\", writer.FormDataContentType())\n");
+    }
+    s.push('\n');
+    s.push_str("\tres, err := client.Do(req)\n");
+    s.push_str("\tif err != nil {\n\t\tfmt.Println(err)\n\t\treturn\n\t}\n");
+    s.push_str("\tdefer res.Body.Close()\n\n");
+    s.push_str("\tbody, err := io.ReadAll(res.Body)\n");
+    s.push_str("\tif err != nil {\n\t\tfmt.Println(err)\n\t\treturn\n\t}\n");
+    s.push_str("\tfmt.Println(string(body))\n");
+    s.push_str("}\n");
+    s
+}
+```
+
+Note on the pre-file `err` variable: the first file block introduces `err` via `file0, err := os.Open(...)` — `:=` is legal because `file0` is new. A form with ONLY text fields declares no `err` before `req, err := http.NewRequest` (also `:=`, `req` is new). Both shapes compile.
+
+- [ ] **Step 4: Run the test gate**
+
+Run: `pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test code_gen"`
+Expected: ALL pass (existing `go_uses_backtick_body_and_strings_import` / `go_uses_nil_body_without_strings_import` stay green).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/code_gen.rs
+git commit -m "feat(export): multipart form-data in Go net/http snippets
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Cleanup, edge-case tests, docs
+
+**Files:**
+- Modify: `src/code_gen.rs` (delete dead helpers, module doc, tests)
+- Modify: `README.md`
+
+- [ ] **Step 1: Add the edge-case tests**
+
+```rust
+    #[test]
+    fn disabled_only_form_data_exports_like_no_body() {
+        let mut req = form_req();
+        req.body = BodyType::FormData(vec![FormDataRow {
+            enabled: false,
+            key: "x".to_string(),
+            value: FormDataValue::Text("y".to_string()),
+        }]);
+        let curl = generate(CodeTarget::Curl, &req);
+        assert!(!curl.contains("--form"));
+        assert!(!curl.contains("--data"));
+        // The pinned multipart Content-Type is skipped for ANY form-data body —
+        // exporting it without a matching body would produce a broken request.
+        assert!(!curl.contains("Content-Type"));
+        let go = generate(CodeTarget::GoNetHttp, &req);
+        assert!(go.contains("http.NewRequest(method, url, nil)"));
+    }
+
+    #[test]
+    fn raw_body_still_exports_content_type() {
+        // Control: the Content-Type skip must not leak to raw bodies.
+        let out = generate(CodeTarget::Curl, &post_json_req());
+        assert!(out.contains("--header 'Content-Type: application/json'"));
+    }
+```
+
+- [ ] **Step 2: Delete the dead helpers**
+
+Remove `form_data_present` (`src/code_gen.rs:79-82` in the pre-change numbering) and the old `headers()` function — every generator now uses `export_headers`/`form_rows`. `cargo check` must come back clean with no `dead_code` warnings.
+
+- [ ] **Step 3: Update the module doc**
+
+Replace the module-doc sentence at `src/code_gen.rs:5` (`//! v1 supports \`None\` and \`Raw\` request bodies across all targets. \`FormData\` …`) with:
+
+```rust
+//! Supports `None`, `Raw`, and multipart `FormData` bodies across all targets.
+//! Form-data exports skip the UI-pinned Content-Type header — each target's
+//! HTTP library generates its own multipart boundary.
+```
+
+(Keep the surrounding module-doc lines as they are.)
+
+- [ ] **Step 4: Update README**
+
+In `README.md`:
+- Under **Possible Future Enhancements**, delete the line
+  `- [ ] Form-data export in code snippets (currently Raw/None bodies only).`
+- In the **Features** bullet for code snippet export, append a sentence so it reads:
+  `- **Code snippet export** — turn the current request into runnable code via the \`</>\` button: **cURL, Rust (reqwest), Python (Requests), JavaScript (Fetch), NodeJS (Axios), Go (net/http)**, with Copy. Raw and multipart form-data bodies both export.`
+
+- [ ] **Step 5: Run checks**
+
+Run: `cargo check 2>&1 | tail -3` (WSL) — expected: clean, no warnings.
+Run: `cargo clippy 2>&1 | tail -3` (WSL) — expected: no new warnings.
+Run: `pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test code_gen"`
+Expected: ALL pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/code_gen.rs README.md
+git commit -m "refactor(export): drop dead form-data helpers, update docs
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Full suite + PR
+
+- [ ] **Step 1: Run the FULL test suite on Windows**
+
+Run: `pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test"`
+Expected: all crate tests pass (db, variables, url_params, curl_import, format, … — not just code_gen).
+
+- [ ] **Step 2: Push and open the PR**
+
+```bash
+git push -u origin feat/formdata-code-export
+gh pr create --title "feat: form-data body support in code snippet export" --body "$(cat <<'EOF'
+All six code-export targets (cURL, Rust reqwest, Python Requests, JS fetch, Node axios, Go net/http) now generate real multipart form-data code instead of a "not yet supported" note.
+
+Spec: docs/superpowers/specs/2026-07-14-formdata-code-export-design.md
+
+- Only enabled rows with non-blank keys export; disabled-only forms export like a body-less request.
+- The UI-pinned `multipart/form-data; boundary=<auto>` Content-Type header is skipped for form-data bodies in every target — each library generates its own boundary.
+- cURL text fields use `--form-string` (immune to `@`/`<` file expansion); Python uses `(None, value)` file-tuples so text-only forms still send multipart; browser fetch emits a commented `fileInput.files[0]` placeholder for file fields; axios merges `formdata.getHeaders()`; Go indexes `fileN`/`partN` per file row.
+- Pure `src/code_gen.rs` change, fully unit-tested (`cargo test code_gen`).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Report the PR URL to the user (via Telegram — they're on mobile)**

--- a/docs/superpowers/specs/2026-07-14-formdata-code-export-design.md
+++ b/docs/superpowers/specs/2026-07-14-formdata-code-export-design.md
@@ -1,0 +1,157 @@
+# Spec: form-data body support in code snippet export
+
+Date: 2026-07-14
+Status: Approved (design confirmed by user via Telegram; B/Ctrl-Tab and C/Ctrl-L deferred)
+
+## Goal
+
+`src/code_gen.rs` currently emits a `NOTE: form-data body is not yet supported`
+comment for all six targets when the request body is multipart form-data.
+Replace that with real, runnable multipart code in every target:
+cURL, Rust (reqwest), Python (Requests), JavaScript (Fetch), NodeJS (Axios),
+Go (net/http).
+
+## Scope decisions
+
+- **Rows exported:** only rows with `enabled == true` and a non-blank key.
+  A form-data body whose rows are all disabled/blank exports like `BodyType::None`.
+- **Content-Type header is skipped** (case-insensitive match) in ALL targets
+  when a non-empty form-data body is present. The UI pins a read-only
+  `multipart/form-data; boundary=<auto>` header on the request; exporting it
+  verbatim would break the request because each library must generate its own
+  boundary. Raw/None bodies keep the existing header pass-through.
+- **Variables:** `generate()` receives an already-resolved `RequestData`
+  (resolution happens upstream, unchanged).
+- **File fields embed the local path** the user typed in the Form-data UI.
+  That path is machine-specific by nature — same behavior as Postman's codegen.
+- Out of scope: Ctrl+Tab/Ctrl+L shortcuts (deferred), snippet UI changes
+  (panel already re-generates on demand), send-path changes (real multipart
+  sending shipped earlier).
+
+## Shared plumbing (`src/code_gen.rs`)
+
+Replace `form_data_present()` with:
+
+```rust
+/// Enabled, non-blank-key form-data rows — the rows that export.
+fn form_rows(req: &RequestData) -> Vec<&FormDataRow> // empty vec unless BodyType::FormData
+```
+
+Add a small helper for header emission:
+
+```rust
+/// Headers to export: all non-blank headers, minus Content-Type when a
+/// non-empty form-data body is present (each target's library generates
+/// its own multipart boundary).
+fn export_headers(req: &RequestData) -> Vec<(&str, &str)>
+```
+
+All six generators switch from `headers(req)` to `export_headers(req)` and
+drop their NOTE lines. Existing escaping helpers are reused: `shell_single`
+for cURL, `dq` for double-quoted contexts (also correct for Windows paths —
+`C:\x` → `C:\\x`).
+
+## Per-target emission (file field key `f`, path `p`; text field key `k`, value `v`)
+
+**cURL** — text fields use `--form-string` (immune to curl's `@`/`<`
+leading-char file expansion); file fields use `--form` with `@`:
+
+```
+  --form-string 'k=v'
+  --form 'f=@"p"'         (p shell-single-escaped inside the double quotes)
+```
+
+**Rust (reqwest, blocking — matches existing style)** — add
+`use reqwest::blocking::multipart;`; build before the request:
+
+```rust
+let form = multipart::Form::new()
+    .text("k", "v")
+    .file("f", "p")?;
+```
+
+and attach with `.multipart(form)` instead of `.body(...)`.
+
+**Python (Requests)** — a single `files` dict forces multipart even when all
+fields are text (bare `data=` alone would send urlencoded):
+
+```python
+files = {
+    "k": (None, "v"),
+    "f": open("p", "rb"),
+}
+response = requests.request("POST", url, headers=headers, files=files)
+```
+
+**JavaScript (Fetch)** — browser JS cannot open a local path; file fields
+emit a commented placeholder:
+
+```js
+const formdata = new FormData();
+formdata.append("k", "v");
+// Browsers can't read local paths — wire this to an <input type="file">:
+// formdata.append("f", fileInput.files[0], "basename-of-p");
+```
+
+`body: formdata` in requestOptions (no Content-Type header appended).
+
+**NodeJS (Axios)** — `form-data` package:
+
+```js
+const FormData = require("form-data");
+const fs = require("fs");
+const formdata = new FormData();
+formdata.append("k", "v");
+formdata.append("f", fs.createReadStream("p"));
+```
+
+config gets `data: formdata` and
+`headers: { ...formdata.getHeaders(), /* other exported headers */ }`.
+
+**Go (net/http)** — `bytes.Buffer` + `mime/multipart` (new imports: `bytes`,
+`mime/multipart`, `os`, `path/filepath`; `io` already imported):
+
+```go
+payload := &bytes.Buffer{}
+writer := multipart.NewWriter(payload)
+_ = writer.WriteField("k", "v")
+file, err := os.Open("p")
+// err check
+part, err := writer.CreateFormFile("f", filepath.Base("p"))
+// err check
+_, err = io.Copy(part, file)
+file.Close()
+writer.Close()
+```
+
+request body is `payload`, then after the exported headers:
+`req.Header.Set("Content-Type", writer.FormDataContentType())`.
+
+## Docs touched
+
+- `src/code_gen.rs` module doc: drop the "v1 supports None and Raw" caveat.
+- `README.md`: remove the "Form-data export in code snippets" item from
+  Possible Future Enhancements; update the code-export feature bullet.
+
+## Testing (pure unit tests in `code_gen::tests`)
+
+New tests (per existing test style, one request fixture with a text row, a
+file row, and a disabled row):
+
+1. Each of the six targets: output contains the text field, the file
+   field/path, and NOT the disabled row's key, and NOT the NOTE string.
+2. Content-Type skipped: a request with a `Content-Type: multipart/...`
+   header + form-data body → no `Content-Type` in output (all targets);
+   control: raw-body request still exports its Content-Type.
+3. cURL specifics: text field uses `--form-string`, file field uses
+   `--form 'f=@...'`; a text value starting with `@` survives literally.
+4. Python: all-text form still emits `files = {` with `(None, ...)` tuples
+   (multipart forced), no `data=` payload.
+5. Empty/disabled-only form-data exports like a body-less request.
+
+Test gate (WSL cannot link the GUI crate):
+`pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test code_gen"`.
+
+## Branch
+
+`feat/formdata-code-export` off `main`, merged via PR per repo convention.

--- a/docs/superpowers/specs/2026-07-14-formdata-code-export-design.md
+++ b/docs/superpowers/specs/2026-07-14-formdata-code-export-design.md
@@ -16,10 +16,12 @@ Go (net/http).
 - **Rows exported:** only rows with `enabled == true` and a non-blank key.
   A form-data body whose rows are all disabled/blank exports like `BodyType::None`.
 - **Content-Type header is skipped** (case-insensitive match) in ALL targets
-  when a non-empty form-data body is present. The UI pins a read-only
-  `multipart/form-data; boundary=<auto>` header on the request; exporting it
-  verbatim would break the request because each library must generate its own
-  boundary. Raw/None bodies keep the existing header pass-through.
+  whenever the body is `BodyType::FormData` — even if every row is disabled,
+  since a `multipart/form-data; boundary=<auto>` header without a matching
+  body is broken either way. The UI pins that read-only header on the
+  request; exporting it verbatim would break the request because each library
+  must generate its own boundary. Raw/None bodies keep the existing header
+  pass-through.
 - **Variables:** `generate()` receives an already-resolved `RequestData`
   (resolution happens upstream, unchanged).
 - **File fields embed the local path** the user typed in the Form-data UI.

--- a/src/code_gen.rs
+++ b/src/code_gen.rs
@@ -95,9 +95,8 @@ fn export_headers(req: &RequestData) -> Vec<(&str, &str)> {
     let skip_content_type = matches!(&req.body, BodyType::FormData(_));
     req.headers
         .iter()
-        .filter(|(k, _)| {
-            !k.trim().is_empty() && !(skip_content_type && k.eq_ignore_ascii_case("content-type"))
-        })
+        .filter(|(k, _)| !k.trim().is_empty())
+        .filter(|(k, _)| !(skip_content_type && k.eq_ignore_ascii_case("content-type")))
         .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect()
 }
@@ -707,7 +706,7 @@ mod tests {
     }
 
     #[test]
-    fn python_form_data_uses_files_dict() {
+    fn python_form_data_uses_files_list() {
         let out = generate(CodeTarget::PythonRequests, &form_req());
         assert!(out.contains("files = ["));
         assert!(out.contains("(\"note\", (None, \"hello world\")),"));

--- a/src/code_gen.rs
+++ b/src/code_gen.rs
@@ -467,7 +467,6 @@ fn gen_go(req: &RequestData) -> String {
     s.push_str("\t\"net/http\"\n");
     if has_file {
         s.push_str("\t\"os\"\n");
-        s.push_str("\t\"path/filepath\"\n");
     }
     if form.is_empty() && body.is_some() {
         s.push_str("\t\"strings\"\n");
@@ -493,11 +492,14 @@ fn gen_go(req: &RequestData) -> String {
                         i = file_idx,
                         p = dq(path)
                     ));
+                    // Basename is resolved here at generation time (like gen_fetch):
+                    // Go's runtime filepath.Base would mis-split a Windows path when
+                    // the exported snippet is compiled on a POSIX machine.
                     s.push_str(&format!(
-                        "\tpart{i}, err := writer.CreateFormFile(\"{k}\", filepath.Base(\"{p}\"))\n\tif err != nil {{\n\t\tfmt.Println(err)\n\t\treturn\n\t}}\n",
+                        "\tpart{i}, err := writer.CreateFormFile(\"{k}\", \"{n}\")\n\tif err != nil {{\n\t\tfmt.Println(err)\n\t\treturn\n\t}}\n",
                         i = file_idx,
                         k = dq(&row.key),
-                        p = dq(path)
+                        n = dq(file_basename(path))
                     ));
                     s.push_str(&format!(
                         "\t_, err = io.Copy(part{i}, file{i})\n\tfile{i}.Close()\n\tif err != nil {{\n\t\tfmt.Println(err)\n\t\treturn\n\t}}\n",
@@ -883,13 +885,13 @@ mod tests {
         assert!(out.contains("\"bytes\""));
         assert!(out.contains("\"mime/multipart\""));
         assert!(out.contains("\"os\""));
-        assert!(out.contains("\"path/filepath\""));
+        // Basename must be baked in at generation time — runtime filepath.Base
+        // would keep the full Windows path when the snippet runs on POSIX.
+        assert!(!out.contains("path/filepath"));
         assert!(out.contains("writer := multipart.NewWriter(payload)"));
         assert!(out.contains("_ = writer.WriteField(\"note\", \"hello world\")"));
         assert!(out.contains("file0, err := os.Open(\"C:\\\\pics\\\\me.png\")"));
-        assert!(out.contains(
-            "part0, err := writer.CreateFormFile(\"avatar\", filepath.Base(\"C:\\\\pics\\\\me.png\"))"
-        ));
+        assert!(out.contains("part0, err := writer.CreateFormFile(\"avatar\", \"me.png\")"));
         assert!(out.contains("req.Header.Set(\"Content-Type\", writer.FormDataContentType())"));
         assert!(out.contains("http.NewRequest(method, url, payload)"));
         assert!(!out.contains("skipme"));

--- a/src/code_gen.rs
+++ b/src/code_gen.rs
@@ -175,6 +175,12 @@ fn js_string(s: &str) -> String {
     }
 }
 
+/// Final path component of a local file path, tolerating / and \ separators
+/// (paths come from the form-data UI and may be Windows- or POSIX-style).
+fn file_basename(path: &str) -> &str {
+    path.rsplit(['/', '\\']).next().unwrap_or(path)
+}
+
 /// Top-level dispatch: generate source code for `target` from `req`.
 pub fn generate(target: CodeTarget, req: &RequestData) -> String {
     match target {
@@ -335,18 +341,35 @@ fn gen_python(req: &RequestData) -> String {
 }
 
 fn gen_fetch(req: &RequestData) -> String {
+    let form = form_rows(req);
     let mut s = String::new();
-    if form_data_present(req) {
-        s.push_str("// NOTE: form-data body is not yet supported in code export\n");
-    }
     s.push_str("const myHeaders = new Headers();\n");
-    for (k, v) in headers(req) {
+    for (k, v) in export_headers(req) {
         s.push_str(&format!("myHeaders.append(\"{}\", \"{}\");\n", dq(k), dq(v)));
+    }
+    if !form.is_empty() {
+        s.push_str("\nconst formdata = new FormData();\n");
+        for row in &form {
+            match &row.value {
+                FormDataValue::Text(v) => s.push_str(&format!(
+                    "formdata.append(\"{}\", \"{}\");\n",
+                    dq(&row.key),
+                    dq(v)
+                )),
+                FormDataValue::File { path } => s.push_str(&format!(
+                    "// Browsers can't read local paths — wire this to an <input type=\"file\">:\n// formdata.append(\"{}\", fileInput.files[0], \"{}\");\n",
+                    dq(&row.key),
+                    dq(file_basename(path))
+                )),
+            }
+        }
     }
     s.push_str("\nconst requestOptions = {\n");
     s.push_str(&format!("  method: \"{}\",\n", req.method.as_str()));
     s.push_str("  headers: myHeaders,\n");
-    if let Some(b) = raw_body(req) {
+    if !form.is_empty() {
+        s.push_str("  body: formdata,\n");
+    } else if let Some(b) = raw_body(req) {
         s.push_str(&format!("  body: {},\n", js_string(&b)));
     }
     s.push_str("  redirect: \"follow\",\n");
@@ -734,5 +757,26 @@ mod tests {
         assert!(!out.contains("skipme"));
         assert!(!out.contains("Content-Type"));
         assert!(!out.contains("not yet supported"));
+    }
+
+    #[test]
+    fn fetch_form_data_appends_fields() {
+        let out = generate(CodeTarget::JavaScriptFetch, &form_req());
+        assert!(out.contains("const formdata = new FormData();"));
+        assert!(out.contains("formdata.append(\"note\", \"hello world\");"));
+        // Browsers can't open local paths — the file row is a commented hint
+        // that carries the field name and the file's basename.
+        assert!(out.contains("// formdata.append(\"avatar\", fileInput.files[0], \"me.png\");"));
+        assert!(out.contains("body: formdata,"));
+        assert!(!out.contains("skipme"));
+        assert!(!out.contains("Content-Type"));
+        assert!(!out.contains("not yet supported"));
+    }
+
+    #[test]
+    fn file_basename_handles_both_separators() {
+        assert_eq!(file_basename("C:\\pics\\me.png"), "me.png");
+        assert_eq!(file_basename("/home/u/me.png"), "me.png");
+        assert_eq!(file_basename("me.png"), "me.png");
     }
 }

--- a/src/code_gen.rs
+++ b/src/code_gen.rs
@@ -2,8 +2,9 @@
 //! into runnable client code for several languages/libraries. All functions are
 //! stateless and unit-testable; no GPUI types here.
 //!
-//! v1 supports `None` and `Raw` request bodies across all targets. `FormData`
-//! bodies are not exported yet — generators prepend a clarifying comment.
+//! Supports `None`, `Raw`, and multipart `FormData` bodies across all targets.
+//! Form-data exports skip the UI-pinned Content-Type header — each target's
+//! HTTP library generates its own multipart boundary.
 
 use crate::types::{BodyType, FormDataRow, FormDataValue, RequestData};
 
@@ -74,20 +75,6 @@ fn raw_body(req: &RequestData) -> Option<String> {
         }
         BodyType::FormData(_) => None,
     }
-}
-
-/// Whether the request has a (currently unsupported) non-empty form-data body.
-fn form_data_present(req: &RequestData) -> bool {
-    matches!(&req.body, BodyType::FormData(rows) if !rows.is_empty())
-}
-
-/// Non-empty headers (skip blank keys left by placeholder rows).
-fn headers(req: &RequestData) -> Vec<(&str, &str)> {
-    req.headers
-        .iter()
-        .filter(|(k, _)| !k.trim().is_empty())
-        .map(|(k, v)| (k.as_str(), v.as_str()))
-        .collect()
 }
 
 /// Enabled, non-blank-key form-data rows — the rows that export.
@@ -898,5 +885,30 @@ mod tests {
         assert!(!out.contains("req.Header.Add(\"Content-Type\""));
         assert!(!out.contains("not yet supported"));
         assert!(!out.contains("\"strings\""));
+    }
+
+    #[test]
+    fn disabled_only_form_data_exports_like_no_body() {
+        let mut req = form_req();
+        req.body = BodyType::FormData(vec![FormDataRow {
+            enabled: false,
+            key: "x".to_string(),
+            value: FormDataValue::Text("y".to_string()),
+        }]);
+        let curl = generate(CodeTarget::Curl, &req);
+        assert!(!curl.contains("--form"));
+        assert!(!curl.contains("--data"));
+        // The pinned multipart Content-Type is skipped for ANY form-data body —
+        // exporting it without a matching body would produce a broken request.
+        assert!(!curl.contains("Content-Type"));
+        let go = generate(CodeTarget::GoNetHttp, &req);
+        assert!(go.contains("http.NewRequest(method, url, nil)"));
+    }
+
+    #[test]
+    fn raw_body_still_exports_content_type() {
+        // Control: the Content-Type skip must not leak to raw bodies.
+        let out = generate(CodeTarget::Curl, &post_json_req());
+        assert!(out.contains("--header 'Content-Type: application/json'"));
     }
 }

--- a/src/code_gen.rs
+++ b/src/code_gen.rs
@@ -5,7 +5,7 @@
 //! v1 supports `None` and `Raw` request bodies across all targets. `FormData`
 //! bodies are not exported yet — generators prepend a clarifying comment.
 
-use crate::types::{BodyType, RequestData};
+use crate::types::{BodyType, FormDataRow, FormDataValue, RequestData};
 
 /// A language/library target for code generation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -90,6 +90,30 @@ fn headers(req: &RequestData) -> Vec<(&str, &str)> {
         .collect()
 }
 
+/// Enabled, non-blank-key form-data rows — the rows that export.
+fn form_rows(req: &RequestData) -> Vec<&FormDataRow> {
+    match &req.body {
+        BodyType::FormData(rows) => rows
+            .iter()
+            .filter(|r| r.enabled && !r.key.trim().is_empty())
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Headers to export: non-blank keys, minus Content-Type for form-data
+/// bodies — the UI pins `multipart/form-data; boundary=<auto>` on such
+/// requests, and each target's library must generate its own boundary.
+fn export_headers(req: &RequestData) -> Vec<(&str, &str)> {
+    let skip_content_type = matches!(&req.body, BodyType::FormData(_));
+    req.headers
+        .iter()
+        .filter(|(k, _)| !k.trim().is_empty())
+        .filter(|(k, _)| !(skip_content_type && k.eq_ignore_ascii_case("content-type")))
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect()
+}
+
 /// Escape a string for a single-quoted shell context (the `'\''` trick).
 fn shell_single(s: &str) -> String {
     s.replace('\'', "'\\''")
@@ -157,16 +181,27 @@ pub fn generate(target: CodeTarget, req: &RequestData) -> String {
 
 fn gen_curl(req: &RequestData) -> String {
     let mut lines: Vec<String> = Vec::new();
-    if form_data_present(req) {
-        lines.push("# NOTE: form-data body is not yet supported in code export".to_string());
-    }
     lines.push(format!(
         "curl --location --request {} '{}'",
         req.method.as_str(),
         shell_single(&req.url)
     ));
-    for (k, v) in headers(req) {
+    for (k, v) in export_headers(req) {
         lines.push(format!("  --header '{}: {}'", shell_single(k), shell_single(v)));
+    }
+    for row in form_rows(req) {
+        match &row.value {
+            FormDataValue::Text(v) => lines.push(format!(
+                "  --form-string '{}={}'",
+                shell_single(&row.key),
+                shell_single(v)
+            )),
+            FormDataValue::File { path } => lines.push(format!(
+                "  --form '{}=@\"{}\"'",
+                shell_single(&row.key),
+                shell_single(path)
+            )),
+        }
     }
     if let Some(body) = raw_body(req) {
         lines.push(format!("  --data '{}'", shell_single(&body)));
@@ -374,6 +409,39 @@ mod tests {
         }
     }
 
+    /// POST with one text row, one file row, one disabled row, and the
+    /// UI-pinned multipart Content-Type header that must NOT be exported.
+    fn form_req() -> RequestData {
+        RequestData {
+            method: HttpMethod::POST,
+            url: "https://api.example.com/upload".to_string(),
+            headers: vec![
+                ("Accept".to_string(), "application/json".to_string()),
+                (
+                    "Content-Type".to_string(),
+                    "multipart/form-data; boundary=<auto>".to_string(),
+                ),
+            ],
+            body: BodyType::FormData(vec![
+                FormDataRow {
+                    enabled: true,
+                    key: "note".to_string(),
+                    value: FormDataValue::Text("hello world".to_string()),
+                },
+                FormDataRow {
+                    enabled: true,
+                    key: "avatar".to_string(),
+                    value: FormDataValue::File { path: "C:\\pics\\me.png".to_string() },
+                },
+                FormDataRow {
+                    enabled: false,
+                    key: "skipme".to_string(),
+                    value: FormDataValue::Text("nope".to_string()),
+                },
+            ]),
+        }
+    }
+
     #[test]
     fn targets_have_six_and_unique_labels() {
         let all = CodeTarget::all();
@@ -501,6 +569,31 @@ mod tests {
         let out = generate(CodeTarget::PythonRequests, &req);
         assert!(out.contains("form-data body is not yet supported"));
         assert!(!out.contains("payload"));
+    }
+
+    #[test]
+    fn curl_form_data_uses_form_flags() {
+        let out = generate(CodeTarget::Curl, &form_req());
+        assert!(out.contains("--form-string 'note=hello world'"));
+        assert!(out.contains("--form 'avatar=@\"C:\\pics\\me.png\"'"));
+        assert!(!out.contains("skipme"));
+        assert!(!out.contains("not yet supported"));
+        assert!(!out.contains("Content-Type"), "boundary header must not export");
+        assert!(out.contains("--header 'Accept: application/json'"));
+        assert!(!out.contains("--data"));
+    }
+
+    #[test]
+    fn curl_form_text_leading_at_stays_literal() {
+        // --form-string never does curl's @file / <file expansion.
+        let mut req = form_req();
+        req.body = BodyType::FormData(vec![FormDataRow {
+            enabled: true,
+            key: "handle".to_string(),
+            value: FormDataValue::Text("@ada".to_string()),
+        }]);
+        let out = generate(CodeTarget::Curl, &req);
+        assert!(out.contains("--form-string 'handle=@ada'"));
     }
 
     #[test]

--- a/src/code_gen.rs
+++ b/src/code_gen.rs
@@ -274,13 +274,11 @@ fn gen_rust(req: &RequestData) -> String {
 }
 
 fn gen_python(req: &RequestData) -> String {
+    let form = form_rows(req);
     let mut s = String::new();
-    if form_data_present(req) {
-        s.push_str("# NOTE: form-data body is not yet supported in code export\n");
-    }
     s.push_str("import requests\n\n");
     s.push_str(&format!("url = \"{}\"\n\n", dq(&req.url)));
-    let hs = headers(req);
+    let hs = export_headers(req);
     if hs.is_empty() {
         s.push_str("headers = {}\n");
     } else {
@@ -294,8 +292,33 @@ fn gen_python(req: &RequestData) -> String {
     if let Some(b) = &body {
         s.push_str(&format!("payload = {}\n", py_string(b)));
     }
+    if !form.is_empty() {
+        // (None, value) tuples force multipart encoding even for text-only
+        // forms; a bare data= dict would send x-www-form-urlencoded instead.
+        s.push_str("files = {\n");
+        for row in &form {
+            match &row.value {
+                FormDataValue::Text(v) => s.push_str(&format!(
+                    "    \"{}\": (None, \"{}\"),\n",
+                    dq(&row.key),
+                    dq(v)
+                )),
+                FormDataValue::File { path } => s.push_str(&format!(
+                    "    \"{}\": open(\"{}\", \"rb\"),\n",
+                    dq(&row.key),
+                    dq(path)
+                )),
+            }
+        }
+        s.push_str("}\n");
+    }
     s.push('\n');
-    if body.is_some() {
+    if !form.is_empty() {
+        s.push_str(&format!(
+            "response = requests.request(\"{}\", url, headers=headers, files=files)\n",
+            req.method.as_str()
+        ));
+    } else if body.is_some() {
         s.push_str(&format!(
             "response = requests.request(\"{}\", url, headers=headers, data=payload)\n",
             req.method.as_str()
@@ -590,15 +613,31 @@ mod tests {
     }
 
     #[test]
-    fn form_data_adds_note_comment() {
-        let mut req = post_json_req();
+    fn python_form_data_uses_files_dict() {
+        let out = generate(CodeTarget::PythonRequests, &form_req());
+        assert!(out.contains("\"note\": (None, \"hello world\"),"));
+        assert!(out.contains("\"avatar\": open(\"C:\\\\pics\\\\me.png\", \"rb\"),"));
+        assert!(out.contains("files=files"));
+        assert!(!out.contains("data="));
+        assert!(!out.contains("skipme"));
+        assert!(!out.contains("Content-Type"));
+        assert!(!out.contains("not yet supported"));
+    }
+
+    #[test]
+    fn python_all_text_form_still_multipart() {
+        // Without files=, requests would send urlencoded — the (None, value)
+        // tuple form forces a real multipart body even for text-only forms.
+        let mut req = form_req();
         req.body = BodyType::FormData(vec![FormDataRow {
             enabled: true,
-            key: "file".to_string(),
-            value: FormDataValue::Text("x".to_string()),
+            key: "a".to_string(),
+            value: FormDataValue::Text("1".to_string()),
         }]);
         let out = generate(CodeTarget::PythonRequests, &req);
-        assert!(out.contains("form-data body is not yet supported"));
+        assert!(out.contains("files = {"));
+        assert!(out.contains("\"a\": (None, \"1\"),"));
+        assert!(out.contains("files=files"));
         assert!(!out.contains("payload"));
     }
 

--- a/src/code_gen.rs
+++ b/src/code_gen.rs
@@ -382,16 +382,47 @@ fn gen_fetch(req: &RequestData) -> String {
 }
 
 fn gen_axios(req: &RequestData) -> String {
+    let form = form_rows(req);
+    let has_file = form
+        .iter()
+        .any(|r| matches!(r.value, FormDataValue::File { .. }));
     let mut s = String::new();
-    if form_data_present(req) {
-        s.push_str("// NOTE: form-data body is not yet supported in code export\n");
+    s.push_str("const axios = require(\"axios\");\n");
+    if !form.is_empty() {
+        s.push_str("const FormData = require(\"form-data\");\n");
+        if has_file {
+            s.push_str("const fs = require(\"fs\");\n");
+        }
+        s.push_str("\nconst formdata = new FormData();\n");
+        for row in &form {
+            match &row.value {
+                FormDataValue::Text(v) => s.push_str(&format!(
+                    "formdata.append(\"{}\", \"{}\");\n",
+                    dq(&row.key),
+                    dq(v)
+                )),
+                FormDataValue::File { path } => s.push_str(&format!(
+                    "formdata.append(\"{}\", fs.createReadStream(\"{}\"));\n",
+                    dq(&row.key),
+                    dq(path)
+                )),
+            }
+        }
     }
-    s.push_str("const axios = require(\"axios\");\n\n");
+    s.push('\n');
     s.push_str("const config = {\n");
     s.push_str(&format!("  method: \"{}\",\n", req.method.as_str().to_lowercase()));
     s.push_str(&format!("  url: \"{}\",\n", dq(&req.url)));
-    let hs = headers(req);
-    if hs.is_empty() {
+    let hs = export_headers(req);
+    if !form.is_empty() {
+        // form-data's getHeaders() provides the multipart Content-Type with
+        // the generated boundary; exported headers merge after it.
+        s.push_str("  headers: {\n    ...formdata.getHeaders(),\n");
+        for (k, v) in hs {
+            s.push_str(&format!("    \"{}\": \"{}\",\n", dq(k), dq(v)));
+        }
+        s.push_str("  },\n");
+    } else if hs.is_empty() {
         s.push_str("  headers: {},\n");
     } else {
         s.push_str("  headers: {\n");
@@ -400,7 +431,9 @@ fn gen_axios(req: &RequestData) -> String {
         }
         s.push_str("  },\n");
     }
-    if let Some(b) = raw_body(req) {
+    if !form.is_empty() {
+        s.push_str("  data: formdata,\n");
+    } else if let Some(b) = raw_body(req) {
         s.push_str(&format!("  data: {},\n", js_string(&b)));
     }
     s.push_str("};\n\n");
@@ -778,5 +811,21 @@ mod tests {
         assert_eq!(file_basename("C:\\pics\\me.png"), "me.png");
         assert_eq!(file_basename("/home/u/me.png"), "me.png");
         assert_eq!(file_basename("me.png"), "me.png");
+    }
+
+    #[test]
+    fn axios_form_data_uses_form_data_package() {
+        let out = generate(CodeTarget::NodeAxios, &form_req());
+        assert!(out.contains("const FormData = require(\"form-data\");"));
+        assert!(out.contains("const fs = require(\"fs\");"));
+        assert!(out.contains("formdata.append(\"note\", \"hello world\");"));
+        assert!(out.contains(
+            "formdata.append(\"avatar\", fs.createReadStream(\"C:\\\\pics\\\\me.png\"));"
+        ));
+        assert!(out.contains("...formdata.getHeaders(),"));
+        assert!(out.contains("data: formdata,"));
+        assert!(!out.contains("skipme"));
+        assert!(!out.contains("\"Content-Type\""));
+        assert!(!out.contains("not yet supported"));
     }
 }

--- a/src/code_gen.rs
+++ b/src/code_gen.rs
@@ -108,8 +108,9 @@ fn export_headers(req: &RequestData) -> Vec<(&str, &str)> {
     let skip_content_type = matches!(&req.body, BodyType::FormData(_));
     req.headers
         .iter()
-        .filter(|(k, _)| !k.trim().is_empty())
-        .filter(|(k, _)| !(skip_content_type && k.eq_ignore_ascii_case("content-type")))
+        .filter(|(k, _)| {
+            !k.trim().is_empty() && !(skip_content_type && k.eq_ignore_ascii_case("content-type"))
+        })
         .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect()
 }
@@ -117,6 +118,13 @@ fn export_headers(req: &RequestData) -> Vec<(&str, &str)> {
 /// Escape a string for a single-quoted shell context (the `'\''` trick).
 fn shell_single(s: &str) -> String {
     s.replace('\'', "'\\''")
+}
+
+/// Escape a path for curl's quoted-filename context (`@"…"`): inside the
+/// quotes curl treats backslash and double-quote as its own escape chars,
+/// so both must be doubled/escaped or UNC paths silently collapse.
+fn curl_quoted(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 /// Escape a string for a double-quoted source string (Rust/Python/JS):
@@ -199,7 +207,7 @@ fn gen_curl(req: &RequestData) -> String {
             FormDataValue::File { path } => lines.push(format!(
                 "  --form '{}=@\"{}\"'",
                 shell_single(&row.key),
-                shell_single(path)
+                shell_single(&curl_quoted(path))
             )),
         }
     }
@@ -575,7 +583,7 @@ mod tests {
     fn curl_form_data_uses_form_flags() {
         let out = generate(CodeTarget::Curl, &form_req());
         assert!(out.contains("--form-string 'note=hello world'"));
-        assert!(out.contains("--form 'avatar=@\"C:\\pics\\me.png\"'"));
+        assert!(out.contains("--form 'avatar=@\"C:\\\\pics\\\\me.png\"'"));
         assert!(!out.contains("skipme"));
         assert!(!out.contains("not yet supported"));
         assert!(!out.contains("Content-Type"), "boundary header must not export");
@@ -594,6 +602,32 @@ mod tests {
         }]);
         let out = generate(CodeTarget::Curl, &req);
         assert!(out.contains("--form-string 'handle=@ada'"));
+    }
+
+    #[test]
+    fn blank_form_keys_are_skipped() {
+        let mut req = form_req();
+        req.body = BodyType::FormData(vec![FormDataRow {
+            enabled: true,
+            key: "  ".to_string(),
+            value: FormDataValue::Text("x".to_string()),
+        }]);
+        let out = generate(CodeTarget::Curl, &req);
+        assert!(!out.contains("--form"));
+    }
+
+    #[test]
+    fn curl_escapes_backslashes_and_quotes_in_file_paths() {
+        // UNC path with an embedded quote: curl's inner quoting layer needs
+        // \ -> \\ and " -> \" or the filename breaks/collapses.
+        let mut req = form_req();
+        req.body = BodyType::FormData(vec![FormDataRow {
+            enabled: true,
+            key: "doc".to_string(),
+            value: FormDataValue::File { path: "\\\\server\\share\\a\".png".to_string() },
+        }]);
+        let out = generate(CodeTarget::Curl, &req);
+        assert!(out.contains("--form 'doc=@\"\\\\\\\\server\\\\share\\\\a\\\".png\"'"));
     }
 
     #[test]

--- a/src/code_gen.rs
+++ b/src/code_gen.rs
@@ -293,24 +293,25 @@ fn gen_python(req: &RequestData) -> String {
         s.push_str(&format!("payload = {}\n", py_string(b)));
     }
     if !form.is_empty() {
-        // (None, value) tuples force multipart encoding even for text-only
-        // forms; a bare data= dict would send x-www-form-urlencoded instead.
-        s.push_str("files = {\n");
+        // A LIST of (key, part) tuples — not a dict — so duplicate form keys
+        // are preserved. The (None, value) part forces multipart encoding even
+        // for text-only forms; a bare data= dict would send urlencoded instead.
+        s.push_str("files = [\n");
         for row in &form {
             match &row.value {
                 FormDataValue::Text(v) => s.push_str(&format!(
-                    "    \"{}\": (None, \"{}\"),\n",
+                    "    (\"{}\", (None, \"{}\")),\n",
                     dq(&row.key),
                     dq(v)
                 )),
                 FormDataValue::File { path } => s.push_str(&format!(
-                    "    \"{}\": open(\"{}\", \"rb\"),\n",
+                    "    (\"{}\", open(\"{}\", \"rb\")),\n",
                     dq(&row.key),
                     dq(path)
                 )),
             }
         }
-        s.push_str("}\n");
+        s.push_str("]\n");
     }
     s.push('\n');
     if !form.is_empty() {
@@ -615,8 +616,9 @@ mod tests {
     #[test]
     fn python_form_data_uses_files_dict() {
         let out = generate(CodeTarget::PythonRequests, &form_req());
-        assert!(out.contains("\"note\": (None, \"hello world\"),"));
-        assert!(out.contains("\"avatar\": open(\"C:\\\\pics\\\\me.png\", \"rb\"),"));
+        assert!(out.contains("files = ["));
+        assert!(out.contains("(\"note\", (None, \"hello world\")),"));
+        assert!(out.contains("(\"avatar\", open(\"C:\\\\pics\\\\me.png\", \"rb\")),"));
         assert!(out.contains("files=files"));
         assert!(!out.contains("data="));
         assert!(!out.contains("skipme"));
@@ -635,10 +637,31 @@ mod tests {
             value: FormDataValue::Text("1".to_string()),
         }]);
         let out = generate(CodeTarget::PythonRequests, &req);
-        assert!(out.contains("files = {"));
-        assert!(out.contains("\"a\": (None, \"1\"),"));
+        assert!(out.contains("files = ["));
+        assert!(out.contains("(\"a\", (None, \"1\")),"));
         assert!(out.contains("files=files"));
         assert!(!out.contains("payload"));
+    }
+
+    #[test]
+    fn python_duplicate_form_keys_preserved() {
+        // dict would silently collapse duplicate keys; the list form keeps both.
+        let mut req = form_req();
+        req.body = BodyType::FormData(vec![
+            FormDataRow {
+                enabled: true,
+                key: "tag".to_string(),
+                value: FormDataValue::Text("red".to_string()),
+            },
+            FormDataRow {
+                enabled: true,
+                key: "tag".to_string(),
+                value: FormDataValue::Text("blue".to_string()),
+            },
+        ]);
+        let out = generate(CodeTarget::PythonRequests, &req);
+        assert!(out.contains("(\"tag\", (None, \"red\")),"));
+        assert!(out.contains("(\"tag\", (None, \"blue\")),"));
     }
 
     #[test]

--- a/src/code_gen.rs
+++ b/src/code_gen.rs
@@ -448,24 +448,69 @@ fn gen_axios(req: &RequestData) -> String {
 }
 
 fn gen_go(req: &RequestData) -> String {
-    let mut s = String::new();
-    if form_data_present(req) {
-        s.push_str("// NOTE: form-data body is not yet supported in code export\n");
-    }
+    let form = form_rows(req);
+    let has_file = form
+        .iter()
+        .any(|r| matches!(r.value, FormDataValue::File { .. }));
     let body = raw_body(req);
+    let mut s = String::new();
     s.push_str("package main\n\n");
     s.push_str("import (\n");
+    if !form.is_empty() {
+        s.push_str("\t\"bytes\"\n");
+    }
     s.push_str("\t\"fmt\"\n");
     s.push_str("\t\"io\"\n");
+    if !form.is_empty() {
+        s.push_str("\t\"mime/multipart\"\n");
+    }
     s.push_str("\t\"net/http\"\n");
-    if body.is_some() {
+    if has_file {
+        s.push_str("\t\"os\"\n");
+        s.push_str("\t\"path/filepath\"\n");
+    }
+    if form.is_empty() && body.is_some() {
         s.push_str("\t\"strings\"\n");
     }
     s.push_str(")\n\n");
     s.push_str("func main() {\n");
     s.push_str(&format!("\turl := \"{}\"\n", dq(&req.url)));
     s.push_str(&format!("\tmethod := \"{}\"\n\n", req.method.as_str()));
-    if let Some(b) = &body {
+    if !form.is_empty() {
+        s.push_str("\tpayload := &bytes.Buffer{}\n");
+        s.push_str("\twriter := multipart.NewWriter(payload)\n");
+        let mut file_idx = 0usize;
+        for row in &form {
+            match &row.value {
+                FormDataValue::Text(v) => s.push_str(&format!(
+                    "\t_ = writer.WriteField(\"{}\", \"{}\")\n",
+                    dq(&row.key),
+                    dq(v)
+                )),
+                FormDataValue::File { path } => {
+                    s.push_str(&format!(
+                        "\tfile{i}, err := os.Open(\"{p}\")\n\tif err != nil {{\n\t\tfmt.Println(err)\n\t\treturn\n\t}}\n",
+                        i = file_idx,
+                        p = dq(path)
+                    ));
+                    s.push_str(&format!(
+                        "\tpart{i}, err := writer.CreateFormFile(\"{k}\", filepath.Base(\"{p}\"))\n\tif err != nil {{\n\t\tfmt.Println(err)\n\t\treturn\n\t}}\n",
+                        i = file_idx,
+                        k = dq(&row.key),
+                        p = dq(path)
+                    ));
+                    s.push_str(&format!(
+                        "\t_, err = io.Copy(part{i}, file{i})\n\tfile{i}.Close()\n\tif err != nil {{\n\t\tfmt.Println(err)\n\t\treturn\n\t}}\n",
+                        i = file_idx
+                    ));
+                    file_idx += 1;
+                }
+            }
+        }
+        s.push_str("\tif err := writer.Close(); err != nil {\n\t\tfmt.Println(err)\n\t\treturn\n\t}\n\n");
+        s.push_str("\tclient := &http.Client{}\n");
+        s.push_str("\treq, err := http.NewRequest(method, url, payload)\n");
+    } else if let Some(b) = &body {
         // Go raw string literal in backticks; backticks can't be escaped, so fall
         // back to a quoted Go string if the body itself contains a backtick.
         if b.contains('`') {
@@ -480,8 +525,11 @@ fn gen_go(req: &RequestData) -> String {
         s.push_str("\treq, err := http.NewRequest(method, url, nil)\n");
     }
     s.push_str("\tif err != nil {\n\t\tfmt.Println(err)\n\t\treturn\n\t}\n");
-    for (k, v) in headers(req) {
+    for (k, v) in export_headers(req) {
         s.push_str(&format!("\treq.Header.Add(\"{}\", \"{}\")\n", dq(k), dq(v)));
+    }
+    if !form.is_empty() {
+        s.push_str("\treq.Header.Set(\"Content-Type\", writer.FormDataContentType())\n");
     }
     s.push('\n');
     s.push_str("\tres, err := client.Do(req)\n");
@@ -827,5 +875,26 @@ mod tests {
         assert!(!out.contains("skipme"));
         assert!(!out.contains("\"Content-Type\""));
         assert!(!out.contains("not yet supported"));
+    }
+
+    #[test]
+    fn go_form_data_uses_multipart_writer() {
+        let out = generate(CodeTarget::GoNetHttp, &form_req());
+        assert!(out.contains("\"bytes\""));
+        assert!(out.contains("\"mime/multipart\""));
+        assert!(out.contains("\"os\""));
+        assert!(out.contains("\"path/filepath\""));
+        assert!(out.contains("writer := multipart.NewWriter(payload)"));
+        assert!(out.contains("_ = writer.WriteField(\"note\", \"hello world\")"));
+        assert!(out.contains("file0, err := os.Open(\"C:\\\\pics\\\\me.png\")"));
+        assert!(out.contains(
+            "part0, err := writer.CreateFormFile(\"avatar\", filepath.Base(\"C:\\\\pics\\\\me.png\"))"
+        ));
+        assert!(out.contains("req.Header.Set(\"Content-Type\", writer.FormDataContentType())"));
+        assert!(out.contains("http.NewRequest(method, url, payload)"));
+        assert!(!out.contains("skipme"));
+        assert!(!out.contains("req.Header.Add(\"Content-Type\""));
+        assert!(!out.contains("not yet supported"));
+        assert!(!out.contains("\"strings\""));
     }
 }

--- a/src/code_gen.rs
+++ b/src/code_gen.rs
@@ -218,16 +218,17 @@ fn gen_curl(req: &RequestData) -> String {
 }
 
 fn gen_rust(req: &RequestData) -> String {
+    let form = form_rows(req);
     let mut s = String::new();
-    if form_data_present(req) {
-        s.push_str("// NOTE: form-data body is not yet supported in code export\n");
-    }
     s.push_str("use reqwest::blocking::Client;\n");
+    if !form.is_empty() {
+        s.push_str("use reqwest::blocking::multipart;\n");
+    }
     s.push_str("use reqwest::header::{HeaderMap, HeaderValue};\n\n");
     s.push_str("fn main() -> Result<(), Box<dyn std::error::Error>> {\n");
     s.push_str("    let client = Client::new();\n\n");
     s.push_str("    let mut headers = HeaderMap::new();\n");
-    for (k, v) in headers(req) {
+    for (k, v) in export_headers(req) {
         s.push_str(&format!(
             "    headers.insert(\"{}\", HeaderValue::from_str(\"{}\")?);\n",
             dq(k),
@@ -235,12 +236,34 @@ fn gen_rust(req: &RequestData) -> String {
         ));
     }
     s.push('\n');
+    if !form.is_empty() {
+        let mut chain: Vec<String> = vec!["    let form = multipart::Form::new()".to_string()];
+        for row in &form {
+            match &row.value {
+                FormDataValue::Text(v) => chain.push(format!(
+                    "        .text(\"{}\", \"{}\")",
+                    dq(&row.key),
+                    dq(v)
+                )),
+                // .file() reads the file at send time; `?` bubbles its io::Result.
+                FormDataValue::File { path } => chain.push(format!(
+                    "        .file(\"{}\", \"{}\")?",
+                    dq(&row.key),
+                    dq(path)
+                )),
+            }
+        }
+        s.push_str(&chain.join("\n"));
+        s.push_str(";\n\n");
+    }
     s.push_str(&format!(
         "    let response = client\n        .request(reqwest::Method::{}, \"{}\")\n        .headers(headers)\n",
         req.method.as_str(),
         dq(&req.url)
     ));
-    if let Some(body) = raw_body(req) {
+    if !form.is_empty() {
+        s.push_str("        .multipart(form)\n");
+    } else if let Some(body) = raw_body(req) {
         s.push_str(&format!("        .body({})\n", rust_raw(&body)));
     }
     s.push_str("        .send()?;\n\n");
@@ -636,5 +659,18 @@ mod tests {
         req.headers.push(("".to_string(), "ignored".to_string()));
         let out = generate(CodeTarget::Curl, &req);
         assert!(!out.contains("ignored"));
+    }
+
+    #[test]
+    fn rust_form_data_builds_multipart() {
+        let out = generate(CodeTarget::RustReqwest, &form_req());
+        assert!(out.contains("use reqwest::blocking::multipart;"));
+        assert!(out.contains(".text(\"note\", \"hello world\")"));
+        assert!(out.contains(".file(\"avatar\", \"C:\\\\pics\\\\me.png\")?"));
+        assert!(out.contains(".multipart(form)"));
+        assert!(!out.contains(".body("));
+        assert!(!out.contains("skipme"));
+        assert!(!out.contains("Content-Type"));
+        assert!(!out.contains("not yet supported"));
     }
 }


### PR DESCRIPTION
All six code-export targets (cURL, Rust reqwest, Python Requests, JS fetch, Node axios, Go net/http) now generate real multipart form-data code instead of a "not yet supported" note.

Spec: docs/superpowers/specs/2026-07-14-formdata-code-export-design.md

- Only enabled rows with non-blank keys export; disabled-only forms export like a body-less request.
- The UI-pinned `multipart/form-data; boundary=<auto>` Content-Type header is skipped for form-data bodies in every target — each library generates its own boundary.
- cURL text fields use `--form-string` (immune to `@`/`<` file expansion) and file paths escape curl's inner quoting layer; Python uses a list of `(key, part)` tuples so duplicate keys and text-only multipart both work; browser fetch emits a commented `fileInput.files[0]` placeholder for file fields; axios merges `formdata.getHeaders()`; Go indexes `fileN`/`partN` per file row and bakes the file basename in at generation time (runtime `filepath.Base` would mis-split Windows paths on POSIX).
- Pure `src/code_gen.rs` change, fully unit-tested (`cargo test code_gen`, 27 tests; full suite 117 green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)