### PR TITLE
feat: app-wide scrolling convention, scrollable tab bar, focus fix

### DIFF
--- a/docs/superpowers/plans/2026-07-15-app-wide-scrolling.md
+++ b/docs/superpowers/plans/2026-07-15-app-wide-scrolling.md
@@ -1,0 +1,939 @@
+# App-Wide Scrolling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the tab bar and response headers scroll, and bring all six scrollable surfaces onto one convention with hover scrollbars.
+
+**Architecture:** A global `theme.scrollbar_show = Hover` gives every scrollbar its visibility policy from one place. Each surface is then rebuilt as three parts — a viewport that owns the size constraint, a scroller that owns content layout and `overflow_scroll`, and a scrollbar that is the scroller's *sibling* inside the viewport, sharing its `ScrollHandle`.
+
+**Tech Stack:** Rust, gpui 0.2.2, gpui-component 0.5.1.
+
+**Spec:** `docs/superpowers/specs/2026-07-15-app-wide-scrolling-design.md`
+
+**Branch:** `feat/app-wide-scrolling` (already checked out; the spec commits are on it).
+
+---
+
+## Background the engineer needs
+
+**This project CANNOT be built or run under WSL2**, which is where you are. `cargo build` and `cargo test` fail on a missing `libxkbcommon`. `cargo check` and `cargo clippy` DO work locally. Tests run on the Windows side, invoked from WSL:
+
+```bash
+pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test"
+```
+
+**Test baseline is 123 passed, 0 failed.** This change adds no tests and must break none.
+
+**There are no unit tests in this plan, and that is correct, not an oversight.** This is a pure layout/rendering change; there is no extractable pure logic, and the behavior needs a real window. Do not invent tests that assert nothing just to have tests. The automated gate is `cargo check` + `cargo clippy` + the unchanged suite. Correctness rests on the user's manual pass (Task 6).
+
+**You cannot verify any of this works.** Do not claim the scrolling works. You can honestly claim it compiles clean and breaks no tests.
+
+### The two rules everything here follows
+
+**Rule A — the three-part idiom.** Every scrollable surface looks like this:
+
+```rust
+div()                              // viewport: owns the size constraint
+    .flex_1()
+    .min_h_0()
+    .child(
+        v_flex()                   // scroller: owns content layout and scrolling
+            .id("some-scroll-container")
+            .size_full()
+            .track_scroll(&self.some_handle)
+            .overflow_scroll()
+            .children(…),
+    )
+    .vertical_scrollbar(&self.some_handle)   // sibling of the scroller, same handle
+```
+
+**The scrollbar goes on the scroller's parent, never on the scroller itself.** `.vertical_scrollbar(&h)` expands to `self.child(ScrollbarLayer{…})`, and that layer renders as `div().absolute().top_0().left_0().right_0().bottom_0()`. Put it inside the scroller and it becomes part of the scrolling content and scrolls away with it. gpui-component places it on the parent at every one of its own call sites (`menu/popup_menu.rs:1309`, `setting/page.rs:189`, `tree.rs:439`).
+
+No `.relative()` is needed on the viewport: gpui defaults `position` to `Position::Relative`, unlike CSS (`gpui-0.2.2/src/style.rs:1193`).
+
+**Do not "simplify" any of this to `.overflow_y_scrollbar()`.** That wrapper moves the element's style onto an outer div and resets the element to a bare one, which relocates `gap`/`padding` away from the content. `history_panel.rs:244` uses it and works — leave it alone — but do not spread it.
+
+**Rule B — `min_h_0` on flex ancestors.** A flex child defaults to `min-height: auto` and refuses to shrink below its content size, so the parent grows to fit instead of constraining the child, and `overflow_scroll` never engages. Every flex ancestor between a scroller and the nearest fixed-height boundary needs `min_h_0()` (`min_w_0()` horizontally). Worked example already in the codebase: `src/body_editor.rs:542`.
+
+**Import paths** (verified; don't guess alternatives):
+- `gpui_component::scroll::ScrollableElement` — the trait providing `.vertical_scrollbar(&h)` / `.horizontal_scrollbar(&h)`. Import as `scroll::ScrollableElement as _`. Precedent: `src/history_panel.rs:6`.
+- `gpui_component::scroll::ScrollbarShow` — the global policy enum.
+- `ScrollHandle` comes from `gpui::*`, already glob-imported in every file you touch.
+
+---
+
+## File Structure
+
+| File | Change | Responsibility |
+|---|---|---|
+| `src/theme.rs` | Modify | The single global scrollbar-visibility lever |
+| `src/tab_bar.rs` | Modify | Scrolling tab strip + pinned "+" + scroll-active-into-view |
+| `src/response_viewer.rs` | Modify | Header list scroll + wrapping values + scrollbar |
+| `src/request_editor.rs` | Modify | Headers/params viewports + scrollbars |
+| `src/body_editor.rs` | Modify | Form-data viewport + scrollbar |
+| `src/environment_manager.rs` | Modify | Two scrollers get handles, viewports, scrollbars |
+
+No new files. `src/history_panel.rs` is deliberately untouched.
+
+---
+
+### Task 1: Global scrollbar policy
+
+Foundational — every later task's scrollbar reads this. Do it first.
+
+**Files:**
+- Modify: `src/theme.rs`
+
+- [ ] **Step 1: Add the import**
+
+`src/theme.rs:5` currently reads:
+
+```rust
+use gpui_component::{Theme, ThemeMode};
+```
+
+Change to:
+
+```rust
+use gpui_component::{scroll::ScrollbarShow, Theme, ThemeMode};
+```
+
+- [ ] **Step 2: Set the policy**
+
+At the end of `apply_theme` there is already a `// Scrollbar` section:
+
+```rust
+    // Scrollbar
+    theme.scrollbar_thumb = c(SCROLLBAR);
+    theme.scrollbar_thumb_hover = c(MUTED_FG);
+```
+
+Replace it with:
+
+```rust
+    // Scrollbar. `Hover` rather than the `Scrolling` default: a scrollbar that only
+    // appears once you are already scrolling cannot tell you scrolling is possible,
+    // which is exactly how a cut-off list reads as broken.
+    // Safe to set here — `Theme::sync_scrollbar_appearance` would overwrite it, but
+    // neither this app nor `gpui_component::init` calls it.
+    theme.scrollbar_show = ScrollbarShow::Hover;
+    theme.scrollbar_thumb = c(SCROLLBAR);
+    theme.scrollbar_thumb_hover = c(MUTED_FG);
+```
+
+- [ ] **Step 3: Verify**
+
+```bash
+cargo check && cargo clippy
+```
+
+Expected: both clean, no warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/theme.rs
+git commit -m "feat(theme): show scrollbars on hover app-wide"
+```
+
+---
+
+### Task 2: Tab bar — horizontal scroll with a pinned "+"
+
+**Files:**
+- Modify: `src/tab_bar.rs`
+
+- [ ] **Step 1: Add the import**
+
+`src/tab_bar.rs:4` currently reads:
+
+```rust
+use gpui_component::{h_flex, ActiveTheme as _};
+```
+
+Change to:
+
+```rust
+use gpui_component::{h_flex, scroll::ScrollableElement as _, ActiveTheme as _};
+```
+
+- [ ] **Step 2: Add the scroll handle field**
+
+`src/tab_bar.rs:26-29` currently reads:
+
+```rust
+pub struct TabBar {
+    tabs: Vec<RequestTab>,
+    active_tab_index: usize,
+}
+```
+
+Change to:
+
+```rust
+pub struct TabBar {
+    tabs: Vec<RequestTab>,
+    active_tab_index: usize,
+    scroll_handle: ScrollHandle,
+}
+```
+
+`src/tab_bar.rs:32-37` currently reads:
+
+```rust
+    pub fn new(_window: &mut Window, _cx: &mut Context<Self>) -> Self {
+        Self {
+            tabs: vec![],
+            active_tab_index: 0,
+        }
+    }
+```
+
+Change to:
+
+```rust
+    pub fn new(_window: &mut Window, _cx: &mut Context<Self>) -> Self {
+        Self {
+            tabs: vec![],
+            active_tab_index: 0,
+            scroll_handle: ScrollHandle::new(),
+        }
+    }
+```
+
+- [ ] **Step 3: Scroll the active tab into view when it changes**
+
+`src/tab_bar.rs:40-43` currently reads:
+
+```rust
+    pub fn update_tabs(&mut self, tabs: Vec<RequestTab>, active_index: usize, _cx: &mut Context<Self>) {
+        self.tabs = tabs;
+        self.active_tab_index = active_index;
+    }
+```
+
+Change to:
+
+```rust
+    pub fn update_tabs(&mut self, tabs: Vec<RequestTab>, active_index: usize, _cx: &mut Context<Self>) {
+        let active_changed = self.active_tab_index != active_index;
+        self.tabs = tabs;
+        self.active_tab_index = active_index;
+
+        // Ctrl+Tab can select a tab that is scrolled out of view. Indices line up
+        // because the tabs are the scroller's direct children and "+" is not —
+        // `scroll_to_item` indexes `child_bounds`.
+        if active_changed {
+            self.scroll_handle.scroll_to_item(active_index);
+        }
+    }
+```
+
+- [ ] **Step 4: Wrap the tab strip in a scrolling viewport**
+
+In `impl Render for TabBar`, `src/tab_bar.rs:75-80` currently reads:
+
+```rust
+            .child(
+                // Render all tabs
+                h_flex()
+                    .gap_1()
+                    .items_center()
+                    .children(self.tabs.iter().enumerate().map(|(index, tab)| {
+```
+
+Change to:
+
+```rust
+            .child(
+                // Viewport for the scrolling tab strip. The "+" button is deliberately
+                // outside it (it stays a child of the outer row below), so a full row
+                // can never push it off-screen.
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .child(
+                        h_flex()
+                            .id("tab-strip")
+                            .gap_1()
+                            .items_center()
+                            .size_full()
+                            .track_scroll(&self.scroll_handle)
+                            .overflow_x_scroll()
+                            .children(self.tabs.iter().enumerate().map(|(index, tab)| {
+```
+
+Then find the end of that `.children(...)` closure — currently `src/tab_bar.rs:131-132`:
+
+```rust
+                    }))
+            )
+```
+
+Change to:
+
+```rust
+                            })),
+                    )
+                    .horizontal_scrollbar(&self.scroll_handle),
+            )
+```
+
+Everything inside the `.children(...)` closure (the per-tab rendering, `src/tab_bar.rs:81-131`) is unchanged — only its indentation shifts. The "+" button block (`src/tab_bar.rs:133-152`) is unchanged and needs no edit: it is already a sibling of this `.child(...)` in the outer `h_flex`, and giving the viewport `flex_1` is what pins it to the right.
+
+- [ ] **Step 5: Verify**
+
+```bash
+cargo check && cargo clippy
+```
+
+Expected: both clean, no warnings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/tab_bar.rs
+git commit -m "feat(tabs): scroll the tab strip horizontally, pin the new-tab button"
+```
+
+---
+
+### Task 3: Response headers — scroll, wrap, scrollbar
+
+**Files:**
+- Modify: `src/response_viewer.rs`
+
+- [ ] **Step 1: Add the import**
+
+`src/response_viewer.rs:3` currently reads:
+
+```rust
+use gpui_component::{button::*, h_flex, input::*, v_flex, ActiveTheme as _};
+```
+
+Change to:
+
+```rust
+use gpui_component::{button::*, h_flex, input::*, scroll::ScrollableElement as _, v_flex, ActiveTheme as _};
+```
+
+- [ ] **Step 2: Turn the header list's parent into a proper viewport**
+
+`src/response_viewer.rs:436-446` currently reads:
+
+```rust
+                        .when(self.active_tab == 1, |this| {
+                            this.child(
+                                div()
+                                    .flex()
+                                    .flex_col()
+                                    .flex_1()
+                                    .w_full()
+                                    .overflow_hidden()
+                                    .child(self.render_headers(cx)),
+                            )
+                        }),
+```
+
+Change to:
+
+```rust
+                        .when(self.active_tab == 1, |this| {
+                            this.child(
+                                div()
+                                    .flex()
+                                    .flex_col()
+                                    .flex_1()
+                                    .min_h_0() // Let the list shrink so its overflow_scroll engages
+                                    .w_full()
+                                    .overflow_hidden()
+                                    .child(self.render_headers(cx))
+                                    .vertical_scrollbar(&self.headers_scroll_handle),
+                            )
+                        }),
+```
+
+This div is the viewport; `render_headers` returns the scroller. The scrollbar belongs here, as the scroller's sibling — not inside `render_headers`.
+
+- [ ] **Step 3: Make long values wrap**
+
+`src/response_viewer.rs:253-275` — the `.child(...)` inside the scroller — currently reads:
+
+```rust
+                .child(
+                    v_flex()
+                        .gap_1()
+                        .p_2()
+                        .children(response.headers.iter().map(|(key, value)| {
+                            h_flex()
+                                .gap_2()
+                                .w_full()
+                                .child(
+                                    div()
+                                        .font_weight(FontWeight::SEMIBOLD)
+                                        .text_sm()
+                                        .flex_shrink_0()
+                                        .child(format!("{}:", key)),
+                                )
+                                .child(
+                                    div()
+                                        .text_sm()
+                                        .flex_1()
+                                        .overflow_hidden()
+                                        .text_ellipsis()
+                                        .whitespace_nowrap()
+                                        .child(value.clone()),
+                                )
+                        })),
+                )
+```
+
+Change to:
+
+```rust
+                .child(
+                    v_flex()
+                        .gap_1()
+                        .p_2()
+                        .children(response.headers.iter().map(|(key, value)| {
+                            h_flex()
+                                .gap_2()
+                                .w_full()
+                                .items_start()
+                                .child(
+                                    div()
+                                        .font_weight(FontWeight::SEMIBOLD)
+                                        .text_sm()
+                                        .flex_shrink_0()
+                                        .child(format!("{}:", key)),
+                                )
+                                .child(
+                                    // Wraps rather than ellipsizing — reading the whole
+                                    // value is the point of looking at headers. min_w_0
+                                    // is load-bearing: a value with no break
+                                    // opportunities (a JWT, a long set-cookie) otherwise
+                                    // has an automatic minimum width of the entire
+                                    // string and blows the row out horizontally.
+                                    div()
+                                        .text_sm()
+                                        .flex_1()
+                                        .min_w_0()
+                                        .child(value.clone()),
+                                )
+                        })),
+                )
+```
+
+Three changes: the row gains `.items_start()` so the key stays top-aligned against a now-multi-line value; the value div drops `.overflow_hidden()`, `.text_ellipsis()`, `.whitespace_nowrap()`; and it gains `.min_w_0()`.
+
+Leave the scroller itself (`src/response_viewer.rs:244-251`) exactly as it is — it already has `.id()`, `.min_h_0()`, `.track_scroll()`, `.overflow_scroll()`. Do **not** add a scrollbar there; Step 2 put it on the viewport.
+
+- [ ] **Step 4: Verify**
+
+```bash
+cargo check && cargo clippy
+```
+
+Expected: both clean, no warnings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/response_viewer.rs
+git commit -m "fix(viewer): scroll the response header list, wrap long values"
+```
+
+---
+
+### Task 4: Request headers and params — viewports + scrollbars
+
+Both scrollers are `this.child(v_flex()…)` with no viewport of their own, so each needs one interposed. Do **not** hang the scrollbar on the enclosing `this` — that is the whole tab-content area, so the scrollbar would span more than the list.
+
+**Files:**
+- Modify: `src/request_editor.rs`
+
+- [ ] **Step 1: Add the import**
+
+`src/request_editor.rs:4-7` currently reads:
+
+```rust
+use gpui_component::{
+    button::*, checkbox::Checkbox, input::*,
+    select::*, v_flex, ActiveTheme as _, Disableable as _, Icon, IndexPath, Sizable as _,
+};
+```
+
+Change to:
+
+```rust
+use gpui_component::{
+    button::*, checkbox::Checkbox, input::*,
+    scroll::ScrollableElement as _,
+    select::*, v_flex, ActiveTheme as _, Disableable as _, Icon, IndexPath, Sizable as _,
+};
+```
+
+- [ ] **Step 2: Interpose a viewport around the headers list**
+
+`src/request_editor.rs:1197-1206` currently reads:
+
+```rust
+                            this.child(
+                                // Scrollable headers list
+                                v_flex()
+                                    .id("headers-scroll-container")
+                                    .gap_2()
+                                    .p_2()
+                                    .pb_4()  // Bottom padding to prevent last row from being obscured
+                                    .flex_1()
+                                    .track_scroll(&self.headers_scroll_handle)
+                                    .overflow_scroll()
+                                    .children(self.headers.iter().enumerate().map(
+```
+
+Change to:
+
+```rust
+                            this.child(
+                                // Viewport: owns the size constraint so the list can
+                                // shrink and actually scroll; also hosts the scrollbar,
+                                // which must be the scroller's sibling rather than its
+                                // child (an absolute layer inside the scroller scrolls
+                                // away with the content).
+                                div()
+                                    .flex_1()
+                                    .min_h_0()
+                                    .child(
+                                        // Scrollable headers list
+                                        v_flex()
+                                            .id("headers-scroll-container")
+                                            .gap_2()
+                                            .p_2()
+                                            .pb_4()  // Bottom padding to prevent last row from being obscured
+                                            .size_full()
+                                            .track_scroll(&self.headers_scroll_handle)
+                                            .overflow_scroll()
+                                            .children(self.headers.iter().enumerate().map(
+```
+
+Note `.flex_1()` moved off the `v_flex` and became `.size_full()` — the viewport owns the flex sizing now.
+
+Then find the end of that `.children(...)` closure and the close of the `v_flex`, and close the new viewport around it, adding the scrollbar:
+
+```rust
+                                    )
+                                    .vertical_scrollbar(&self.headers_scroll_handle),
+                            )
+```
+
+- [ ] **Step 3: Interpose a viewport around the params list**
+
+`src/request_editor.rs:1272-1279` currently reads:
+
+```rust
+                                v_flex()
+                                    .id("params-scroll-container")
+                                    .gap_2()
+                                    .p_2()
+                                    .pb_4()
+                                    .flex_1()
+                                    .track_scroll(&self.params_scroll_handle)
+                                    .overflow_scroll()
+                                    .children(self.params.iter().enumerate().map(
+```
+
+Change to:
+
+```rust
+                                div()
+                                    .flex_1()
+                                    .min_h_0()
+                                    .child(
+                                        v_flex()
+                                            .id("params-scroll-container")
+                                            .gap_2()
+                                            .p_2()
+                                            .pb_4()
+                                            .size_full()
+                                            .track_scroll(&self.params_scroll_handle)
+                                            .overflow_scroll()
+                                            .children(self.params.iter().enumerate().map(
+```
+
+and close the viewport after the `v_flex` closes:
+
+```rust
+                                    )
+                                    .vertical_scrollbar(&self.params_scroll_handle),
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+cargo check && cargo clippy
+```
+
+Expected: both clean, no warnings. Watch for brace/paren mismatches — this task re-nests two long builder chains, and that is where it will go wrong. If the errors are confusing, re-read the whole `.when(...)` block rather than patching braces one at a time.
+
+Both lists keep their `ScrollHandle`: `request_editor.rs:468-495` uses them to auto-scroll to the newly added row. Do not remove the handles.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/request_editor.rs
+git commit -m "fix(editor): scroll headers and params lists, add scrollbars"
+```
+
+---
+
+### Task 5: Form-data — viewport + scrollbar
+
+**Files:**
+- Modify: `src/body_editor.rs`
+
+- [ ] **Step 1: Add the import**
+
+`src/body_editor.rs:4-7` currently reads:
+
+```rust
+use gpui_component::{
+    button::*, checkbox::Checkbox, h_flex, input::{Input, InputState, InputEvent as InputChangeEvent, TabSize},
+    select::*, v_flex, ActiveTheme as _, IndexPath, Sizable as _,
+};
+```
+
+Change to:
+
+```rust
+use gpui_component::{
+    button::*, checkbox::Checkbox, h_flex, input::{Input, InputState, InputEvent as InputChangeEvent, TabSize},
+    scroll::ScrollableElement as _,
+    select::*, v_flex, ActiveTheme as _, IndexPath, Sizable as _,
+};
+```
+
+- [ ] **Step 2: Interpose the viewport**
+
+`src/body_editor.rs:657-667` currently reads:
+
+```rust
+                this.child(
+                    v_flex()
+                        .id("formdata-scroll-container")
+                        .gap_2()
+                        .p_2()
+                        .pb_4()  // Bottom padding to prevent last row from being obscured
+                        .flex_1()
+                        .min_h_0()  // Allow scrolling to work
+                        .w_full()
+                        .track_scroll(&self.formdata_scroll_handle)
+                        .overflow_scroll()
+```
+
+Change to:
+
+```rust
+                this.child(
+                    div()
+                        .flex_1()
+                        .min_h_0()  // Allow scrolling to work
+                        .child(
+                            v_flex()
+                                .id("formdata-scroll-container")
+                                .gap_2()
+                                .p_2()
+                                .pb_4()  // Bottom padding to prevent last row from being obscured
+                                .size_full()
+                                .track_scroll(&self.formdata_scroll_handle)
+                                .overflow_scroll()
+```
+
+and close the viewport after the `v_flex` closes, adding the scrollbar:
+
+```rust
+                        )
+                        .vertical_scrollbar(&self.formdata_scroll_handle),
+                )
+```
+
+This surface already scrolled correctly — it had `min_h_0` all along — so it is only gaining the scrollbar and the uniform shape. Keep the handle: `body_editor.rs:364-390` uses it for scroll-to-new-row.
+
+- [ ] **Step 3: Verify**
+
+```bash
+cargo check && cargo clippy
+```
+
+Expected: both clean, no warnings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/body_editor.rs
+git commit -m "fix(body): add a scrollbar to the form-data list"
+```
+
+---
+
+### Task 6: Environment manager — handles, viewports, scrollbars
+
+Neither scroller here owns a `ScrollHandle` today, so both need one. `.overflow_y_scrollbar()` is **not** an option: `env-list` carries `.gap_0p5()`, and that wrapper would relocate the gap onto an outer div, silently collapsing the spacing between environment rows.
+
+**Files:**
+- Modify: `src/environment_manager.rs`
+
+- [ ] **Step 1: Add the import**
+
+`src/environment_manager.rs:8-10` currently reads:
+
+```rust
+use gpui_component::{
+    button::*, checkbox::Checkbox, h_flex, input::*, v_flex, ActiveTheme as _, Sizable as _,
+};
+```
+
+Change to:
+
+```rust
+use gpui_component::{
+    button::*, checkbox::Checkbox, h_flex, input::*, scroll::ScrollableElement as _, v_flex,
+    ActiveTheme as _, Sizable as _,
+};
+```
+
+- [ ] **Step 2: Add two scroll handle fields**
+
+`src/environment_manager.rs:27-39` currently reads:
+
+```rust
+pub struct EnvironmentManager {
+    db: Arc<Database>,
+    environments: Vec<Environment>,
+    active_id: Option<i64>,
+    selected_id: Option<i64>,
+    name_input: Entity<InputState>,
+    var_rows: Vec<VarRow>,
+    /// True while programmatically loading inputs, so their `Change` events don't
+    /// trigger an auto-save of values we just set.
+    suspend_autosave: bool,
+    /// Live input-change subscriptions (name + each var row), rewired on load.
+    _subs: Vec<Subscription>,
+}
+```
+
+Change to:
+
+```rust
+pub struct EnvironmentManager {
+    db: Arc<Database>,
+    environments: Vec<Environment>,
+    active_id: Option<i64>,
+    selected_id: Option<i64>,
+    name_input: Entity<InputState>,
+    var_rows: Vec<VarRow>,
+    env_list_scroll_handle: ScrollHandle,
+    var_list_scroll_handle: ScrollHandle,
+    /// True while programmatically loading inputs, so their `Change` events don't
+    /// trigger an auto-save of values we just set.
+    suspend_autosave: bool,
+    /// Live input-change subscriptions (name + each var row), rewired on load.
+    _subs: Vec<Subscription>,
+}
+```
+
+`src/environment_manager.rs:50-59` currently reads:
+
+```rust
+        let mut this = Self {
+            db,
+            environments,
+            active_id,
+            selected_id,
+            name_input,
+            var_rows: vec![],
+            suspend_autosave: false,
+            _subs: vec![],
+        };
+```
+
+Change to:
+
+```rust
+        let mut this = Self {
+            db,
+            environments,
+            active_id,
+            selected_id,
+            name_input,
+            var_rows: vec![],
+            env_list_scroll_handle: ScrollHandle::new(),
+            var_list_scroll_handle: ScrollHandle::new(),
+            suspend_autosave: false,
+            _subs: vec![],
+        };
+```
+
+- [ ] **Step 3: Rebuild the environment list as viewport / scroller / scrollbar**
+
+`src/environment_manager.rs:310-315` currently reads:
+
+```rust
+                        v_flex()
+                            .id("env-list")
+                            .flex_1()
+                            .gap_0p5()
+                            .overflow_scroll()
+                            .children(self.environments.iter().map(|env| {
+```
+
+Change to:
+
+```rust
+                        div()
+                            .flex_1()
+                            .min_h_0()
+                            .child(
+                                v_flex()
+                                    .id("env-list")
+                                    .size_full()
+                                    .gap_0p5()
+                                    .track_scroll(&self.env_list_scroll_handle)
+                                    .overflow_scroll()
+                                    .children(self.environments.iter().map(|env| {
+```
+
+and close the viewport after the `v_flex` closes, adding the scrollbar:
+
+```rust
+                            )
+                            .vertical_scrollbar(&self.env_list_scroll_handle),
+```
+
+- [ ] **Step 4: Rebuild the variables list the same way**
+
+`src/environment_manager.rs:438-442` currently reads:
+
+```rust
+                            .child(
+                                v_flex()
+                                    .id("env-vars")
+                                    .flex_1()
+                                    .overflow_scroll()
+                                    .children(self.var_rows.iter().enumerate().map(|(index, row)| {
+```
+
+Change to:
+
+```rust
+                            .child(
+                                div()
+                                    .flex_1()
+                                    .min_h_0()
+                                    .child(
+                                        v_flex()
+                                            .id("env-vars")
+                                            .size_full()
+                                            .track_scroll(&self.var_list_scroll_handle)
+                                            .overflow_scroll()
+                                            .children(self.var_rows.iter().enumerate().map(|(index, row)| {
+```
+
+and close the viewport after the `v_flex` closes, adding the scrollbar:
+
+```rust
+                                    )
+                                    .vertical_scrollbar(&self.var_list_scroll_handle),
+                            )
+```
+
+- [ ] **Step 5: Apply Rule B to this file's ancestor chains**
+
+**This step requires you to read the code. The ancestors are deliberately not listed — they were not traced during design, and writing them from memory would be guessing.**
+
+For each of the two viewports you just created, read outward to the nearest fixed-height boundary (a `.h(px(…))`, a `.max_h(…)`, a sized dialog container, or the window root). Add `.min_h_0()` to every intervening flex ancestor that lacks it. Rule B and its rationale are in the Background section; the worked example is `src/body_editor.rs:542`.
+
+If a chain is ambiguous, report DONE_WITH_CONCERNS describing what you found rather than guessing. A superfluous `min_h_0` is inert; a missing one leaves the surface broken and the manual pass will blame the wrong change.
+
+- [ ] **Step 6: Verify**
+
+```bash
+cargo check && cargo clippy
+```
+
+Expected: both clean, no warnings.
+
+- [ ] **Step 7: Run the full suite**
+
+```bash
+pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test"
+```
+
+Expected: `123 passed; 0 failed` — unchanged.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/environment_manager.rs
+git commit -m "fix(env): scroll the environment and variable lists, add scrollbars"
+```
+
+---
+
+### Task 7: User manual verification
+
+**This cannot be signed off from WSL.** Every claim about whether scrolling works is the user's to make. Build a release exe and ask them to walk the checklist.
+
+- [ ] **Step 1: Build the exe on Windows**
+
+Kill any running `poopman.exe` first — it holds a file lock — then:
+
+```bash
+pwsh.exe -NoProfile -Command "cd E:\code\poopman; \$env:GPUI_FXC_PATH = 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22000.0\x64\fxc.exe'; cargo build --release"
+```
+
+Expected: `Finished release profile [optimized]`, roughly 2-3 minutes. Binary at `E:\code\poopman\target\release\poopman.exe`.
+
+- [ ] **Step 2: Ask the user to walk the checklist**
+
+Tab bar:
+- [ ] Open enough tabs to overflow the row — the strip scrolls horizontally
+- [ ] The "+" button stays visible and clickable no matter how many tabs are open
+- [ ] A hover scrollbar appears under the tab strip when the mouse is over it
+- [ ] Ctrl+Tab to a tab scrolled out of view scrolls it back into view
+- [ ] Ctrl+Shift+Tab likewise, in the other direction
+- [ ] Clicking a partially visible tab still selects it
+
+Response headers:
+- [ ] A response with many headers scrolls vertically
+- [ ] A long value with spaces (e.g. `content-security-policy`) wraps and is fully readable
+- [ ] A long value with no break opportunities (a JWT in `authorization`, a long `set-cookie`) does not blow the row out horizontally — note what it actually does
+- [ ] A hover scrollbar appears when the mouse is over the header list
+- [ ] The scrollbar stays put while scrolling (it must not scroll away with the content)
+- [ ] Header text can still be selected
+
+Other surfaces:
+- [ ] Request headers and params lists scroll, with a hover scrollbar
+- [ ] Adding a header/param row still auto-scrolls to the new row (no regression)
+- [ ] Form-data rows scroll, with a hover scrollbar; add-row auto-scroll still works
+- [ ] Environment manager: both the environment list and the variable list scroll, with hover scrollbars
+- [ ] Environment rows still have visible spacing between them (the `gap_0p5` regression check)
+- [ ] History panel is unchanged
+
+Global:
+- [ ] Scrollbars are invisible until hovered, everywhere
+- [ ] Scrolling the response area does not scroll the history panel or vice versa
+
+- [ ] **Step 3: If the lists still don't scroll, STOP**
+
+The `min_h_0` diagnosis is a hypothesis (see the spec's "Risk" section). If the manual pass shows the lists still don't scroll, **do not layer more fixes on it** — return to root-cause investigation with the `superpowers:systematic-debugging` skill.
+
+The tab-bar changes and the header-value wrapping are independent of that hypothesis and should hold regardless; report them separately rather than reverting everything.
+
+---
+
+## Definition of done
+
+- `cargo check` and `cargo clippy` clean under WSL.
+- `pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test"` still 123 passed, 0 failed.
+- User has walked the Task 7 checklist and confirmed.
+- Then, and only then, open the PR against `main` for rebase-merge (matching PRs #13–#20).

--- a/docs/superpowers/specs/2026-07-15-app-wide-scrolling-design.md
+++ b/docs/superpowers/specs/2026-07-15-app-wide-scrolling-design.md
@@ -43,9 +43,8 @@ in form-data`.
   shrink-to-fit was rejected (titles become unreadable fast, and the flex-shrink logic
   is fussier); an overflow dropdown was rejected as scope creep.
 - **Scrollbars appear on hover**, set once globally rather than per-call-site.
-- **Long header values wrap** rather than scrolling horizontally or hiding behind a
-  tooltip. Reading the value is the whole point of looking at headers; a tooltip can't
-  be selected or copied.
+- ~~**Long header values wrap**~~ — **attempted and reverted.** See "Wrapping:
+  attempted and reverted" below. Values stay on one line, ellipsized, as before.
 - **All surfaces change in one batch, verified in one manual pass** (user's call). See
   "Risk" below for why this is safe here.
 - Out of scope: response body and code snippet panel (Input-internal scrolling);
@@ -246,6 +245,80 @@ Enumerating them here from memory would be guessing.
 
 No change. Already conforms.
 
+## Wrapping: attempted and reverted
+
+Wrapping long header values shipped in `e843417`, broke the layout, and was reverted.
+Recorded here in full because the underlying fragility is still live and someone will
+hit it again.
+
+**Symptom.** With wrapping on, opening a response and switching to its Headers tab
+collapsed the **request** card above to ~280px — its URL input vanished entirely and its
+header inputs squashed to squares. The response card stayed full width. Nothing else
+changed.
+
+**What was proven, by bisecting five real GUI builds on Windows:**
+
+| Build | request card |
+|---|---|
+| `5829b0f` baseline, before any code change | wide |
+| baseline + all seven code commits | narrow |
+| all commits, `request_editor.rs` reverted | narrow |
+| baseline + `response_viewer.rs` changes only | narrow |
+| baseline + `response_viewer.rs` with only the **wrap** reverted | wide |
+
+So: dropping `whitespace_nowrap` from the header value div is the sole trigger. The
+`min_h_0()` and `.vertical_scrollbar()` added alongside it are innocent — they are
+present in the "wide" build.
+
+**Where it breaks, measured** — `canvas` probes logging each element's width:
+
+```
+n575-right-column   1238        (unchanged when the response loads)
+n594-splitter-host  1238        (unchanged)
+resp-card           1236        (unchanged)
+req-panel-inner     1238 -> 281 (collapses)
+req-card            1236 -> 279
+request-editor-root 1236 -> 279
+```
+
+The break is exactly at the request `ResizablePanel`'s own div, inside `v_resizable`.
+Its sibling response panel, in the same `v_flex`, is unaffected.
+
+**Ruled out** (each by experiment or by reading the vendored source, not by argument):
+
+- `request_editor.rs`'s viewports — reverting them changes nothing.
+- `min_h_0()` and `.vertical_scrollbar()` — present in a working build.
+- The resizable state machine — `update_panel_size` and `adjust_to_container_size`
+  (`resizable/mod.rs:124,268`) only ever touch `bounds.size.along(axis)`, i.e. height
+  for a vertical group. They cannot set a width.
+- `initial_size` → `flex_basis`. Removing `.size()`/`.size_range()` makes the request
+  panel structurally identical to the response panel; it still collapses to 281.
+- A constant coincidentally equal to 281 — `REQUEST_MIN` is 150, `REQUEST_MAX` 700,
+  `PANEL_MIN_SIZE` 100. 281 is a computed content width.
+
+**What is known about the mechanism:** `ResizablePanel::render` sizes itself with
+`size_full()`, i.e. `width: 100%`. Per taffy, a percentage cross-size also **disables
+stretch** — `flexbox.rs:1601` tests the *raw* style's `is_auto()`, and `relative(1.)` is
+`Percent`, not `Auto`. So the panel's width depends entirely on that percentage
+resolving; there is no stretch fallback. When it fails to resolve, the panel falls back
+to content sizing — which is exactly the observed 281. A faithful reconstruction of the
+tree in raw taffy 0.9 reproduces the symptom *only* when the panels' inner main size is
+forced indefinite, and in that regime the request card is 281 regardless of wrapping.
+
+**What was never explained:** why removing `nowrap` in the *response* subtree changes
+the *request* panel's width at all. They are siblings under a container sized from
+above. The taffy reconstruction says it is impossible; five GUI builds say it happens.
+The real tree therefore contains something neither the source reading nor the model
+captured. Chasing it further was not worth more of the user's time, so wrapping stays
+off until someone finds it.
+
+**If you pick this up:** start from the probe result above — the break is at the request
+panel's div and nowhere higher. The next measurement worth taking is the width of
+`v_resizable`'s own `v_flex`, which no probe reached because
+`ResizablePanelGroup::child` only accepts `Into<ResizablePanel>`. If that reads 1238 the
+break is inside `ResizablePanel`; if it reads 281 the break is above it and the model is
+missing a node.
+
 ## Risk: the `min_h_0` diagnosis is a hypothesis
 
 The only established facts are that the user reports these surfaces don't scroll, and
@@ -294,10 +367,9 @@ Tab bar:
 
 Response headers:
 - [ ] A response with many headers scrolls vertically
-- [ ] A long value with spaces (e.g. `content-security-policy`) wraps and is fully readable
-- [ ] A long value with **no** break opportunities (e.g. a JWT in `authorization`, a long
-      `set-cookie`) does not blow the row out horizontally — this is the `min_w_0()` case;
-      note what it actually does, since a single unbreakable token has nowhere to wrap
+- [ ] Long values stay on one line, ellipsized (wrapping was reverted — see above)
+- [ ] The request card above is still full width with a response loaded and the Headers
+      tab open — the regression this revert addresses
 - [ ] A hover scrollbar appears when the mouse is over the header list
 - [ ] Header text can still be selected
 

--- a/docs/superpowers/specs/2026-07-15-app-wide-scrolling-design.md
+++ b/docs/superpowers/specs/2026-07-15-app-wide-scrolling-design.md
@@ -60,9 +60,18 @@ theme.scrollbar_show = ScrollbarShow::Hover;
 ```
 
 Every `Scrollbar` reads `cx.theme().scrollbar_show`, so this is the single lever.
-Verified safe: `Theme::sync_scrollbar_appearance` (`theme/mod.rs:141`) would overwrite
-this, but neither poopman nor `gpui_component::init` (`lib.rs:97-109`) calls it.
-`Hover` is also what gpui-component itself picks for systems not set to auto-hide.
+
+**This assignment survives by ordering, not by absence** — an earlier draft of this spec
+claimed `Theme::sync_scrollbar_appearance` (`theme/mod.rs:141`) is never called, having
+only skimmed `gpui_component::init`'s body (`lib.rs:97-109`) without following into
+`theme::init`. It *is* called: `init` → `theme::init` (`theme/mod.rs:21-26`) →
+`sync_scrollbar_appearance` at `:24`. The assignment wins because `src/main.rs:111` runs
+`gpui_component::init(cx)` before `:112` runs `apply_theme(cx)`. **Reordering those two
+lines would silently revert the policy.** The code comment must say this, so nobody
+"tidies" the ordering later.
+
+`sync_scrollbar_appearance` picks `Hover` itself on systems not set to auto-hide, so on
+those machines this is a no-op; on auto-hide systems it overrides `Scrolling`.
 
 **Rule 2 — One idiom: wrapper / scroller / scrollbar.** Every scrollable surface is
 three parts, with the scrollbar a *sibling* of the scroller:
@@ -149,6 +158,16 @@ h_flex()                                  // existing outer row
     .child(…existing "+" button, unchanged…)   // outside the viewport → pinned
 ```
 
+- **Each tab's `h_flex` needs `.flex_shrink_0()`.** Without it the strip does not scroll
+  at all: gpui defaults `flex_shrink` to `1.0` (`gpui-0.2.2/src/style.rs`,
+  `Style::default()`), so a strip with a definite width squishes its tabs to fit rather
+  than overflowing, and `overflow_x_scroll` never engages. The tab title div carries
+  `.overflow_hidden()`, which drops its automatic minimum width to 0, so tabs collapse to
+  method + close button with the title gone long before any scrolling starts.
+  gpui-component's own `Tab` sets `.flex_shrink_0()` for exactly this reason
+  (`tab/tab.rs:591`), and this codebase already uses the idiom at
+  `environment_manager.rs:267`. This was missed in the first draft of this spec and caught
+  in final review — the scroll would have silently never happened.
 - The "+" button already *is* a sibling of the tab strip in today's outer `h_flex`, so it
   needs no change; giving the viewport `flex_1` is what pins the button. Today "+" is
   pushed off-screen along with the tabs — that is the "点满了" half of the defect.

--- a/docs/superpowers/specs/2026-07-15-app-wide-scrolling-design.md
+++ b/docs/superpowers/specs/2026-07-15-app-wide-scrolling-design.md
@@ -1,0 +1,221 @@
+# Spec: app-wide scrolling convention + tab-bar and response-header scroll fixes
+
+Date: 2026-07-15
+Status: Approved (design confirmed by user)
+
+## Goal
+
+Two reported defects, plus the app-wide convention that prevents them recurring:
+
+1. **Response headers** — long values are truncated with no way to read them, and the
+   header list does not scroll.
+2. **Tab bar** — once tabs fill the row they overflow with no way to reach them, and
+   the "+" button gets pushed off-screen with them.
+
+The user explicitly asked for the whole app's scrolling to be considered rather than
+two isolated patches, because the root cause is an absent convention: three different
+scroll idioms coexist today and `min_h_0` is applied inconsistently.
+
+## Audit (the fact base)
+
+**Six surfaces, not eight.** The response body (`response_viewer.rs:365`) and the code
+snippet panel (`code_snippet_panel.rs:149`) both render `Input::new(&self.body_display)`
+— a gpui-component editor that owns its internal scrolling. They are out of scope.
+
+| Surface | Current state | Verdict |
+|---|---|---|
+| Tab bar (`tab_bar.rs:70-152`) | No scroll at all; container has no `id`; "+" is a sibling of the tab strip | ✗ defect 2 |
+| Response headers (`response_viewer.rs:242-276`) | Self has `overflow_scroll` + `min_h_0`; **parent (`:437-444`) lacks `min_h_0`**; values are `text_ellipsis` + `whitespace_nowrap` | ✗ defect 1 — two independent problems (vertical + horizontal) |
+| Request headers (`request_editor.rs:1203-1206`) | `track_scroll` + `overflow_scroll`, **no `min_h_0`** | ✗ same suspected cause |
+| Request params (`request_editor.rs:1278`) | Same as above | ✗ same suspected cause |
+| Form-data (`body_editor.rs:659-667`) | Has `min_h_0`; scrolls | ~ missing scrollbar only |
+| Environment manager (`environment_manager.rs:314, 442`) | `overflow_scroll` | ~ suspected + missing scrollbar |
+| History (`history_panel.rs:244`) | `overflow_y_scrollbar` | ✓ the only surface written correctly |
+
+The `min_h_0` lesson was already learned once and left un-generalized:
+`body_editor.rs:542` carries the comment `.min_h_0()  // Critical for scrolling to work
+in form-data`.
+
+## Scope decisions
+
+- **Tab overflow: horizontal scroll with a pinned "+".** Tab widths stay fixed; the
+  strip scrolls; "+" moves outside the scroll area and stays at the right. Chrome-style
+  shrink-to-fit was rejected (titles become unreadable fast, and the flex-shrink logic
+  is fussier); an overflow dropdown was rejected as scope creep.
+- **Scrollbars appear on hover**, set once globally rather than per-call-site.
+- **Long header values wrap** rather than scrolling horizontally or hiding behind a
+  tooltip. Reading the value is the whole point of looking at headers; a tooltip can't
+  be selected or copied.
+- **All surfaces change in one batch, verified in one manual pass** (user's call). See
+  "Risk" below for why this is safe here.
+- Out of scope: response body and code snippet panel (Input-internal scrolling);
+  Collections; auth helper tab.
+
+## The convention (three rules)
+
+**Rule 1 — Scrollbar visibility is global.** `src/theme.rs`'s `apply_theme` sets:
+
+```rust
+theme.scrollbar_show = ScrollbarShow::Hover;
+```
+
+Every `Scrollbar` reads `cx.theme().scrollbar_show`, so this is the single lever.
+Verified safe: `Theme::sync_scrollbar_appearance` (`theme/mod.rs:141`) would overwrite
+this, but neither poopman nor `gpui_component::init` (`lib.rs:97-109`) calls it.
+`Hover` is also what gpui-component itself picks for systems not set to auto-hide.
+
+**Rule 2 — Pick the API by whether you need programmatic scroll control.**
+
+- Need to drive the scroll position (scroll-to-bottom on row add, scroll-into-view):
+  own a `ScrollHandle`, then `.track_scroll(&h).overflow_scroll()` plus
+  `.vertical_scrollbar(&h)` / `.horizontal_scrollbar(&h)`.
+- Don't need it: `.overflow_y_scrollbar()` / `.overflow_x_scrollbar()`, which wrap the
+  element in `Scrollable` and manage their own scroll state via
+  `ElementId::CodeLocation`.
+
+Both come from `gpui_component::scroll::ScrollableElement`, already imported in
+`history_panel.rs:6`.
+
+**Rule 3 — `min_h_0` on every flex ancestor.** From the scroll container up to the
+nearest fixed-height boundary, every intervening flex ancestor needs `min_h_0()`
+(`min_w_0()` for horizontal). A flex child defaults to `min-height: auto`, which
+refuses to shrink below content size — the parent grows to fit instead of constraining
+the child, and the child's `overflow_scroll` never engages.
+
+## Changes by surface
+
+### Tab bar (`src/tab_bar.rs`)
+
+Split the single `h_flex` into a scrolling strip plus a pinned button:
+
+- The tab strip becomes the scroll container: `.id("tab-strip")`,
+  `.track_scroll(&self.scroll_handle)`, `.overflow_x_scroll()`,
+  `.horizontal_scrollbar(&self.scroll_handle)`, `.min_w_0()`.
+- The "+" button moves **out** of the strip and becomes its sibling, so it can never be
+  pushed off-screen. This is the actual fix for "点满了" — today "+" scrolls away with
+  the tabs.
+- `TabBar` gains a `scroll_handle: ScrollHandle` field.
+- `update_tabs` calls `self.scroll_handle.scroll_to_item(active_index)` when
+  `active_index` changes, so Ctrl+Tab to an off-screen tab brings it into view.
+
+`scroll_to_item` genuinely handles the horizontal axis — verified at
+`gpui-0.2.2/src/elements/div.rs`, where `scroll_to_active_item`'s
+`if state.overflow.x == Overflow::Scroll` branch sits *outside* the `strategy` match and
+runs unconditionally, performing a minimal scroll to make the item fully visible.
+
+**Constraint this imposes:** `scroll_to_item(ix)` indexes `child_bounds`, i.e. the
+scroll container's **direct children**. Tabs must therefore be direct children of the
+strip, and "+" must not be. Both hold under this design, so the index equals the tab
+index exactly.
+
+No change needed in `src/app.rs`: `:589` already wraps the tab bar in
+`div().flex_1().min_w_0()`, so the horizontal constraint is in place.
+
+### Response headers (`src/response_viewer.rs`)
+
+- Parent container (`:437-444`) gains `.min_h_0()`.
+- The value `div` (`:266-273`) drops `.whitespace_nowrap()`, `.text_ellipsis()`, and
+  `.overflow_hidden()` so long values wrap, and **gains `.min_w_0()`**.
+
+  The `min_w_0()` is Rule 3's horizontal counterpart and is load-bearing, not
+  decoration. The value div is a `flex_1` child of an `h_flex` row. Dropping
+  `whitespace_nowrap` alone makes values with spaces (`content-security-policy`) wrap,
+  but a value with no break opportunities — a JWT in `authorization`, a long
+  `set-cookie` — has an automatic minimum width equal to the whole string, so the row
+  would blow out horizontally instead. `min_w_0()` lets it shrink.
+
+  A single unbreakable token longer than the pane still has nowhere to wrap; the
+  checklist covers observing what actually happens rather than guessing.
+- `render_headers` gains `.vertical_scrollbar(&self.headers_scroll_handle)`. It already
+  owns the handle (`:63`), so Rule 2's first branch applies.
+
+### Request headers and params (`src/request_editor.rs`)
+
+Both scroll containers (`:1203-1206`, `:1278`) gain `.min_h_0()` and a
+`.vertical_scrollbar(&…_scroll_handle)`. Both already own handles for the existing
+scroll-to-bottom-on-add behavior, which must keep working.
+
+### Form-data (`src/body_editor.rs`) and environment manager (`src/environment_manager.rs`)
+
+Form-data (`:659-667`) already scrolls correctly; it gains only
+`.vertical_scrollbar(&self.formdata_scroll_handle)`.
+
+Environment manager (`:314`, `:442`) has no handle and needs no programmatic control, so
+it takes Rule 2's second branch: `.overflow_scroll()` → `.overflow_y_scrollbar()`.
+
+Rule 3 also applies to both containers, but the exact ancestors are **not enumerated
+here** — unlike the other surfaces, this file's chains were not traced during design.
+The implementer must read outward from each of `:314` and `:442` to the nearest
+fixed-height boundary and add `min_h_0()` to each intervening flex ancestor that lacks
+it. Enumerating them here from memory would be guessing.
+
+### History (`src/history_panel.rs`)
+
+No change. Already conforms.
+
+## Risk: the `min_h_0` diagnosis is a hypothesis
+
+The only established facts are that the user reports these surfaces don't scroll, and
+that the codebase already fixed this exact symptom with `min_h_0` elsewhere. Whether
+gpui's taffy layout implements CSS's automatic-minimum-size rule strictly enough for
+this to be *the* cause has **not** been verified — it cannot be, without a GUI build.
+
+Batching all surfaces before verifying is nonetheless safe here, and this is the reason:
+**`min_h_0` is inert if the hypothesis is wrong.** It relaxes a minimum constraint; it
+cannot break a layout that was working. This is categorically unlike the
+`request_animation_frame` mistake in the 2026-07-15 shortcuts round, where the
+speculative fix actively introduced a panic — that is what made incremental verification
+mandatory there and optional here.
+
+**If manual verification shows the surfaces still don't scroll:** stop. Return to root-
+cause investigation rather than layering more fixes on a disproven hypothesis. The tab
+bar and header-wrapping changes are independent of this hypothesis and should still hold.
+
+## Error handling
+
+No fallible operations. No new state beyond `TabBar`'s `ScrollHandle`, which is
+infallible to construct (`ScrollHandle::new()`).
+
+## Testing
+
+This is a pure GUI/layout change. Unlike the previous round's `cycle_index`, there is no
+extractable pure logic worth unit-testing — the entire behavior is layout and rendering,
+which needs a real window.
+
+- Local gate (WSL2): `cargo check` and `cargo clippy` must be clean.
+- Test gate (Windows, from WSL):
+  `pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test"` — must stay at 123
+  passed, 0 failed (this change adds no tests and must break none).
+- Correctness rests entirely on the manual checklist below. Do not claim the feature
+  works before the user confirms.
+
+## Manual verification checklist (user, on Windows)
+
+Tab bar:
+- [ ] Open enough tabs to overflow the row — the strip scrolls horizontally
+- [ ] The "+" button stays visible and clickable no matter how many tabs are open
+- [ ] A hover scrollbar appears under the tab strip when the mouse is over it
+- [ ] Ctrl+Tab to a tab scrolled out of view scrolls it back into view
+- [ ] Ctrl+Shift+Tab likewise, in the other direction
+- [ ] Clicking a partially visible tab still selects it (no misrouted hit-testing)
+
+Response headers:
+- [ ] A response with many headers scrolls vertically
+- [ ] A long value with spaces (e.g. `content-security-policy`) wraps and is fully readable
+- [ ] A long value with **no** break opportunities (e.g. a JWT in `authorization`, a long
+      `set-cookie`) does not blow the row out horizontally — this is the `min_w_0()` case;
+      note what it actually does, since a single unbreakable token has nowhere to wrap
+- [ ] A hover scrollbar appears when the mouse is over the header list
+- [ ] Header text can still be selected
+
+Other surfaces:
+- [ ] Request headers and params lists scroll, with a hover scrollbar
+- [ ] Adding a header/param row still auto-scrolls to the new row (no regression)
+- [ ] Form-data rows scroll, with a hover scrollbar; add-row auto-scroll still works
+- [ ] Environment manager variable list scrolls, with a hover scrollbar
+- [ ] History panel is unchanged
+
+Global:
+- [ ] Scrollbars are invisible until hovered, everywhere
+- [ ] Scrolling the response area does not scroll the history panel or vice versa
+      (`app.rs:566, 583` isolate scroll events — no regression)

--- a/docs/superpowers/specs/2026-07-15-app-wide-scrolling-design.md
+++ b/docs/superpowers/specs/2026-07-15-app-wide-scrolling-design.md
@@ -64,17 +64,57 @@ Verified safe: `Theme::sync_scrollbar_appearance` (`theme/mod.rs:141`) would ove
 this, but neither poopman nor `gpui_component::init` (`lib.rs:97-109`) calls it.
 `Hover` is also what gpui-component itself picks for systems not set to auto-hide.
 
-**Rule 2 — Pick the API by whether you need programmatic scroll control.**
+**Rule 2 — One idiom: wrapper / scroller / scrollbar.** Every scrollable surface is
+three parts, with the scrollbar a *sibling* of the scroller:
 
-- Need to drive the scroll position (scroll-to-bottom on row add, scroll-into-view):
-  own a `ScrollHandle`, then `.track_scroll(&h).overflow_scroll()` plus
-  `.vertical_scrollbar(&h)` / `.horizontal_scrollbar(&h)`.
-- Don't need it: `.overflow_y_scrollbar()` / `.overflow_x_scrollbar()`, which wrap the
-  element in `Scrollable` and manage their own scroll state via
-  `ElementId::CodeLocation`.
+```rust
+div()                              // viewport: owns the size constraint
+    .flex_1()
+    .min_h_0()
+    .child(
+        v_flex()                   // scroller: owns content layout and scrolling
+            .id("some-scroll-container")
+            .size_full()
+            .track_scroll(&self.some_handle)
+            .overflow_scroll()
+            .children(…),
+    )
+    .vertical_scrollbar(&self.some_handle)   // sibling of the scroller, sharing its handle
+```
 
-Both come from `gpui_component::scroll::ScrollableElement`, already imported in
-`history_panel.rs:6`.
+`.vertical_scrollbar(&h)` / `.horizontal_scrollbar(&h)` come from
+`gpui_component::scroll::ScrollableElement` (already imported at `history_panel.rs:6`).
+
+**The scrollbar must go on the scroller's parent, never on the scroller itself.**
+`ScrollableElement::scrollbar` is `self.child(ScrollbarLayer{…})`, and that layer renders
+as `div().absolute().top_0().left_0().right_0().bottom_0()`
+(`scroll/scrollable.rs`, `render_scrollbar`). Put it inside the scroller and it becomes
+part of the scrolling content and scrolls away with it. gpui-component's own three call
+sites all place it on the parent: `menu/popup_menu.rs:1309`, `setting/page.rs:189`,
+`tree.rs:439`. `Scrollable` does the same internally — wrapper(relative) > [scroll-area,
+scrollbar].
+
+No explicit `.relative()` is needed on the wrapper: gpui defaults `position` to
+`Position::Relative`, unlike CSS (`gpui-0.2.2/src/style.rs:1193`, and `Style::default()`
+at `:743`).
+
+**Do not use `.overflow_y_scrollbar()` / `.overflow_scrollbar()` on an element whose own
+styles lay out its content.** `Scrollable::render` (`scroll/scrollable.rs:115-125`) does:
+
+```rust
+let style = self.element.style().clone();
+*self.element.style() = StyleRefinement::default();
+div().refine_style(&style).relative().child(…self.element.flex_1()…)
+```
+
+— it *moves* the element's style to an outer wrapper and resets the element to a bare
+div. Since `Style::default()` is `display: Block` (`style.rs:734`), the content still
+stacks vertically, which is why `history_panel.rs:244` works. But any `gap`, `padding`,
+or `flex_col` on the element lands on the wrapper instead of applying between its
+children. `env-list` carries `.gap_0p5()`, so converting it would silently drop the
+spacing between environment rows. `history_panel.rs` keeps its existing
+`.overflow_y_scrollbar()` — it works today and is not worth churning — but new code uses
+the three-part idiom above.
 
 **Rule 3 — `min_h_0` on every flex ancestor.** From the scroll container up to the
 nearest fixed-height boundary, every intervening flex ancestor needs `min_h_0()`
@@ -86,14 +126,32 @@ the child, and the child's `overflow_scroll` never engages.
 
 ### Tab bar (`src/tab_bar.rs`)
 
-Split the single `h_flex` into a scrolling strip plus a pinned button:
+Apply Rule 2's three-part idiom, with the "+" button outside the viewport entirely:
 
-- The tab strip becomes the scroll container: `.id("tab-strip")`,
-  `.track_scroll(&self.scroll_handle)`, `.overflow_x_scroll()`,
-  `.horizontal_scrollbar(&self.scroll_handle)`, `.min_w_0()`.
-- The "+" button moves **out** of the strip and becomes its sibling, so it can never be
-  pushed off-screen. This is the actual fix for "点满了" — today "+" scrolls away with
-  the tabs.
+```rust
+h_flex()                                  // existing outer row
+    .gap_1().items_center().px_1p5().py_1()
+    .child(
+        div()                             // viewport
+            .flex_1()
+            .min_w_0()
+            .child(
+                h_flex()                  // scroller: the tab strip
+                    .id("tab-strip")
+                    .gap_1()
+                    .items_center()
+                    .track_scroll(&self.scroll_handle)
+                    .overflow_x_scroll()
+                    .children(…tabs unchanged…),
+            )
+            .horizontal_scrollbar(&self.scroll_handle),
+    )
+    .child(…existing "+" button, unchanged…)   // outside the viewport → pinned
+```
+
+- The "+" button already *is* a sibling of the tab strip in today's outer `h_flex`, so it
+  needs no change; giving the viewport `flex_1` is what pins the button. Today "+" is
+  pushed off-screen along with the tabs — that is the "点满了" half of the defect.
 - `TabBar` gains a `scroll_handle: ScrollHandle` field.
 - `update_tabs` calls `self.scroll_handle.scroll_to_item(active_index)` when
   `active_index` changes, so Ctrl+Tab to an off-screen tab brings it into view.
@@ -126,28 +184,44 @@ No change needed in `src/app.rs`: `:589` already wraps the tab bar in
 
   A single unbreakable token longer than the pane still has nowhere to wrap; the
   checklist covers observing what actually happens rather than guessing.
-- `render_headers` gains `.vertical_scrollbar(&self.headers_scroll_handle)`. It already
-  owns the handle (`:63`), so Rule 2's first branch applies.
+- The scrollbar goes on that same parent (`:437-444`), not inside `render_headers` —
+  `render_headers` returns the scroller. Per Rule 2 the parent is already the viewport,
+  so it takes `.vertical_scrollbar(&self.headers_scroll_handle)`. `ResponseViewer` owns
+  the handle (`:63`) and both sites can reach it.
 
 ### Request headers and params (`src/request_editor.rs`)
 
-Both scroll containers (`:1203-1206`, `:1278`) gain `.min_h_0()` and a
-`.vertical_scrollbar(&…_scroll_handle)`. Both already own handles for the existing
-scroll-to-bottom-on-add behavior, which must keep working.
+Both scroll containers (`:1199-1206`, `:1272-1279`) are `this.child(v_flex()…)` with no
+viewport of their own, so each gets one interposed per Rule 2: a `div().flex_1()
+.min_h_0()` wrapping the existing `v_flex`, carrying
+`.vertical_scrollbar(&…_scroll_handle)`. The `v_flex` keeps its id, padding, gap,
+`track_scroll`, and `overflow_scroll`, and takes `.size_full()` in place of its current
+`.flex_1()` (the wrapper owns the flex sizing now).
+
+Interposing a wrapper rather than hanging the scrollbar on the enclosing builder is
+deliberate: the enclosing `this` is the whole tab-content area, so the scrollbar would
+span more than the list.
+
+Both already own handles for the existing scroll-to-bottom-on-add behavior
+(`request_editor.rs:468-495`), which must keep working.
 
 ### Form-data (`src/body_editor.rs`) and environment manager (`src/environment_manager.rs`)
 
-Form-data (`:659-667`) already scrolls correctly; it gains only
-`.vertical_scrollbar(&self.formdata_scroll_handle)`.
+Form-data (`:659-667`) already scrolls correctly — it has `min_h_0` — so it needs only a
+viewport wrapper carrying `.vertical_scrollbar(&self.formdata_scroll_handle)`, with the
+existing `v_flex` keeping its handle for scroll-to-new-row (`body_editor.rs:364-390`).
 
-Environment manager (`:314`, `:442`) has no handle and needs no programmatic control, so
-it takes Rule 2's second branch: `.overflow_scroll()` → `.overflow_y_scrollbar()`.
+Environment manager (`:310-315` `env-list`, `:439-442` `env-vars`) has no handles today.
+Both take the same three-part idiom, which means **each gains a `ScrollHandle` field** on
+`EnvironmentManager` — `.overflow_y_scrollbar()` is not an option here: `env-list`
+carries `.gap_0p5()`, which `Scrollable` would relocate to its wrapper, silently
+collapsing the spacing between environment rows (see Rule 2).
 
 Rule 3 also applies to both containers, but the exact ancestors are **not enumerated
 here** — unlike the other surfaces, this file's chains were not traced during design.
-The implementer must read outward from each of `:314` and `:442` to the nearest
-fixed-height boundary and add `min_h_0()` to each intervening flex ancestor that lacks
-it. Enumerating them here from memory would be guessing.
+The implementer must read outward from each container to the nearest fixed-height
+boundary and add `min_h_0()` to each intervening flex ancestor that lacks it.
+Enumerating them here from memory would be guessing.
 
 ### History (`src/history_panel.rs`)
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -22,6 +22,16 @@ actions!(poopman, [SendRequest, NewTab, CloseTab, NextTab, PrevTab, FocusUrl]);
 
 /// Main application view
 pub struct PoopmanApp {
+    /// Focused at startup so the window's focus is never `None`.
+    ///
+    /// This is load-bearing for every keyboard shortcut, not a nicety.
+    /// `Window::dispatch_key_event` (`gpui-0.2.2/src/window.rs:3735`) resolves the
+    /// dispatch path from the focused node, and `focus_node_id_in_rendered_frame`
+    /// falls back to the dispatch tree's *root* when focus is `None`. The path is
+    /// then just that root — and our `on_action` handlers live on `PoopmanApp`'s own
+    /// element, a descendant of it, so with no focus they are never reached and
+    /// every shortcut silently does nothing.
+    focus_handle: FocusHandle,
     db: Arc<Database>,
     history_panel: Entity<HistoryPanel>,
     request_editor: Entity<RequestEditor>,
@@ -203,7 +213,14 @@ impl PoopmanApp {
             bar.update_tabs(request_tabs.clone(), active_tab_index, cx);
         });
 
+        // Focus the root so the window's focus is never `None` — see the field's
+        // doc comment. Without this, shortcuts are dead until the user happens to
+        // click something focusable.
+        let focus_handle = cx.focus_handle();
+        window.focus(&focus_handle);
+
         Self {
+            focus_handle,
             db,
             history_panel,
             request_editor,
@@ -499,6 +516,7 @@ impl Render for PoopmanApp {
         let theme = cx.theme();
 
         v_flex()
+            .track_focus(&self.focus_handle)
             .key_context("Poopman")
             .on_action(cx.listener(|this, _: &SendRequest, window, cx| {
                 this.request_editor.update(cx, |editor, cx| editor.send(window, cx));

--- a/src/body_editor.rs
+++ b/src/body_editor.rs
@@ -3,6 +3,7 @@ use gpui::*;
 use gpui::px;
 use gpui_component::{
     button::*, checkbox::Checkbox, h_flex, input::{Input, InputState, InputEvent as InputChangeEvent, TabSize},
+    scroll::ScrollableElement as _,
     select::*, v_flex, ActiveTheme as _, IndexPath, Sizable as _,
 };
 
@@ -655,17 +656,20 @@ impl Render for BodyEditor {
             .when(self.body_type_index == 2, |this| {
                 // Form-data - show table (like headers layout)
                 this.child(
-                    v_flex()
-                        .id("formdata-scroll-container")
-                        .gap_2()
-                        .p_2()
-                        .pb_4()  // Bottom padding to prevent last row from being obscured
+                    div()
                         .flex_1()
                         .min_h_0()  // Allow scrolling to work
-                        .w_full()
-                        .track_scroll(&self.formdata_scroll_handle)
-                        .overflow_scroll()
-                        .children(self.formdata_rows.iter().enumerate().zip(self.formdata_input_states.iter()).map(|((index, row), (key_input_entity, value_input_entity, type_select_entity))| {
+                        .child(
+                            v_flex()
+                                .id("formdata-scroll-container")
+                                .gap_2()
+                                .p_2()
+                                .pb_4()  // Bottom padding to prevent last row from being obscured
+                                .size_full()
+                                .w_full()
+                                .track_scroll(&self.formdata_scroll_handle)
+                                .overflow_scroll()
+                                .children(self.formdata_rows.iter().enumerate().zip(self.formdata_input_states.iter()).map(|((index, row), (key_input_entity, value_input_entity, type_select_entity))| {
                                     let is_file = matches!(row.value, FormDataValue::File { .. });
 
                                     h_flex()
@@ -731,6 +735,8 @@ impl Render for BodyEditor {
                                                 )
                                         )
                                 }))
+                        )
+                        .vertical_scrollbar(&self.formdata_scroll_handle),
                 )
             })
     }

--- a/src/body_editor.rs
+++ b/src/body_editor.rs
@@ -666,7 +666,6 @@ impl Render for BodyEditor {
                                 .p_2()
                                 .pb_4()  // Bottom padding to prevent last row from being obscured
                                 .size_full()
-                                .w_full()
                                 .track_scroll(&self.formdata_scroll_handle)
                                 .overflow_scroll()
                                 .children(self.formdata_rows.iter().enumerate().zip(self.formdata_input_states.iter()).map(|((index, row), (key_input_entity, value_input_entity, type_select_entity))| {

--- a/src/environment_manager.rs
+++ b/src/environment_manager.rs
@@ -6,7 +6,8 @@
 use gpui::prelude::FluentBuilder as _;
 use gpui::*;
 use gpui_component::{
-    button::*, checkbox::Checkbox, h_flex, input::*, v_flex, ActiveTheme as _, Sizable as _,
+    button::*, checkbox::Checkbox, h_flex, input::*, scroll::ScrollableElement as _, v_flex,
+    ActiveTheme as _, Sizable as _,
 };
 use gpui_component::input::InputEvent;
 use std::sync::Arc;
@@ -31,6 +32,8 @@ pub struct EnvironmentManager {
     selected_id: Option<i64>,
     name_input: Entity<InputState>,
     var_rows: Vec<VarRow>,
+    env_list_scroll_handle: ScrollHandle,
+    var_list_scroll_handle: ScrollHandle,
     /// True while programmatically loading inputs, so their `Change` events don't
     /// trigger an auto-save of values we just set.
     suspend_autosave: bool,
@@ -54,6 +57,8 @@ impl EnvironmentManager {
             selected_id,
             name_input,
             var_rows: vec![],
+            env_list_scroll_handle: ScrollHandle::new(),
+            var_list_scroll_handle: ScrollHandle::new(),
             suspend_autosave: false,
             _subs: vec![],
         };
@@ -307,12 +312,17 @@ impl Render for EnvironmentManager {
                             ),
                     )
                     .child(
-                        v_flex()
-                            .id("env-list")
+                        div()
                             .flex_1()
-                            .gap_0p5()
-                            .overflow_scroll()
-                            .children(self.environments.iter().map(|env| {
+                            .min_h_0()
+                            .child(
+                                v_flex()
+                                    .id("env-list")
+                                    .size_full()
+                                    .gap_0p5()
+                                    .track_scroll(&self.env_list_scroll_handle)
+                                    .overflow_scroll()
+                                    .children(self.environments.iter().map(|env| {
                                 let id = env.id;
                                 let is_selected = selected_id == Some(id);
                                 let is_active = active_id == Some(id);
@@ -385,6 +395,8 @@ impl Render for EnvironmentManager {
                                         )
                                     })
                             })),
+                        )
+                        .vertical_scrollbar(&self.env_list_scroll_handle),
                     ),
             )
             // ---- Right: selected environment editor ----
@@ -392,6 +404,7 @@ impl Render for EnvironmentManager {
                 v_flex()
                     .flex_1()
                     .h_full()
+                    .min_h_0()
                     .min_w_0()
                     .gap_3()
                     .child(
@@ -436,11 +449,16 @@ impl Render for EnvironmentManager {
                                     .child(div().w(px(24.)).flex_shrink_0()),
                             )
                             .child(
-                                v_flex()
-                                    .id("env-vars")
+                                div()
                                     .flex_1()
-                                    .overflow_scroll()
-                                    .children(self.var_rows.iter().enumerate().map(|(index, row)| {
+                                    .min_h_0()
+                                    .child(
+                                        v_flex()
+                                            .id("env-vars")
+                                            .size_full()
+                                            .track_scroll(&self.var_list_scroll_handle)
+                                            .overflow_scroll()
+                                            .children(self.var_rows.iter().enumerate().map(|(index, row)| {
                                         h_flex()
                                             .w_full()
                                             .gap_2()
@@ -472,6 +490,8 @@ impl Render for EnvironmentManager {
                                                 ),
                                             )
                                     })),
+                                    )
+                                    .vertical_scrollbar(&self.var_list_scroll_handle),
                             ),
                     )
                     .child(

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -3,6 +3,7 @@ use gpui::*;
 use gpui::px;
 use gpui_component::{
     button::*, checkbox::Checkbox, input::*,
+    scroll::ScrollableElement as _,
     select::*, v_flex, ActiveTheme as _, Disableable as _, Icon, IndexPath, Sizable as _,
 };
 use gpui_component::input::InputEvent;
@@ -1195,16 +1196,25 @@ impl Render for RequestEditor {
                         )
                         .when(self.active_tab == 0, |this| {
                             this.child(
-                                // Scrollable headers list
-                                v_flex()
-                                    .id("headers-scroll-container")
-                                    .gap_2()
-                                    .p_2()
-                                    .pb_4()  // Bottom padding to prevent last row from being obscured
+                                // Viewport: owns the size constraint so the list can
+                                // shrink and actually scroll; also hosts the scrollbar,
+                                // which must be the scroller's sibling rather than its
+                                // child (an absolute layer inside the scroller scrolls
+                                // away with the content).
+                                div()
                                     .flex_1()
-                                    .track_scroll(&self.headers_scroll_handle)
-                                    .overflow_scroll()
-                                    .children(self.headers.iter().enumerate().map(
+                                    .min_h_0()
+                                    .child(
+                                        // Scrollable headers list
+                                        v_flex()
+                                            .id("headers-scroll-container")
+                                            .gap_2()
+                                            .p_2()
+                                            .pb_4()  // Bottom padding to prevent last row from being obscured
+                                            .size_full()
+                                            .track_scroll(&self.headers_scroll_handle)
+                                            .overflow_scroll()
+                                            .children(self.headers.iter().enumerate().map(
                                         |(index, header)| {
                                             let enabled = header.enabled;
                                             let is_mandatory = matches!(header.header_type, HeaderType::Mandatory);
@@ -1264,19 +1274,30 @@ impl Render for RequestEditor {
                                                 )
                                         },
                                     ))
+                                    )
+                                    .vertical_scrollbar(&self.headers_scroll_handle),
                             )
                         })
                         .when(self.active_tab == 1, |this| {
                             this.child(
-                                // Scrollable params list
-                                v_flex()
-                                    .id("params-scroll-container")
-                                    .gap_2()
-                                    .p_2()
-                                    .pb_4()
+                                // Viewport: owns the size constraint so the list can
+                                // shrink and actually scroll; also hosts the scrollbar,
+                                // which must be the scroller's sibling rather than its
+                                // child (an absolute layer inside the scroller scrolls
+                                // away with the content).
+                                div()
                                     .flex_1()
-                                    .track_scroll(&self.params_scroll_handle)
-                                    .overflow_scroll()
+                                    .min_h_0()
+                                    .child(
+                                        // Scrollable params list
+                                        v_flex()
+                                            .id("params-scroll-container")
+                                            .gap_2()
+                                            .p_2()
+                                            .pb_4()
+                                            .size_full()
+                                            .track_scroll(&self.params_scroll_handle)
+                                            .overflow_scroll()
                                     .children(self.params.iter().enumerate().map(
                                         |(index, param)| {
                                             let enabled = param.enabled;
@@ -1326,6 +1347,8 @@ impl Render for RequestEditor {
                                                 )
                                         },
                                     ))
+                                    )
+                                    .vertical_scrollbar(&self.params_scroll_handle),
                             )
                         })
                         .when(self.active_tab == 2, |this| {

--- a/src/response_viewer.rs
+++ b/src/response_viewer.rs
@@ -1,6 +1,6 @@
 use gpui::prelude::FluentBuilder as _;
 use gpui::*;
-use gpui_component::{button::*, h_flex, input::*, v_flex, ActiveTheme as _};
+use gpui_component::{button::*, h_flex, input::*, scroll::ScrollableElement as _, v_flex, ActiveTheme as _};
 use std::sync::Arc;
 
 use crate::types::ResponseData;
@@ -256,6 +256,7 @@ impl ResponseViewer {
                             h_flex()
                                 .gap_2()
                                 .w_full()
+                                .items_start()
                                 .child(
                                     div()
                                         .font_weight(FontWeight::SEMIBOLD)
@@ -264,12 +265,16 @@ impl ResponseViewer {
                                         .child(format!("{}:", key)),
                                 )
                                 .child(
+                                    // Wraps rather than ellipsizing — reading the whole
+                                    // value is the point of looking at headers. min_w_0
+                                    // is load-bearing: a value with no break
+                                    // opportunities (a JWT, a long set-cookie) otherwise
+                                    // has an automatic minimum width of the entire
+                                    // string and blows the row out horizontally.
                                     div()
                                         .text_sm()
                                         .flex_1()
-                                        .overflow_hidden()
-                                        .text_ellipsis()
-                                        .whitespace_nowrap()
+                                        .min_w_0()
                                         .child(value.clone()),
                                 )
                         })),
@@ -439,9 +444,11 @@ impl Render for ResponseViewer {
                                     .flex()
                                     .flex_col()
                                     .flex_1()
+                                    .min_h_0() // Let the list shrink so its overflow_scroll engages
                                     .w_full()
                                     .overflow_hidden()
-                                    .child(self.render_headers(cx)),
+                                    .child(self.render_headers(cx))
+                                    .vertical_scrollbar(&self.headers_scroll_handle),
                             )
                         }),
                 )

--- a/src/response_viewer.rs
+++ b/src/response_viewer.rs
@@ -256,7 +256,6 @@ impl ResponseViewer {
                             h_flex()
                                 .gap_2()
                                 .w_full()
-                                .items_start()
                                 .child(
                                     div()
                                         .font_weight(FontWeight::SEMIBOLD)
@@ -265,16 +264,23 @@ impl ResponseViewer {
                                         .child(format!("{}:", key)),
                                 )
                                 .child(
-                                    // Wraps rather than ellipsizing — reading the whole
-                                    // value is the point of looking at headers. min_w_0
-                                    // is load-bearing: a value with no break
-                                    // opportunities (a JWT, a long set-cookie) otherwise
-                                    // has an automatic minimum width of the entire
-                                    // string and blows the row out horizontally.
+                                    // Stays on one line, ellipsized. Wrapping was tried
+                                    // and reverted: dropping `whitespace_nowrap` collapses
+                                    // this value's min-content width, and that somehow
+                                    // collapses the *request* card above to ~280px — its
+                                    // ResizablePanel stops resolving `size_full`'s
+                                    // width:100% and falls back to content sizing.
+                                    // Bisected across five GUI builds and localised with
+                                    // canvas probes; the mechanism was never found, so
+                                    // wrapping stays off until it is. See
+                                    // docs/superpowers/specs/2026-07-15-app-wide-scrolling-design.md
+                                    // ("Wrapping: attempted and reverted").
                                     div()
                                         .text_sm()
                                         .flex_1()
-                                        .min_w_0()
+                                        .overflow_hidden()
+                                        .text_ellipsis()
+                                        .whitespace_nowrap()
                                         .child(value.clone()),
                                 )
                         })),

--- a/src/tab_bar.rs
+++ b/src/tab_bar.rs
@@ -86,8 +86,14 @@ impl Render for TabBar {
                 // Viewport for the scrolling tab strip. The "+" button is deliberately
                 // outside it (it stays a child of the outer row below), so a full row
                 // can never push it off-screen.
+                //
+                // No flex_1 on purpose: the default `flex: 0 1 auto` sizes this to the
+                // strip's content, so "+" sits right after the last tab while there is
+                // room (Postman's behaviour). min_w_0 is what lets it shrink past that
+                // content width once the row fills, at which point the strip overflows
+                // and scrolls internally and "+" ends up pinned at the right edge.
+                // flex_1 here would hold "+" against the right edge even with two tabs.
                 div()
-                    .flex_1()
                     .min_w_0()
                     .child(
                         h_flex()
@@ -158,6 +164,7 @@ impl Render for TabBar {
                 // New tab button
                 div()
                     .id("new-tab-button")
+                    .flex_shrink_0()
                     .px_2()
                     .py_1()
                     .rounded(theme.radius)

--- a/src/tab_bar.rs
+++ b/src/tab_bar.rs
@@ -1,7 +1,7 @@
 use gpui::*;
 use gpui::px;
 use gpui::prelude::FluentBuilder as _;
-use gpui_component::{h_flex, ActiveTheme as _};
+use gpui_component::{h_flex, scroll::ScrollableElement as _, ActiveTheme as _};
 
 use crate::request_tab::RequestTab;
 use crate::theme::method_color;
@@ -26,6 +26,7 @@ pub struct TabCloseClicked {
 pub struct TabBar {
     tabs: Vec<RequestTab>,
     active_tab_index: usize,
+    scroll_handle: ScrollHandle,
 }
 
 impl TabBar {
@@ -33,13 +34,22 @@ impl TabBar {
         Self {
             tabs: vec![],
             active_tab_index: 0,
+            scroll_handle: ScrollHandle::new(),
         }
     }
 
     /// Update tabs and active index
     pub fn update_tabs(&mut self, tabs: Vec<RequestTab>, active_index: usize, _cx: &mut Context<Self>) {
+        let active_changed = self.active_tab_index != active_index;
         self.tabs = tabs;
         self.active_tab_index = active_index;
+
+        // Ctrl+Tab can select a tab that is scrolled out of view. Indices line up
+        // because the tabs are the scroller's direct children and "+" is not —
+        // `scroll_to_item` indexes `child_bounds`.
+        if active_changed {
+            self.scroll_handle.scroll_to_item(active_index);
+        }
     }
 
     fn on_tab_click(&mut self, tab_index: usize, _event: &ClickEvent, _window: &mut Window, cx: &mut Context<Self>) {
@@ -73,62 +83,74 @@ impl Render for TabBar {
             .px_1p5()
             .py_1()
             .child(
-                // Render all tabs
-                h_flex()
-                    .gap_1()
-                    .items_center()
-                    .children(self.tabs.iter().enumerate().map(|(index, tab)| {
-                        let is_active = index == active_index;
-                        let tab_index = index;
-                        let method = tab.request.method.as_str();
-
-                        let verb_color = method_color(tab.request.method, theme);
-
+                // Viewport for the scrolling tab strip. The "+" button is deliberately
+                // outside it (it stays a child of the outer row below), so a full row
+                // can never push it off-screen.
+                div()
+                    .flex_1()
+                    .min_w_0()
+                    .child(
                         h_flex()
-                            .id(("tab", tab.id))
-                            .gap_1p5()
+                            .id("tab-strip")
+                            .gap_1()
                             .items_center()
-                            .px_3()
-                            .py_1()
-                            .rounded(theme.radius)
-                            .bg(if is_active { theme.muted } else { gpui::transparent_black() })
-                            .when(!is_active, |s| s.hover(|s| s.bg(theme.list_hover)))
-                            .cursor_pointer()
-                            .on_click(cx.listener(move |this, event, window, cx| {
-                                this.on_tab_click(tab_index, event, window, cx);
-                            }))
-                            .child(
-                                div()
-                                    .text_xs()
-                                    .font_weight(gpui::FontWeight::BOLD)
-                                    .text_color(verb_color)
-                                    .child(method)
-                            )
-                            .child(
-                                // Tab title
-                                div()
-                                    .text_sm()
-                                    .text_color(if is_active { theme.foreground } else { theme.muted_foreground })
-                                    .max_w(px(150.))
-                                    .overflow_hidden()
-                                    .whitespace_nowrap()
-                                    .child(tab.title.clone())
-                            )
-                            .child(
-                                // Close button
-                                div()
-                                    .id(("close-tab", tab.id))
-                                    .text_xs()
-                                    .text_color(theme.muted_foreground)
+                            .size_full()
+                            .track_scroll(&self.scroll_handle)
+                            .overflow_x_scroll()
+                            .children(self.tabs.iter().enumerate().map(|(index, tab)| {
+                                let is_active = index == active_index;
+                                let tab_index = index;
+                                let method = tab.request.method.as_str();
+
+                                let verb_color = method_color(tab.request.method, theme);
+
+                                h_flex()
+                                    .id(("tab", tab.id))
+                                    .gap_1p5()
+                                    .items_center()
+                                    .px_3()
+                                    .py_1()
+                                    .rounded(theme.radius)
+                                    .bg(if is_active { theme.muted } else { gpui::transparent_black() })
+                                    .when(!is_active, |s| s.hover(|s| s.bg(theme.list_hover)))
                                     .cursor_pointer()
-                                    .hover(|style| style.text_color(theme.foreground))
                                     .on_click(cx.listener(move |this, event, window, cx| {
-                                        cx.stop_propagation();
-                                        this.on_close_tab_click(tab_index, event, window, cx);
+                                        this.on_tab_click(tab_index, event, window, cx);
                                     }))
-                                    .child("×")
-                            )
-                    }))
+                                    .child(
+                                        div()
+                                            .text_xs()
+                                            .font_weight(gpui::FontWeight::BOLD)
+                                            .text_color(verb_color)
+                                            .child(method)
+                                    )
+                                    .child(
+                                        // Tab title
+                                        div()
+                                            .text_sm()
+                                            .text_color(if is_active { theme.foreground } else { theme.muted_foreground })
+                                            .max_w(px(150.))
+                                            .overflow_hidden()
+                                            .whitespace_nowrap()
+                                            .child(tab.title.clone())
+                                    )
+                                    .child(
+                                        // Close button
+                                        div()
+                                            .id(("close-tab", tab.id))
+                                            .text_xs()
+                                            .text_color(theme.muted_foreground)
+                                            .cursor_pointer()
+                                            .hover(|style| style.text_color(theme.foreground))
+                                            .on_click(cx.listener(move |this, event, window, cx| {
+                                                cx.stop_propagation();
+                                                this.on_close_tab_click(tab_index, event, window, cx);
+                                            }))
+                                            .child("×")
+                                    )
+                            })),
+                    )
+                    .horizontal_scrollbar(&self.scroll_handle),
             )
             .child(
                 // New tab button

--- a/src/tab_bar.rs
+++ b/src/tab_bar.rs
@@ -108,6 +108,7 @@ impl Render for TabBar {
                                     .id(("tab", tab.id))
                                     .gap_1p5()
                                     .items_center()
+                                    .flex_shrink_0()
                                     .px_3()
                                     .py_1()
                                     .rounded(theme.radius)

--- a/src/tab_bar.rs
+++ b/src/tab_bar.rs
@@ -133,6 +133,7 @@ impl Render for TabBar {
                                             .max_w(px(150.))
                                             .overflow_hidden()
                                             .whitespace_nowrap()
+                                            .text_ellipsis()
                                             .child(tab.title.clone())
                                     )
                                     .child(

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -2,7 +2,7 @@
 //! global theme application applied once at startup.
 
 use gpui::{px, App, Hsla};
-use gpui_component::{Theme, ThemeMode};
+use gpui_component::{scroll::ScrollbarShow, Theme, ThemeMode};
 
 use crate::types::HttpMethod;
 
@@ -114,7 +114,12 @@ pub fn apply_theme(cx: &mut App) {
     theme.warning = c(WARNING);
     theme.warning_foreground = c(SURFACE);
 
-    // Scrollbar
+    // Scrollbar. `Hover` rather than the `Scrolling` default: a scrollbar that only
+    // appears once you are already scrolling cannot tell you scrolling is possible,
+    // which is exactly how a cut-off list reads as broken.
+    // Safe to set here — `Theme::sync_scrollbar_appearance` would overwrite it, but
+    // neither this app nor `gpui_component::init` calls it.
+    theme.scrollbar_show = ScrollbarShow::Hover;
     theme.scrollbar_thumb = c(SCROLLBAR);
     theme.scrollbar_thumb_hover = c(MUTED_FG);
 

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -114,11 +114,12 @@ pub fn apply_theme(cx: &mut App) {
     theme.warning = c(WARNING);
     theme.warning_foreground = c(SURFACE);
 
-    // Scrollbar. `Hover` rather than the `Scrolling` default: a scrollbar that only
-    // appears once you are already scrolling cannot tell you scrolling is possible,
-    // which is exactly how a cut-off list reads as broken.
-    // Safe to set here — `Theme::sync_scrollbar_appearance` would overwrite it, but
-    // neither this app nor `gpui_component::init` calls it.
+    // Scrollbar. `Hover` rather than gpui-component's platform-dependent default: a
+    // scrollbar that only appears once you are already scrolling cannot tell you
+    // scrolling is possible, which is exactly how a cut-off list reads as broken.
+    // This assignment sticks because `main.rs` runs `gpui_component::init` — whose
+    // `theme::init` calls `Theme::sync_scrollbar_appearance` — before `apply_theme`.
+    // Reordering those two calls would silently revert this.
     theme.scrollbar_show = ScrollbarShow::Hover;
     theme.scrollbar_thumb = c(SCROLLBAR);
     theme.scrollbar_thumb_hover = c(MUTED_FG);


### PR DESCRIPTION
## Summary

Two reported defects — the tab bar overflowed with no way to reach hidden tabs (pushing "+" off-screen with them), and the response header list didn't scroll. Rather than patch both, all scrollable surfaces are brought onto one convention, since the root cause was an absent one: three scroll idioms coexisted and `min_h_0` was applied inconsistently.

**The convention** (`docs/superpowers/specs/2026-07-15-app-wide-scrolling-design.md`) — every scrollable surface is three parts:

```rust
div().flex_1().min_h_0()                    // viewport: owns the size constraint
    .child(v_flex().id("…").size_full()
        .track_scroll(&h).overflow_scroll())  // scroller: content layout + scrolling
    .vertical_scrollbar(&h)                   // scrollbar: SIBLING of the scroller
```

plus one global lever: `theme.scrollbar_show = ScrollbarShow::Hover`.

The scrollbar **must** be the scroller's sibling: `.vertical_scrollbar(&h)` expands to `self.child(ScrollbarLayer)`, which renders `div().absolute().inset(0)` — inside the scroller it scrolls away with the content. gpui-component places it on the parent at all three of its own call sites. A clean compile proves nothing here, since `ScrollableElement` is implemented for both `Div` and `Stateful<Div>`.

**Surfaces:** tab strip (horizontal, "+" pinned outside the viewport, `scroll_to_item` on Ctrl+Tab), response headers, request headers/params, form-data, environment manager. `history_panel` deliberately untouched.

**Also fixed, found in review rather than by symptom:**
- `2a7b1b6` — the tab strip would never have scrolled at all. gpui defaults `flex_shrink` to 1.0, so a strip with a definite width squishes its tabs instead of overflowing; the title div's `overflow_hidden` drops its automatic min-width to 0, so tabs collapsed to method + close button long before scrolling. This shipped past a clean compile and a passing spec review.
- `270b8b1` — **every keyboard shortcut was dead whenever the window's focus was `None`**, including cold start before the user clicked something focusable. `dispatch_key_event` resolves the dispatch path from the focused node, and `focus_node_id_in_rendered_frame` falls back to the dispatch tree's root when focus is `None`; our `on_action` handlers live on a descendant. Pre-existing since the shortcuts landed. The root now takes focus at startup.

### Not shipped: header-value wrapping

Wrapping was specified, implemented, and reverted (`fc0ebc1`). It collapsed the **request** card above to ~280px whenever a response was open on its Headers tab.

Bisected across five GUI builds: dropping `whitespace_nowrap` is the sole trigger. Canvas probes localise the break exactly to the request `ResizablePanel`'s div (1238 → 281) while its sibling response panel, same `v_flex`, is untouched. Ruled out by experiment: `request_editor`'s viewports; `min_h_0`/`vertical_scrollbar`; the resizable state machine (axis-only, i.e. height); `initial_size` → `flex_basis`.

Known: `ResizablePanel` sizes itself with `size_full()`, and a percentage cross-size disables taffy's stretch fallback (`flexbox.rs:1601` tests the *raw* style's `is_auto()`), so it is one failed percentage resolution away from content sizing — and 281 is a content width. **Unexplained: why a change in the response subtree moves a sibling panel's width at all.** A faithful taffy 0.9 reconstruction says it cannot; five builds say it does.

The full evidence — bisect table, probe numbers, what was ruled out and how, and the next measurement worth taking — is written up in the spec so the next attempt starts from data rather than scratch. Header values stay ellipsized until someone finds it.

## Test Plan

- [x] `cargo test` on Windows: 123 passed, 0 failed (unchanged — this branch adds no tests; it is pure layout, with no extractable pure logic worth asserting on)
- [x] `cargo check` and `cargo clippy`: clean, no warnings
- [x] Manually verified on a `--release` build (WSL2 cannot run the GUI):
  - [x] Tab strip scrolls horizontally when full; "+" sits next to the last tab while there is room and pins right once the row fills; long titles ellipsize
  - [x] Ctrl+Tab / Ctrl+Shift+Tab scroll an off-screen tab back into view
  - [x] Hover scrollbars on all six surfaces; they stay put while scrolling
  - [x] Environment rows keep their `gap_0p5` spacing (the regression `.overflow_y_scrollbar()` would have caused)
  - [x] Add-row still auto-scrolls to the new row in headers / params / form-data
  - [x] Request card is full width with a response open on Headers — the reverted-wrap regression is gone
  - [x] Cold start + Ctrl+Tab with no prior click; still works after clicking dead space and cycling the environment dialog; URL input still focuses and types normally

Spec: `docs/superpowers/specs/2026-07-15-app-wide-scrolling-design.md`
Plan: `docs/superpowers/plans/2026-07-15-app-wide-scrolling.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)