### PR TITLE
fix(app): track focus on the content area, not the root

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -31,6 +31,9 @@ pub struct PoopmanApp {
     /// then just that root — and our `on_action` handlers live on `PoopmanApp`'s own
     /// element, a descendant of it, so with no focus they are never reached and
     /// every shortcut silently does nothing.
+    ///
+    /// Tracked on the content area rather than the root — see the note at the
+    /// `track_focus` call in `render`. Moving it back up kills the window controls.
     focus_handle: FocusHandle,
     db: Arc<Database>,
     history_panel: Entity<HistoryPanel>,
@@ -516,7 +519,6 @@ impl Render for PoopmanApp {
         let theme = cx.theme();
 
         v_flex()
-            .track_focus(&self.focus_handle)
             .key_context("Poopman")
             .on_action(cx.listener(|this, _: &SendRequest, window, cx| {
                 this.request_editor.update(cx, |editor, cx| editor.send(window, cx));
@@ -566,6 +568,21 @@ impl Render for PoopmanApp {
             )
             .child(
                 div()
+                    // Focus lives here, on the content area, and deliberately NOT on the
+                    // root — the root spans the title bar too, and that breaks the window
+                    // controls. `track_focus` makes an element insert a hitbox
+                    // (`div.rs:1699`) and registers a focus-on-mouse-down listener that
+                    // calls `window.prevent_default()` (`div.rs:2035`). Windows delivers
+                    // WM_NCLBUTTONDOWN on minimize/maximize/close through gpui as an
+                    // ordinary MouseDownEvent first, and treats it as consumed when the
+                    // default was prevented (`platform/windows/events.rs:976`) — so it
+                    // returns early and never records `nc_button_pressed`, leaving the
+                    // matching mouse-up with nothing to act on. All three buttons go dead
+                    // while still painting their hover styles.
+                    //
+                    // The actions stay on the root: dispatch walks the whole focus path,
+                    // and the root is still an ancestor of this element.
+                    .track_focus(&self.focus_handle)
                     .flex_1()
                     .min_h_0()
                     .flex()


### PR DESCRIPTION
## Summary

The minimize/maximize/close buttons went dead in d535431, which added `track_focus` to `PoopmanApp`'s **root** element to keep window focus from ever being `None`. That read as a keyboard-only change. It is also a mouse change — nothing in the name `track_focus` suggests it inserts a hitbox and calls `prevent_default()`.

The chain, all in vendored sources:

1. `track_focus` makes an element insert a hitbox (`div.rs:1699` — `should_insert_hitbox` tests `tracked_focus_handle.is_some()`) and registers a focus-on-mouse-down listener that calls `window.prevent_default()` (`div.rs:2035`). On the root, that hitbox spans the whole window, title bar included.
2. The window controls have **no click handler** on Windows. gpui-component's `TitleBar` marks them with `window_control_area()`, gpui answers `WM_NCHITTEST` with `HTMINBUTTON`/`HTMAXBUTTON`/`HTCLOSE`, and the OS sends `WM_NCLBUTTONDOWN`.
3. gpui feeds that through as an ordinary `MouseDownEvent` first and treats it as consumed when the default was prevented (`platform/windows/events.rs:976`: `!result.propagate || result.default_prevented`), returning early at `:980` — before the arm at `:988` that records `nc_button_pressed`.
4. `WM_NCLBUTTONUP` then finds `last_pressed == None`, so the `(HTMINBUTTON, HTMINBUTTON)` match never fires.

All three buttons die together while still painting their hover styles, since hover resolves through a separate path — which is what made it look like a rendering-is-fine/clicks-are-ignored puzzle.

**Fix:** move `track_focus` down to the content div, keeping the hitbox below the title bar. The `on_action` handlers stay on the root — action dispatch walks the whole focus path and the root is still an ancestor, so the cold-start shortcut fix from d535431 is preserved.

## Test Plan

Verified manually on Windows (release build):

- [x] Minimize, maximize/restore, and close all work
- [x] Title-bar drag works (same `WM_NC*` path, so it was almost certainly broken too)
- [x] Cold start + Ctrl+Tab with no prior click still cycles tabs — the d535431 regression does not return
- [x] Ctrl+L still focuses and selects the URL; URL input still focuses and types normally
- [x] `cargo test` — 123 passed, 0 failed

## Note

d535431's commit message listed its manual verification: cold start + Ctrl+Tab, clicking dead space, the environment dialog, URL focus and typing. Every item is a keyboard check, because the change was filed mentally as "keyboard fix." The mouse surface it silently altered went untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)