### PR TITLE
feat: Ctrl+Tab tab cycling and Ctrl+L focus-URL shortcuts

### DIFF
--- a/docs/superpowers/plans/2026-07-15-tab-cycling-focus-url.md
+++ b/docs/superpowers/plans/2026-07-15-tab-cycling-focus-url.md
@@ -100,7 +100,7 @@ mod tests {
 - [ ] **Step 2: Run the tests to verify they fail**
 
 ```bash
-pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test cycle_index"
+pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test app::tests"
 ```
 
 Expected: compile error — `cannot find function 'cycle_index' in module 'super'`.
@@ -131,7 +131,7 @@ Note the backward case adds `len - 1` rather than subtracting 1: `usize` subtrac
 - [ ] **Step 4: Run the tests to verify they pass**
 
 ```bash
-pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test cycle_index"
+pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test app::tests"
 ```
 
 Expected: `test result: ok. 6 passed`.
@@ -198,19 +198,10 @@ Add inside `impl RequestEditor`, directly above `pub fn send`:
 ///
 /// Select-all goes through action dispatch because `InputState::select_all`
 /// is `pub(super)` in gpui-component and unreachable from this crate; the
-/// `SelectAll` action itself is public. The dispatch must wait for the next
-/// frame: `Window::dispatch_action` resolves its target from the *last
-/// rendered* frame's focus, so dispatching in this same tick would route to
-/// whatever was focused before. `request_animation_frame` guarantees that
-/// frame happens even when the URL input already had focus — `Window::focus`
-/// early-returns without scheduling a redraw in that case, which would
-/// otherwise strand the callback and make a second Ctrl+L do nothing.
+/// `SelectAll` action itself is public.
 pub fn focus_url(&mut self, window: &mut Window, cx: &mut Context<Self>) {
     self.url_input.update(cx, |input, cx| input.focus(window, cx));
-    window.request_animation_frame();
-    window.on_next_frame(|window, cx| {
-        window.dispatch_action(Box::new(gpui_component::input::SelectAll), cx);
-    });
+    window.dispatch_action(Box::new(gpui_component::input::SelectAll), cx);
 }
 ```
 

--- a/docs/superpowers/plans/2026-07-15-tab-cycling-focus-url.md
+++ b/docs/superpowers/plans/2026-07-15-tab-cycling-focus-url.md
@@ -1,0 +1,376 @@
+# Tab Cycling & Focus-URL Shortcuts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Ctrl+Tab / Ctrl+Shift+Tab (linear tab cycling with wrap-around) and Ctrl+L (focus the URL input and select all its text).
+
+**Architecture:** Follows the shortcut pattern already established by ctrl-enter/ctrl-t/ctrl-w in three steps: declare a gpui action in `src/app.rs`, bind a keystroke to it in `src/main.rs`, handle it with `.on_action` on `PoopmanApp`'s root element. Tab index math is extracted into a pure free function so it can be unit-tested without a GPUI window. Ctrl+L delegates to a new `pub fn focus_url` on `RequestEditor`, mirroring the existing `pub fn send`.
+
+**Tech Stack:** Rust, gpui 0.2.2, gpui-component 0.5.1.
+
+**Spec:** `docs/superpowers/specs/2026-07-15-tab-cycling-focus-url-design.md`
+
+**Branch:** `feat/keyboard-shortcuts-cycling` (already checked out; the spec commit is on it).
+
+---
+
+## Background the engineer needs
+
+**This project cannot be built or run under WSL2.** `cargo check` and `cargo clippy` work locally; `cargo build`/`cargo test` fail on a missing `libxkbcommon`. Tests run on the Windows side, invoked from WSL:
+
+```bash
+pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test"
+```
+
+That command is the test gate. Use it wherever this plan says "run the tests".
+
+**Critical gotcha — test modules in files that `use gpui::*`:** `src/app.rs` starts with `use gpui::*;`. gpui exports a `test` attribute macro that **shadows the standard `#[test]`**. A test module in such a file must NOT `use super::*`; import the items under test by name instead. `src/response_viewer.rs:467` is the working precedent — copy its shape.
+
+**GUI behavior cannot be verified from WSL.** Tasks 1–2 are unit-testable. Tasks 3–5 change GUI wiring and are verified by `cargo check` + `cargo clippy` plus the user's manual checklist at the end.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `src/app.rs` | Modify | Declare the three new actions; add `cycle_index` free function + its tests; add three `.on_action` handlers |
+| `src/main.rs` | Modify | Bind `ctrl-tab` / `ctrl-shift-tab` / `ctrl-l` to those actions |
+| `src/request_editor.rs` | Modify | New `pub fn focus_url` — focus URL input + dispatch select-all |
+
+No new files. All three changes are small and belong with their existing owners.
+
+---
+
+### Task 1: `cycle_index` pure function + tests
+
+The only unit-testable logic in this feature. Do it first, TDD.
+
+**Files:**
+- Modify: `src/app.rs` (add function near the bottom, before any `#[cfg(test)]` block)
+- Test: `src/app.rs` (new `#[cfg(test)] mod tests` at end of file)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the very end of `src/app.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    // NOT `use super::*`: that would pull in `gpui::*`, whose `test` attribute
+    // macro shadows the standard `#[test]`.
+    use super::cycle_index;
+
+    #[test]
+    fn steps_forward_through_the_middle_of_the_list() {
+        assert_eq!(cycle_index(0, 3, true), 1);
+        assert_eq!(cycle_index(1, 3, true), 2);
+    }
+
+    #[test]
+    fn wraps_forward_past_the_last_tab() {
+        assert_eq!(cycle_index(2, 3, true), 0);
+    }
+
+    #[test]
+    fn steps_backward_through_the_middle_of_the_list() {
+        assert_eq!(cycle_index(2, 3, false), 1);
+        assert_eq!(cycle_index(1, 3, false), 0);
+    }
+
+    #[test]
+    fn wraps_backward_past_the_first_tab() {
+        assert_eq!(cycle_index(0, 3, false), 2);
+    }
+
+    #[test]
+    fn single_tab_stays_put_in_both_directions() {
+        assert_eq!(cycle_index(0, 1, true), 0);
+        assert_eq!(cycle_index(0, 1, false), 0);
+    }
+
+    #[test]
+    fn empty_list_returns_current_without_panicking() {
+        assert_eq!(cycle_index(0, 0, true), 0);
+        assert_eq!(cycle_index(0, 0, false), 0);
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test cycle_index"
+```
+
+Expected: compile error — `cannot find function 'cycle_index' in module 'super'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Add to `src/app.rs`, immediately after the `impl Render for PoopmanApp { ... }` block (top-level, not inside an impl):
+
+```rust
+/// Next (`forward`) or previous tab index, wrapping at both ends.
+///
+/// Returns `current` unchanged when `len` is 0 or 1 — callers then hit
+/// `switch_to_tab`'s `index == self.active_tab_index` early-return and no-op.
+fn cycle_index(current: usize, len: usize, forward: bool) -> usize {
+    if len <= 1 {
+        return current;
+    }
+    if forward {
+        (current + 1) % len
+    } else {
+        (current + len - 1) % len
+    }
+}
+```
+
+Note the backward case adds `len - 1` rather than subtracting 1: `usize` subtraction underflows and panics when `current == 0`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test cycle_index"
+```
+
+Expected: `test result: ok. 6 passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app.rs
+git commit -m "feat(tabs): cycle_index helper for wrap-around tab navigation"
+```
+
+---
+
+### Task 2: Declare the actions
+
+**Files:**
+- Modify: `src/app.rs:21`
+
+- [ ] **Step 1: Extend the actions! macro**
+
+Replace line 21 of `src/app.rs`:
+
+```rust
+actions!(poopman, [SendRequest, NewTab, CloseTab]);
+```
+
+with:
+
+```rust
+actions!(poopman, [SendRequest, NewTab, CloseTab, NextTab, PrevTab, FocusUrl]);
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cargo check
+```
+
+Expected: success. Warnings about `NextTab`/`PrevTab`/`FocusUrl` being unused are expected at this point — the handlers land in Task 4.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app.rs
+git commit -m "feat(actions): declare NextTab, PrevTab, FocusUrl actions"
+```
+
+---
+
+### Task 3: `RequestEditor::focus_url`
+
+**Files:**
+- Modify: `src/request_editor.rs` (add the method inside `impl RequestEditor`, next to `pub fn send` at ~line 864)
+
+No unit test: this needs a live `Window` and a rendered frame. It is covered by the manual checklist.
+
+- [ ] **Step 1: Write the method**
+
+Add inside `impl RequestEditor`, directly above `pub fn send`:
+
+```rust
+/// Focus the URL input and select all of its text. Public so the ctrl-l
+/// action can trigger it from PoopmanApp.
+///
+/// Select-all goes through action dispatch because `InputState::select_all`
+/// is `pub(super)` in gpui-component and unreachable from this crate; the
+/// `SelectAll` action itself is public. The dispatch must wait for the next
+/// frame: `Window::dispatch_action` resolves its target from the *last
+/// rendered* frame's focus, so dispatching in this same tick would route to
+/// whatever was focused before. `request_animation_frame` guarantees that
+/// frame happens even when the URL input already had focus — `Window::focus`
+/// early-returns without scheduling a redraw in that case, which would
+/// otherwise strand the callback and make a second Ctrl+L do nothing.
+pub fn focus_url(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    self.url_input.update(cx, |input, cx| input.focus(window, cx));
+    window.request_animation_frame();
+    window.on_next_frame(|window, cx| {
+        window.dispatch_action(Box::new(gpui_component::input::SelectAll), cx);
+    });
+}
+```
+
+`SelectAll` is spelled fully-qualified on purpose. `request_editor.rs` already globs `gpui_component::input::*`, so the bare name would resolve, but the file also globs `gpui::*` — writing the full path removes any doubt for the reader. No new `use` line is needed.
+
+- [ ] **Step 2: Verify it compiles and is clean**
+
+```bash
+cargo check && cargo clippy
+```
+
+Expected: both succeed. A dead-code warning for `focus_url` is expected here — the caller lands in Task 4.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/request_editor.rs
+git commit -m "feat(editor): expose focus_url() for keyboard dispatch"
+```
+
+---
+
+### Task 4: Wire the action handlers
+
+**Files:**
+- Modify: `src/app.rs` (the `.on_action` chain in `impl Render for PoopmanApp`, ~line 503-513)
+
+- [ ] **Step 1: Add the three handlers**
+
+In `src/app.rs`, find the existing chain that starts at `.key_context("Poopman")`. After the existing `CloseTab` handler:
+
+```rust
+.on_action(cx.listener(|this, _: &CloseTab, window, cx| {
+    let index = this.active_tab_index;
+    this.close_tab(index, window, cx);
+}))
+```
+
+add:
+
+```rust
+.on_action(cx.listener(|this, _: &NextTab, window, cx| {
+    let next = cycle_index(this.active_tab_index, this.request_tabs.len(), true);
+    this.switch_to_tab(next, window, cx);
+}))
+.on_action(cx.listener(|this, _: &PrevTab, window, cx| {
+    let prev = cycle_index(this.active_tab_index, this.request_tabs.len(), false);
+    this.switch_to_tab(prev, window, cx);
+}))
+.on_action(cx.listener(|this, _: &FocusUrl, window, cx| {
+    this.request_editor.update(cx, |editor, cx| editor.focus_url(window, cx));
+}))
+```
+
+No bounds-checking needed at the call site: `cycle_index` returns `current` for `len <= 1`, and `switch_to_tab` (`src/app.rs:320`) already early-returns on `index >= self.request_tabs.len() || index == self.active_tab_index`.
+
+- [ ] **Step 2: Verify it compiles and is clean**
+
+```bash
+cargo check && cargo clippy
+```
+
+Expected: both succeed, and the dead-code warnings from Tasks 2 and 3 are now gone.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app.rs
+git commit -m "feat(app): handle NextTab, PrevTab and FocusUrl actions"
+```
+
+---
+
+### Task 5: Bind the keystrokes
+
+**Files:**
+- Modify: `src/main.rs:118-123`
+
+- [ ] **Step 1: Add the bindings**
+
+In `src/main.rs`, extend the existing `cx.bind_keys([...])` call so it reads:
+
+```rust
+cx.bind_keys([
+    KeyBinding::new("ctrl-enter", crate::app::SendRequest, None),
+    KeyBinding::new("ctrl-enter", crate::app::SendRequest, Some("Input")),
+    KeyBinding::new("ctrl-t", crate::app::NewTab, None),
+    KeyBinding::new("ctrl-w", crate::app::CloseTab, None),
+    KeyBinding::new("ctrl-tab", crate::app::NextTab, None),
+    KeyBinding::new("ctrl-shift-tab", crate::app::PrevTab, None),
+    KeyBinding::new("ctrl-l", crate::app::FocusUrl, None),
+]);
+```
+
+Keep them inside this same call — the existing comment above it explains that binding late lets these win over gpui-component's own bindings, and that reasoning still applies.
+
+Context is `None` for all three new bindings; do **not** add `Some("Input")` shadow bindings. That was needed only for ctrl-enter, to out-register gpui-component's secondary-enter binding. gpui-component 0.5.1 binds neither `ctrl-tab` nor `ctrl-l` anywhere. Its bare `tab` → `IndentInline` binding (`input/state.rs:127`) does not collide, because gpui matches modifiers exactly.
+
+- [ ] **Step 2: Verify the whole thing compiles and is clean**
+
+```bash
+cargo check && cargo clippy
+```
+
+Expected: both succeed with no warnings.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test"
+```
+
+Expected: all tests pass, including the 6 new `cycle_index` tests.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "feat(keys): bind ctrl-tab, ctrl-shift-tab and ctrl-l"
+```
+
+---
+
+### Task 6: User manual verification
+
+**This feature cannot be signed off from WSL.** Ask the user to build and run on Windows and walk the checklist. Do not claim the feature works before they report back.
+
+- [ ] **Step 1: Ask the user to run through the checklist**
+
+From the spec's manual verification section:
+
+- [ ] Ctrl+Tab past the last tab wraps to the first
+- [ ] Ctrl+Shift+Tab past the first tab wraps to the last
+- [ ] Both still fire while typing in the URL input and in the body editor
+- [ ] Ctrl+Tab with only one tab open does nothing (no flicker, no reload)
+- [ ] Ctrl+L from the body editor focuses the URL input and selects the whole URL
+- [ ] Typing right after Ctrl+L replaces the URL rather than appending
+- [ ] Ctrl+L pressed twice in a row (URL input already focused) still re-selects
+- [ ] Ctrl+L with an empty URL does not crash
+- [ ] Tab-switching still saves/restores per-tab state (no regression in `switch_to_tab`)
+
+Build note for the user: run via `pwsh.exe` with `GPUI_FXC_PATH` set to the SDK's `fxc.exe`, and kill any running `poopman.exe` first (it holds a file lock).
+
+- [ ] **Step 2: If select-all misbehaves, fall back to focus-only**
+
+The user pre-approved this retreat. If the `SelectAll` dispatch proves unreliable, cut it down to:
+
+```rust
+pub fn focus_url(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    self.url_input.update(cx, |input, cx| input.focus(window, cx));
+}
+```
+
+and update the spec's scope decision to record that focus-only shipped.
+
+---
+
+## Definition of done
+
+- `cargo check` and `cargo clippy` clean under WSL.
+- `pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test"` fully green.
+- User has walked the Task 6 checklist and confirmed.
+- Then, and only then, open the PR against `main` for rebase-merge (matching PRs #13–#19).

--- a/docs/superpowers/specs/2026-07-15-tab-cycling-focus-url-design.md
+++ b/docs/superpowers/specs/2026-07-15-tab-cycling-focus-url-design.md
@@ -1,0 +1,151 @@
+# Spec: Ctrl+Tab tab cycling and Ctrl+L focus-URL shortcuts
+
+Date: 2026-07-15
+Status: Approved (design confirmed by user)
+
+## Goal
+
+Ship the two shortcuts deferred from the 2026-07-14 quick-wins round (items B
+and C):
+
+- **Ctrl+Tab / Ctrl+Shift+Tab** — cycle the active request tab forward/backward
+  in tab-bar order, wrapping at both ends.
+- **Ctrl+L** — focus the URL input and select its whole contents.
+
+This completes the keyboard-shortcut surface started in PR #15
+(ctrl-enter / ctrl-t / ctrl-w). No other behavior changes.
+
+## Scope decisions
+
+- **Cycling is linear, not MRU.** Ctrl+Tab walks the tab bar left-to-right and
+  wraps to the first tab past the last; Ctrl+Shift+Tab is the mirror. This
+  matches Postman. MRU (browser/VSCode-style, hold-Ctrl-to-keep-flipping) was
+  rejected: it needs an MRU stack plus "Ctrl released" detection, which gpui
+  exposes no hook for.
+- **Ctrl+L focuses *and* selects all**, like a browser address bar, so the next
+  keystroke replaces the URL. Fallback if the select-all dispatch proves
+  unreliable in practice: ship focus-only (user-approved retreat).
+- **No new persistence, no new UI.** Both shortcuts drive existing state.
+- Out of scope: Collections, auth helper tab (the two remaining roadmap blocks).
+
+## Architecture
+
+Follows the established three-step shortcut pattern verbatim.
+
+### 1. Actions (`src/app.rs:21`)
+
+```rust
+actions!(poopman, [SendRequest, NewTab, CloseTab, NextTab, PrevTab, FocusUrl]);
+```
+
+### 2. Bindings (`src/main.rs:118`)
+
+```rust
+KeyBinding::new("ctrl-tab", crate::app::NextTab, None),
+KeyBinding::new("ctrl-shift-tab", crate::app::PrevTab, None),
+KeyBinding::new("ctrl-l", crate::app::FocusUrl, None),
+```
+
+Context is `None` for all three — **no `Some("Input")` shadow binding needed**,
+unlike ctrl-enter. Verified against gpui-component 0.5.1 source: it binds
+neither `ctrl-tab` nor `ctrl-l` anywhere. The only nearby binding is bare `tab`
+→ `IndentInline` (`input/state.rs:127`) and bare `tab` → `Tab` (`root.rs:21`);
+gpui matches modifiers exactly, so `ctrl-tab` does not collide with `tab`.
+The ctrl-enter shadow binding existed only to out-register gpui-component's own
+secondary-enter binding in the `Input` context; there is no equivalent here.
+
+Bindings stay inside the existing late-`bind_keys` call, so the
+later-bindings-win ordering note in that comment still holds.
+
+### 3. Handlers (`src/app.rs`, root `v_flex().on_action(...)`)
+
+```rust
+.on_action(cx.listener(|this, _: &NextTab, window, cx| {
+    let next = cycle_index(this.active_tab_index, this.request_tabs.len(), true);
+    this.switch_to_tab(next, window, cx);
+}))
+.on_action(cx.listener(|this, _: &PrevTab, window, cx| {
+    let prev = cycle_index(this.active_tab_index, this.request_tabs.len(), false);
+    this.switch_to_tab(prev, window, cx);
+}))
+.on_action(cx.listener(|this, _: &FocusUrl, window, cx| {
+    this.request_editor.update(cx, |editor, cx| editor.focus_url(window, cx));
+}))
+```
+
+### 4. Index math (`src/app.rs`, free function)
+
+Extracted as a free function so it is unit-testable without a GPUI window:
+
+```rust
+/// Next/previous tab index, wrapping at both ends. Returns `current`
+/// unchanged when `len` is 0 or 1 (callers then no-op).
+fn cycle_index(current: usize, len: usize, forward: bool) -> usize
+```
+
+Single-tab and empty cases need no special-casing at the call site:
+`switch_to_tab` already early-returns when `index >= len || index ==
+self.active_tab_index` (`src/app.rs:320`), and `cycle_index` returns `current`
+for `len <= 1`.
+
+### 5. Focus URL (`src/request_editor.rs`)
+
+New public method mirroring the existing `pub fn send()` (made public for
+exactly this reason — see its doc comment at `src/request_editor.rs:864`):
+
+```rust
+/// Focus the URL input and select its contents. Public so the ctrl-l
+/// action can trigger it from PoopmanApp.
+pub fn focus_url(&mut self, window: &mut Window, cx: &mut Context<Self>)
+```
+
+Implementation:
+
+1. `self.url_input.update(cx, |input, cx| input.focus(window, cx))` —
+   `InputState::focus` is `pub` in gpui-component 0.5.1 (`input/state.rs:825`).
+2. Dispatch select-all **one frame later** via the codebase's existing
+   `cx.spawn_in(window, async move |...| { ... }).detach()` deferral pattern.
+   The dispatch itself is `window.dispatch_action(Box::new(input::SelectAll),
+   cx)` (`gpui-0.2.2 window.rs:1476`), reached from inside the async block
+   through the async window context's `update(...)` — `window` is not directly
+   in scope there.
+
+**Why dispatch instead of a direct call:** `InputState::select_all` is
+`pub(super)` (`input/state.rs:856`) and unreachable from this crate. The
+`SelectAll` *action* is public — `input/mod.rs:29` re-exports it via
+`pub use state::*`. Dispatching routes it to the focused input's own handler.
+
+**Why deferred a frame:** gpui computes the action dispatch path from the
+last rendered frame's focus, so dispatching in the same tick as `focus()`
+can route to the previously focused element instead of the URL input.
+
+## Error handling
+
+No fallible operations. The only edge cases are structural (empty/single tab
+list, empty URL string) and are handled by the early-returns described above;
+an empty URL selects nothing rather than erroring.
+
+## Testing
+
+- **Unit-testable:** `cycle_index` only — forward wrap past last, backward wrap
+  past first, mid-list steps both directions, `len == 1`, `len == 0`.
+- **Not unit-testable:** action binding, dispatch routing, and focus/selection
+  behavior all need a real window; these are covered by the manual checklist.
+- Gotcha (from the 2026-07-14 round): in files that `use gpui::*`, the test
+  module must NOT `use super::*` — gpui's `test` attribute macro shadows
+  `#[test]`. Import the items under test by name.
+- Local gate (WSL2): `cargo check` + `cargo clippy` must be clean.
+- Test gate (Windows, from WSL):
+  `pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test"`.
+
+## Manual verification checklist (user, on Windows)
+
+- [ ] Ctrl+Tab past the last tab wraps to the first
+- [ ] Ctrl+Shift+Tab past the first tab wraps to the last
+- [ ] Both still fire while typing in the URL input and in the body editor
+- [ ] Ctrl+Tab with only one tab open does nothing (no flicker, no reload)
+- [ ] Ctrl+L from the body editor focuses the URL input and selects the whole URL
+- [ ] Typing right after Ctrl+L replaces the URL rather than appending
+- [ ] Ctrl+L with an empty URL does not crash
+- [ ] Tab-switching still saves/restores per-tab state (no regression in
+      `switch_to_tab`'s save-then-load path)

--- a/docs/superpowers/specs/2026-07-15-tab-cycling-focus-url-design.md
+++ b/docs/superpowers/specs/2026-07-15-tab-cycling-focus-url-design.md
@@ -99,15 +99,12 @@ exactly this reason — see its doc comment at `src/request_editor.rs:864`):
 pub fn focus_url(&mut self, window: &mut Window, cx: &mut Context<Self>)
 ```
 
-Implementation:
+Implementation — two lines, no deferral:
 
 1. `self.url_input.update(cx, |input, cx| input.focus(window, cx))` —
    `InputState::focus` is `pub` in gpui-component 0.5.1 (`input/state.rs:825`).
-2. `window.request_animation_frame()` — force a redraw even when the input was
-   already focused (see below).
-3. `window.on_next_frame(|window, cx| window.dispatch_action(
-   Box::new(gpui_component::input::SelectAll), cx))` (`gpui-0.2.2`
-   `window.rs:1644` / `:1476`).
+2. `window.dispatch_action(Box::new(gpui_component::input::SelectAll), cx)`
+   (`gpui-0.2.2 window.rs:1476`).
 
 **Why dispatch instead of a direct call:** `InputState::select_all` is
 `pub(super)` (`input/state.rs:856`) and unreachable from this crate. The
@@ -115,19 +112,32 @@ Implementation:
 `pub use state::*`. Dispatching routes it to the focused input's own handler.
 No new import is needed: `request_editor.rs` already globs `input::*`. (gpui's
 own `SelectAll` is an `OsAction` enum variant, not a top-level item, so
-`gpui::*` does not collide; the plan still spells it fully-qualified.)
+`gpui::*` does not collide; the code still spells it fully-qualified.)
 
-**Why deferred a frame:** `Window::dispatch_action` resolves the target via
-`focus_node_id_in_rendered_frame` (`window.rs:1477-1484`) — the *last rendered*
-frame. Dispatching in the same tick as `focus()` would route to the previously
-focused element, not the URL input.
+**Why no frame deferral is needed** — this reverses an earlier draft of this
+spec, which was wrong on both of its premises and specified a fix that provably
+panicked. Corrected after reading the gpui 0.2.2 source:
 
-**Why the explicit `request_animation_frame`:** `Window::focus`
-(`window.rs:1386`) early-returns *without* calling `refresh()` when the handle
-is already focused. Without a forced frame, pressing Ctrl+L while the URL input
-already has focus would schedule an `on_next_frame` callback that no redraw ever
-runs. `request_animation_frame` guarantees the frame, so repeated Ctrl+L
-re-selects reliably.
+- `Window::dispatch_action` (`window.rs:1477`) opens with
+  `let focus_id = self.focused(cx)` — the **current** focus, already updated by
+  the `input.focus(...)` call on the preceding line. The earlier claim that it
+  resolves focus from the *last rendered frame* was a misreading:
+  `focus_node_id_in_rendered_frame` (`window.rs:3982`) uses the rendered frame
+  only to map an already-chosen `focus_id` onto a dispatch-tree node, and the
+  URL input renders every frame, so its focusable node is always present.
+  `dispatch_action` additionally defers internally via `cx.defer`. A same-tick
+  dispatch is correct.
+- Consequently the "`Window::focus` early-returns without `refresh()` when
+  already focused, stranding the callback" concern is moot — with no
+  `on_next_frame` callback in play, no frame is needed for anything. Repeated
+  Ctrl+L works without special handling.
+- **Never call `window.request_animation_frame()` from an action listener.** It
+  calls `current_view()` (`window.rs:1654` → `:3362`), which asserts the draw
+  phase is Paint/Prepaint and then `.unwrap()`s `rendered_entity_stack.last()`.
+  Outside `draw()` that stack is empty (`debug_assert!(...is_empty())` at
+  `window.rs:1917` and `:1973`), so it panics in debug via the assertion and in
+  release via the unwrap. Every gpui/gpui-component call site for it sits inside
+  element paint.
 
 ## Error handling
 
@@ -157,7 +167,6 @@ an empty URL selects nothing rather than erroring.
 - [ ] Ctrl+L from the body editor focuses the URL input and selects the whole URL
 - [ ] Typing right after Ctrl+L replaces the URL rather than appending
 - [ ] Ctrl+L pressed twice in a row (URL input already focused) still re-selects
-      — this is the `request_animation_frame` case
 - [ ] Ctrl+L with an empty URL does not crash
 - [ ] Tab-switching still saves/restores per-tab state (no regression in
       `switch_to_tab`'s save-then-load path)

--- a/docs/superpowers/specs/2026-07-15-tab-cycling-focus-url-design.md
+++ b/docs/superpowers/specs/2026-07-15-tab-cycling-focus-url-design.md
@@ -103,21 +103,31 @@ Implementation:
 
 1. `self.url_input.update(cx, |input, cx| input.focus(window, cx))` —
    `InputState::focus` is `pub` in gpui-component 0.5.1 (`input/state.rs:825`).
-2. Dispatch select-all **one frame later** via the codebase's existing
-   `cx.spawn_in(window, async move |...| { ... }).detach()` deferral pattern.
-   The dispatch itself is `window.dispatch_action(Box::new(input::SelectAll),
-   cx)` (`gpui-0.2.2 window.rs:1476`), reached from inside the async block
-   through the async window context's `update(...)` — `window` is not directly
-   in scope there.
+2. `window.request_animation_frame()` — force a redraw even when the input was
+   already focused (see below).
+3. `window.on_next_frame(|window, cx| window.dispatch_action(
+   Box::new(gpui_component::input::SelectAll), cx))` (`gpui-0.2.2`
+   `window.rs:1644` / `:1476`).
 
 **Why dispatch instead of a direct call:** `InputState::select_all` is
 `pub(super)` (`input/state.rs:856`) and unreachable from this crate. The
 `SelectAll` *action* is public — `input/mod.rs:29` re-exports it via
 `pub use state::*`. Dispatching routes it to the focused input's own handler.
+No new import is needed: `request_editor.rs` already globs `input::*`. (gpui's
+own `SelectAll` is an `OsAction` enum variant, not a top-level item, so
+`gpui::*` does not collide; the plan still spells it fully-qualified.)
 
-**Why deferred a frame:** gpui computes the action dispatch path from the
-last rendered frame's focus, so dispatching in the same tick as `focus()`
-can route to the previously focused element instead of the URL input.
+**Why deferred a frame:** `Window::dispatch_action` resolves the target via
+`focus_node_id_in_rendered_frame` (`window.rs:1477-1484`) — the *last rendered*
+frame. Dispatching in the same tick as `focus()` would route to the previously
+focused element, not the URL input.
+
+**Why the explicit `request_animation_frame`:** `Window::focus`
+(`window.rs:1386`) early-returns *without* calling `refresh()` when the handle
+is already focused. Without a forced frame, pressing Ctrl+L while the URL input
+already has focus would schedule an `on_next_frame` callback that no redraw ever
+runs. `request_animation_frame` guarantees the frame, so repeated Ctrl+L
+re-selects reliably.
 
 ## Error handling
 
@@ -146,6 +156,8 @@ an empty URL selects nothing rather than erroring.
 - [ ] Ctrl+Tab with only one tab open does nothing (no flicker, no reload)
 - [ ] Ctrl+L from the body editor focuses the URL input and selects the whole URL
 - [ ] Typing right after Ctrl+L replaces the URL rather than appending
+- [ ] Ctrl+L pressed twice in a row (URL input already focused) still re-selects
+      — this is the `request_animation_frame` case
 - [ ] Ctrl+L with an empty URL does not crash
 - [ ] Tab-switching still saves/restores per-tab state (no regression in
       `switch_to_tab`'s save-then-load path)

--- a/src/app.rs
+++ b/src/app.rs
@@ -18,7 +18,7 @@ use crate::theme::{
     REQUEST_INITIAL_HEIGHT, REQUEST_MAX, REQUEST_MIN, SIDEBAR_MAX, SIDEBAR_MIN, SIDEBAR_WIDTH,
 };
 
-actions!(poopman, [SendRequest, NewTab, CloseTab]);
+actions!(poopman, [SendRequest, NewTab, CloseTab, NextTab, PrevTab, FocusUrl]);
 
 /// Main application view
 pub struct PoopmanApp {

--- a/src/app.rs
+++ b/src/app.rs
@@ -613,3 +613,59 @@ impl Render for PoopmanApp {
             .children(Root::render_dialog_layer(window, cx))
     }
 }
+
+/// Next (`forward`) or previous tab index, wrapping at both ends.
+///
+/// Returns `current` unchanged when `len` is 0 or 1 — callers then hit
+/// `switch_to_tab`'s `index == self.active_tab_index` early-return and no-op.
+fn cycle_index(current: usize, len: usize, forward: bool) -> usize {
+    if len <= 1 {
+        return current;
+    }
+    if forward {
+        (current + 1) % len
+    } else {
+        (current + len - 1) % len
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // NOT `use super::*`: that would pull in `gpui::*`, whose `test` attribute
+    // macro shadows the standard `#[test]`.
+    use super::cycle_index;
+
+    #[test]
+    fn steps_forward_through_the_middle_of_the_list() {
+        assert_eq!(cycle_index(0, 3, true), 1);
+        assert_eq!(cycle_index(1, 3, true), 2);
+    }
+
+    #[test]
+    fn wraps_forward_past_the_last_tab() {
+        assert_eq!(cycle_index(2, 3, true), 0);
+    }
+
+    #[test]
+    fn steps_backward_through_the_middle_of_the_list() {
+        assert_eq!(cycle_index(2, 3, false), 1);
+        assert_eq!(cycle_index(1, 3, false), 0);
+    }
+
+    #[test]
+    fn wraps_backward_past_the_first_tab() {
+        assert_eq!(cycle_index(0, 3, false), 2);
+    }
+
+    #[test]
+    fn single_tab_stays_put_in_both_directions() {
+        assert_eq!(cycle_index(0, 1, true), 0);
+        assert_eq!(cycle_index(0, 1, false), 0);
+    }
+
+    #[test]
+    fn empty_list_returns_current_without_panicking() {
+        assert_eq!(cycle_index(0, 0, true), 0);
+        assert_eq!(cycle_index(0, 0, false), 0);
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -510,6 +510,17 @@ impl Render for PoopmanApp {
                 let index = this.active_tab_index;
                 this.close_tab(index, window, cx);
             }))
+            .on_action(cx.listener(|this, _: &NextTab, window, cx| {
+                let next = cycle_index(this.active_tab_index, this.request_tabs.len(), true);
+                this.switch_to_tab(next, window, cx);
+            }))
+            .on_action(cx.listener(|this, _: &PrevTab, window, cx| {
+                let prev = cycle_index(this.active_tab_index, this.request_tabs.len(), false);
+                this.switch_to_tab(prev, window, cx);
+            }))
+            .on_action(cx.listener(|this, _: &FocusUrl, window, cx| {
+                this.request_editor.update(cx, |editor, cx| editor.focus_url(window, cx));
+            }))
             .size_full()
             .bg(theme.muted)
             .child(

--- a/src/main.rs
+++ b/src/main.rs
@@ -120,6 +120,9 @@ fn main() {
             KeyBinding::new("ctrl-enter", crate::app::SendRequest, Some("Input")),
             KeyBinding::new("ctrl-t", crate::app::NewTab, None),
             KeyBinding::new("ctrl-w", crate::app::CloseTab, None),
+            KeyBinding::new("ctrl-tab", crate::app::NextTab, None),
+            KeyBinding::new("ctrl-shift-tab", crate::app::PrevTab, None),
+            KeyBinding::new("ctrl-l", crate::app::FocusUrl, None),
         ]);
 
         cx.spawn(async move |cx| {

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -866,19 +866,10 @@ impl RequestEditor {
     ///
     /// Select-all goes through action dispatch because `InputState::select_all`
     /// is `pub(super)` in gpui-component and unreachable from this crate; the
-    /// `SelectAll` action itself is public. The dispatch must wait for the next
-    /// frame: `Window::dispatch_action` resolves its target from the *last
-    /// rendered* frame's focus, so dispatching in this same tick would route to
-    /// whatever was focused before. `request_animation_frame` guarantees that
-    /// frame happens even when the URL input already had focus — `Window::focus`
-    /// early-returns without scheduling a redraw in that case, which would
-    /// otherwise strand the callback and make a second Ctrl+L do nothing.
+    /// `SelectAll` action itself is public.
     pub fn focus_url(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.url_input.update(cx, |input, cx| input.focus(window, cx));
-        window.request_animation_frame();
-        window.on_next_frame(|window, cx| {
-            window.dispatch_action(Box::new(gpui_component::input::SelectAll), cx);
-        });
+        window.dispatch_action(Box::new(gpui_component::input::SelectAll), cx);
     }
 
     /// Send the current request. Public so the ctrl-enter action can trigger

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -861,6 +861,26 @@ impl RequestEditor {
         self.send(window, cx);
     }
 
+    /// Focus the URL input and select all of its text. Public so the ctrl-l
+    /// action can trigger it from PoopmanApp.
+    ///
+    /// Select-all goes through action dispatch because `InputState::select_all`
+    /// is `pub(super)` in gpui-component and unreachable from this crate; the
+    /// `SelectAll` action itself is public. The dispatch must wait for the next
+    /// frame: `Window::dispatch_action` resolves its target from the *last
+    /// rendered* frame's focus, so dispatching in this same tick would route to
+    /// whatever was focused before. `request_animation_frame` guarantees that
+    /// frame happens even when the URL input already had focus — `Window::focus`
+    /// early-returns without scheduling a redraw in that case, which would
+    /// otherwise strand the callback and make a second Ctrl+L do nothing.
+    pub fn focus_url(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.url_input.update(cx, |input, cx| input.focus(window, cx));
+        window.request_animation_frame();
+        window.on_next_frame(|window, cx| {
+            window.dispatch_action(Box::new(gpui_component::input::SelectAll), cx);
+        });
+    }
+
     /// Send the current request. Public so the ctrl-enter action can trigger
     /// it from PoopmanApp; no-op while a request is already in flight (the
     /// button is swapped to Cancel then, but the keyboard path isn't).


### PR DESCRIPTION
## Summary

Completes the keyboard-shortcut surface started in PR #15 (ctrl-enter / ctrl-t / ctrl-w) by shipping the two items deferred from the 2026-07-14 quick-wins round:

- **Ctrl+Tab / Ctrl+Shift+Tab** — cycle the active request tab forward/backward in tab-bar order, wrapping at both ends (Postman's behavior; MRU was rejected since gpui exposes no "Ctrl released" hook).
- **Ctrl+L** — focus the URL input and select all its text, like a browser address bar.

Follows the existing three-step pattern exactly: declare the action in `src/app.rs` via `actions!` → bind the keystroke in `src/main.rs` → handle it with `.on_action` on `PoopmanApp`'s root element. 82 lines of source across 3 files.

Two details worth knowing:

- **No `Some("Input")` shadow bindings.** ctrl-enter needs one to out-register gpui-component's secondary-enter. Verified against gpui-component 0.5.1 that it binds neither `ctrl-tab` nor `ctrl-l` anywhere; its bare `tab` → `IndentInline` can't collide because `should_match` compares modifiers with exact equality (`platform/keystroke.rs:112`).
- **No bounds-checking at the call site.** `cycle_index` returns `current` for `len <= 1`, and `switch_to_tab` already early-returns on `index >= len || index == active_tab_index`, so single-tab and empty-list cases no-op by construction.

`focus_url` reaches select-all through action dispatch because `InputState::select_all` is `pub(super)` in gpui-component and unreachable from this crate, while the `SelectAll` action itself is public.

### A design bug this PR fixed before merge

The approved design specified a one-frame deferral (`request_animation_frame` + `on_next_frame`) for the SelectAll dispatch. Code review against the gpui 0.2.2 source disproved both of its premises:

- `dispatch_action` (`window.rs:1477`) samples the **current** focus, not the last rendered frame's — the rendered frame only maps an already-chosen `focus_id` onto a dispatch-tree node, and the URL input renders every frame. It also defers internally via `cx.defer`. Same-tick dispatch is correct.
- `request_animation_frame` **panics from an action listener**: it calls `current_view()` (`window.rs:3362`), which asserts the draw phase is Paint/Prepaint and then unwraps `rendered_entity_stack.last()`, which is empty outside `draw()`. Debug builds hit the assertion; release builds hit the unwrap. Ctrl+L would have crashed on every press.

`0e4d26a` removes both lines. The already-focused edge case the deferral nominally guarded is correct precisely *because* the deferral is gone. The spec and plan are corrected in `03da1af` with the source evidence, so this isn't rediscovered later.

## Test Plan

- [x] 6 new unit tests for `cycle_index` (both wrap directions, mid-list steps, `len == 1`, `len == 0`) — note the backward branch uses `(current + len - 1) % len`; `current - 1` underflows and panics at `current == 0`
- [x] `cargo test` on Windows: 123 passed, 0 failed
- [x] `cargo check` and `cargo clippy --all-targets`: clean, no warnings
- [x] Manually verified in a real window (WSL2 can't run the GUI) on a `--release` build:
  - [x] Ctrl+Tab wraps forward past the last tab; Ctrl+Shift+Tab wraps backward past the first
  - [x] Both fire while typing in the URL input and the body editor
  - [x] Ctrl+Tab with one tab open does nothing
  - [x] Ctrl+L from the body editor focuses the URL and selects the whole thing; typing replaces it
  - [x] Ctrl+L pressed twice in a row still re-selects
  - [x] Ctrl+L with an empty URL does not crash
  - [x] Tab-switching still saves/restores per-tab state

Spec: `docs/superpowers/specs/2026-07-15-tab-cycling-focus-url-design.md`
Plan: `docs/superpowers/plans/2026-07-15-tab-cycling-focus-url.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)