### PR TITLE
fix: clear both known-debt items — history scrolling convention, header-wrapping collapse

### DIFF
--- a/docs/superpowers/specs/2026-07-15-app-wide-scrolling-design.md
+++ b/docs/superpowers/specs/2026-07-15-app-wide-scrolling-design.md
@@ -319,6 +319,61 @@ panel's div and nowhere higher. The next measurement worth taking is the width o
 break is inside `ResizablePanel`; if it reads 281 the break is above it and the model is
 missing a node.
 
+### Second round, 2026-07-20
+
+Attacked again while clearing known debt. Did **not** find the mechanism either, but
+narrowed it enough to be worth recording.
+
+**The two panels were never symmetric, and the asymmetry is in our code** (`app.rs`):
+
+```rust
+// request
+resizable_panel().size(..).size_range(..).child(card_panel().size_full())
+// response — not a resizable_panel() at all; From<E> wraps it via
+// `resizable_panel().child(value)`, so initial_size is None
+card_panel().flex_1().min_h(px(200.)).mt(px(10.)).into_any_element()
+```
+
+`ResizablePanel::render` builds its div with `.flex().flex_grow().size_full()`, i.e. the
+panel is itself a flex **row**. For its child card that makes width the *main* axis.
+`size_full()` asks for `width: 100%` and fills only while that percentage resolves;
+`flex_1()` fills unconditionally. That maps exactly onto the bisect: the card depending
+on percentage resolution is the one that collapsed, the card that grows never did. Hence
+the fix attempted this round — request card to `flex_1() + h_full()`, plus `w_full()` on
+the `v_resizable` host to keep the percentage chain definite.
+
+**Also ruled out this round:**
+
+- `ResizePanelGroupElement`, the container's third child and the one custom `Element` in
+  the subtree. Its `request_layout` returns `window.request_layout(Style::default(), ..)`
+  — a zero-size node with no children. It cannot influence sibling widths.
+- gpui's `AvailableSpace::min_size()` paths (`window.rs:2058,2102`) — they apply to the
+  active-drag preview and to tooltips, neither of which is in this tree outside a drag.
+
+**Two more headless taffy 0.9 reconstructions, both negative.** Reconstruction #1
+repeated the original round's result. Reconstruction #2 fixed two infidelities that
+looked load-bearing:
+
+1. the response headers subtree was modelled as one leaf, eliding the
+   `overflow_hidden` wrapper → `overflow: scroll` scroller → inner `v_flex` → row chain,
+   and `overflow: scroll` changes how intrinsic sizes propagate;
+2. nowrap text was measured as `min(max_content, available)`, whereas gpui's nowrap
+   measurement ignores available space and returns the whole string's width — that
+   difference is precisely what the bisect isolated.
+
+With both corrected, and with `size_full` vs `flex_1` on the request card as a second
+variable, all four combinations still put both panels at the full 1238. Script kept out
+of tree; it is ~350 lines of taffy tree construction and reproducible from this
+description.
+
+**So three independent models now say the collapse cannot happen, against five GUI
+builds that say it does.** That is enough to stop blaming styles. The remaining suspects
+are above taffy's flexbox math: gpui's layout driver (`gpui/src/taffy.rs`) — how it feeds
+available space per pass — or its layout/text-measurement caching across frames, where a
+stale measurement from one frame could size a node in the next. A third round should
+start by instrumenting `TaffyLayoutEngine::compute_layout` for this window rather than by
+editing flex properties.
+
 ## Risk: the `min_h_0` diagnosis is a hypothesis
 
 The only established facts are that the user reports these surfaces don't scroll, and

--- a/docs/superpowers/specs/2026-07-15-app-wide-scrolling-design.md
+++ b/docs/superpowers/specs/2026-07-15-app-wide-scrolling-design.md
@@ -366,13 +366,30 @@ variable, all four combinations still put both panels at the full 1238. Script k
 of tree; it is ~350 lines of taffy tree construction and reproducible from this
 description.
 
-**So three independent models now say the collapse cannot happen, against five GUI
-builds that say it does.** That is enough to stop blaming styles. The remaining suspects
-are above taffy's flexbox math: gpui's layout driver (`gpui/src/taffy.rs`) — how it feeds
-available space per pass — or its layout/text-measurement caching across frames, where a
-stale measurement from one frame could size a node in the next. A third round should
-start by instrumenting `TaffyLayoutEngine::compute_layout` for this window rather than by
-editing flex properties.
+**So three independent models said the collapse cannot happen, against five GUI builds
+that said it does.** The models were wrong about something, but the fix they suggested
+was right anyway.
+
+### Resolved, 2026-07-20
+
+**Verified fixed by manual GUI test.** With the request card on `flex_1() + h_full()` and
+`w_full()` on the `v_resizable` host, wrapping long response header values no longer
+collapses the request card. Wrapping is back on; values are readable in full.
+
+The mechanism was never proven — the reconstructions still say this subtree cannot
+produce the collapse, so *why* percentage resolution failed in the real tree remains
+open. What is now established empirically:
+
+- the collapse is a property of **`size_full()` on a `ResizablePanel`'s child**, not of
+  anything in the response subtree. Wrapping only ever exposed it;
+- `flex_1()` on that child is immune, which is why the response card never collapsed
+  across any of the five bisect builds.
+
+**Rule for this codebase: never size a `ResizablePanel`'s child with `size_full()`. Use
+`flex_1()` plus an explicit cross-axis size.** The panel is a flex row, so `size_full()`
+puts the child's main size on a percentage with no stretch fallback; that is one failed
+resolution away from content sizing, and something in gpui's real layout does make it
+fail. If a third panel is ever added, style its child the same way.
 
 ## Risk: the `min_h_0` diagnosis is a hypothesis
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -626,15 +626,28 @@ impl Render for PoopmanApp {
                                     )
                                     .child(
                                         // Request editor and response viewer with resizable splitter
-                                        div().flex_1().overflow_hidden().child(
+                                        // w_full keeps this host's width definite, so the
+                                        // width:100% that ResizablePanelGroup and
+                                        // ResizablePanel both size themselves with has
+                                        // something to resolve against.
+                                        div().flex_1().w_full().overflow_hidden().child(
                                             v_resizable("request-response-splitter")
                                                 .child(
                                                     resizable_panel()
                                                         .size(px(REQUEST_INITIAL_HEIGHT))
                                                         .size_range(px(REQUEST_MIN)..px(REQUEST_MAX))
                                                         .child(
+                                                            // flex_1 rather than size_full: the
+                                                            // panel is a flex ROW, so this is the
+                                                            // main axis. size_full asks for
+                                                            // width:100%, which only fills if that
+                                                            // percentage resolves; flex-grow fills
+                                                            // unconditionally. The response card
+                                                            // below has always used flex_1 and has
+                                                            // never collapsed, while this one has.
                                                             crate::ui::card_panel(theme)
-                                                                .size_full()
+                                                                .flex_1()
+                                                                .h_full()
                                                                 .child(self.request_editor.clone()),
                                                         ),
                                                 )

--- a/src/history_panel.rs
+++ b/src/history_panel.rs
@@ -27,6 +27,7 @@ pub struct HistoryPanel {
     selected_id: Option<i64>,
     search: Entity<InputState>,
     query: String,
+    list_scroll_handle: ScrollHandle,
 }
 
 impl HistoryPanel {
@@ -43,6 +44,7 @@ impl HistoryPanel {
             selected_id: None,
             search,
             query: String::new(),
+            list_scroll_handle: ScrollHandle::new(),
         }
     }
 
@@ -99,6 +101,84 @@ impl HistoryPanel {
         self.search
             .update(cx, |state, cx| state.set_value("", window, cx));
         cx.notify();
+    }
+
+    /// Render one history row. Split out of `render` so the list body stays
+    /// shallow enough for rustfmt to format it.
+    fn render_item(&self, item: &HistoryItem, cx: &Context<Self>) -> impl IntoElement {
+        let theme = cx.theme();
+        let item_id = item.id;
+        let is_selected = self.selected_id == Some(item_id);
+        let verb = item.request.method.as_str();
+        let verb_color = crate::theme::method_color(item.request.method, theme);
+        let url = item.request.url.clone();
+        let time = crate::format::format_relative_time(&item.timestamp, chrono::Utc::now());
+        let item_clone = item.clone();
+
+        h_flex()
+            .id(("history-item", item_id as u64))
+            .gap_2()
+            .items_start()
+            .w_full()
+            .px_2p5()
+            .py_2()
+            .rounded(theme.radius_lg)
+            .border_1()
+            .border_color(if is_selected {
+                theme.list_active_border
+            } else {
+                gpui::transparent_black()
+            })
+            .bg(if is_selected {
+                theme.list_active
+            } else {
+                gpui::transparent_black()
+            })
+            .cursor_pointer()
+            .hover(|s| {
+                s.bg(if is_selected {
+                    theme.list_active
+                } else {
+                    theme.list_hover
+                })
+            })
+            .on_click(
+                cx.listener(move |this, _event: &gpui::ClickEvent, window, cx| {
+                    this.on_item_click(&item_clone, window, cx);
+                }),
+            )
+            .child(
+                // small mono method label, no filled pill
+                div()
+                    .flex_shrink_0()
+                    .w(px(34.))
+                    .text_right()
+                    .text_xs()
+                    .font_weight(FontWeight::BOLD)
+                    .text_color(verb_color)
+                    .child(verb),
+            )
+            .child(
+                v_flex()
+                    .min_w_0()
+                    .flex_1()
+                    .gap_0p5()
+                    .child(
+                        div()
+                            .text_sm()
+                            .text_color(theme.foreground)
+                            .overflow_x_hidden()
+                            .whitespace_nowrap()
+                            .text_ellipsis()
+                            .child(url),
+                    )
+                    .child(
+                        div()
+                            .text_xs()
+                            .text_color(theme.muted_foreground)
+                            .child(time),
+                    ),
+            )
     }
 }
 
@@ -166,83 +246,27 @@ impl Render for HistoryPanel {
             })
             .when(!self.history.is_empty(), |this| {
                 this.child(
-                    // List - use size_full to fill available space
-                    v_flex()
-                        .size_full()
-                        .gap_0p5()
-                        .px_2()
-                        .py_1()
-                        .children(self.history.iter().map(|item| {
-                            let item_id = item.id;
-                            let is_selected = self.selected_id == Some(item_id);
-                            let verb = item.request.method.as_str();
-                            let verb_color = crate::theme::method_color(item.request.method, theme);
-                            let url = item.request.url.clone();
-                            let time = crate::format::format_relative_time(
-                                &item.timestamp,
-                                chrono::Utc::now(),
-                            );
-                            let item_clone = item.clone();
-
-                            h_flex()
-                                .id(("history-item", item_id as u64))
-                                .gap_2()
-                                .items_start()
+                    // Viewport: bounded so the scroller inside it can overflow.
+                    div()
+                        .flex()
+                        .flex_col()
+                        .flex_1()
+                        .min_h_0() // Let the list shrink so its overflow_scroll engages
+                        .w_full()
+                        .overflow_hidden()
+                        .child(
+                            v_flex()
+                                .id("history-list-scroll")
+                                .flex_1()
                                 .w_full()
-                                .px_2p5()
-                                .py_2()
-                                .rounded(theme.radius_lg)
-                                .border_1()
-                                .border_color(if is_selected {
-                                    theme.list_active_border
-                                } else {
-                                    gpui::transparent_black()
-                                })
-                                .bg(if is_selected {
-                                    theme.list_active
-                                } else {
-                                    gpui::transparent_black()
-                                })
-                                .cursor_pointer()
-                                .hover(|s| s.bg(if is_selected { theme.list_active } else { theme.list_hover }))
-                                .on_click(cx.listener(move |this, _event: &gpui::ClickEvent, window, cx| {
-                                    this.on_item_click(&item_clone, window, cx);
-                                }))
-                                .child(
-                                    // small mono method label, no filled pill
-                                    div()
-                                        .flex_shrink_0()
-                                        .w(px(34.))
-                                        .text_right()
-                                        .text_xs()
-                                        .font_weight(FontWeight::BOLD)
-                                        .text_color(verb_color)
-                                        .child(verb),
-                                )
-                                .child(
-                                    v_flex()
-                                        .min_w_0()
-                                        .flex_1()
-                                        .gap_0p5()
-                                        .child(
-                                            div()
-                                                .text_sm()
-                                                .text_color(theme.foreground)
-                                                .overflow_x_hidden()
-                                                .whitespace_nowrap()
-                                                .text_ellipsis()
-                                                .child(url),
-                                        )
-                                        .child(
-                                            div()
-                                                .text_xs()
-                                                .text_color(theme.muted_foreground)
-                                                .child(time),
-                                        ),
-                                )
-                        }))
-                        .overflow_y_scrollbar()
-                        .size_full(),
+                                .min_h_0()
+                                .track_scroll(&self.list_scroll_handle)
+                                .overflow_scroll()
+                                .child(v_flex().gap_0p5().px_2().py_1().children(
+                                    self.history.iter().map(|item| self.render_item(item, cx)),
+                                )),
+                        )
+                        .vertical_scrollbar(&self.list_scroll_handle),
                 )
             })
     }

--- a/src/response_viewer.rs
+++ b/src/response_viewer.rs
@@ -256,6 +256,7 @@ impl ResponseViewer {
                             h_flex()
                                 .gap_2()
                                 .w_full()
+                                .items_start()
                                 .child(
                                     div()
                                         .font_weight(FontWeight::SEMIBOLD)
@@ -264,23 +265,16 @@ impl ResponseViewer {
                                         .child(format!("{}:", key)),
                                 )
                                 .child(
-                                    // Stays on one line, ellipsized. Wrapping was tried
-                                    // and reverted: dropping `whitespace_nowrap` collapses
-                                    // this value's min-content width, and that somehow
-                                    // collapses the *request* card above to ~280px — its
-                                    // ResizablePanel stops resolving `size_full`'s
-                                    // width:100% and falls back to content sizing.
-                                    // Bisected across five GUI builds and localised with
-                                    // canvas probes; the mechanism was never found, so
-                                    // wrapping stays off until it is. See
-                                    // docs/superpowers/specs/2026-07-15-app-wide-scrolling-design.md
-                                    // ("Wrapping: attempted and reverted").
+                                    // Wraps rather than ellipsizing — reading the whole
+                                    // value is the point of looking at headers. min_w_0
+                                    // is load-bearing: a value with no break
+                                    // opportunities (a JWT, a long set-cookie) otherwise
+                                    // has an automatic minimum width of the entire
+                                    // string and blows the row out horizontally.
                                     div()
                                         .text_sm()
                                         .flex_1()
-                                        .overflow_hidden()
-                                        .text_ellipsis()
-                                        .whitespace_nowrap()
+                                        .min_w_0()
                                         .child(value.clone()),
                                 )
                         })),


### PR DESCRIPTION
Clears both items recorded as known debt at the end of the app-wide scrolling round (PR #21/#22).

## (a) History list was still on the trapped `.overflow_y_scrollbar()`

`history_panel.rs` was the last surface not on the convention PR #21 established everywhere else, so "one convention app-wide" was not literally true. Moved to viewport / scroller / sibling scrollbar. The old `.size_full()` on the list is dropped — it disables stretch and left the list unbounded.

Row rendering moved to `HistoryPanel::render_item`; the added nesting pushed the list body past the depth rustfmt will format.

## (b) Wrapping response header values collapsed the request card to ~281px

Reverted in `5b3a2b1` after five bisect GUI builds failed to find the mechanism. Fixed here.

The two panels under `v_resizable` were never symmetric, and `app.rs` is where the asymmetry lives:

```rust
// request
resizable_panel().size(..).size_range(..).child(card_panel().size_full())
// response — not a resizable_panel() at all; From<E> wraps it
card_panel().flex_1().min_h(px(200.)).mt(px(10.)).into_any_element()
```

`ResizablePanel::render` builds its div with `.flex().flex_grow().size_full()`, so the panel is itself a flex **row** and width is the *main* axis for its child. `size_full()` asks for `width: 100%` and fills only while that percentage resolves; `flex_1()` fills unconditionally. That is exactly the split the bisect saw — the card depending on percentage resolution collapsed, the card that grows never did.

Request card is now `flex_1() + h_full()`, and the `v_resizable` host gets `w_full()`. Wrapping is back on.

**The mechanism is still unproven.** Three headless taffy 0.9 reconstructions — including one modelling the response scroll-container chain and gpui's nowrap measurement semantics (it returns the whole string's width rather than clamping to available space) — all decline to reproduce the collapse. The fix is verified empirically, not derived. The rule it establishes: **never size a `ResizablePanel`'s child with `size_full()`; use `flex_1()` plus an explicit cross-axis size.**

## Verification

- `cargo check` and `cargo clippy --all-targets`: clean, zero warnings
- `cargo test` on Windows: **123 passed, 0 failed**
- Manual GUI test on Windows confirmed both: history list scrolls with a hover scrollbar; long header values wrap while the request card stays full width
- Layout is not covered by any automated test — both were confirmed by eye

🤖 Generated with [Claude Code](https://claude.com/claude-code)