### PR TITLE
ci: drive releases from a version input so Cargo.toml cannot drift

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,95 @@
 name: Build and Release
 
+# Releasing is dispatch-driven so Cargo.toml can never drift from the tag:
+# the version you type here is written into Cargo.toml and committed FIRST,
+# and everything downstream builds from that commit. There is deliberately no
+# `push: tags` trigger — a hand-pushed tag would bypass the bump and
+# reintroduce the drift this workflow exists to prevent.
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release, without the leading v (e.g. 0.3.3)'
+        required: true
+        type: string
 
 jobs:
+  bump:
+    name: Bump Cargo.toml and push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      sha: ${{ steps.commit.outputs.sha }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Validate input
+        run: |
+          VERSION="${{ inputs.version }}"
+          if ! printf '%s' "$VERSION" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::'$VERSION' is not a semver version. Pass it without the leading v, e.g. 0.3.3"
+            exit 1
+          fi
+          if git rev-parse -q --verify "refs/tags/v$VERSION" >/dev/null; then
+            echo "::error::tag v$VERSION already exists"
+            exit 1
+          fi
+
+      - name: Set the crate version
+        run: |
+          VERSION="${{ inputs.version }}"
+          # Section-aware on purpose. Two versions have to move together:
+          # [package] and [package.metadata.bundle], the latter being what
+          # cargo-bundle stamps into the macOS .app/.dmg. A blanket sed would
+          # also rewrite dependency versions; a first-match-only edit would
+          # silently leave the macOS bundle on the old version forever.
+          # Cargo.toml is CRLF in this repo, so the section header carries a
+          # trailing \r that has to come off before comparing.
+          awk -v v="$VERSION" '
+            /^\[/ { sect = $0; sub(/\r$/, "", sect) }
+            /^version = / && (sect == "[package]" || sect == "[package.metadata.bundle]") {
+              sub(/"[^"]*"/, "\"" v "\"")
+            }
+            { print }
+          ' Cargo.toml > Cargo.toml.new
+          mv Cargo.toml.new Cargo.toml
+
+          # Both must now read the new version, or the edit missed one.
+          if [ "$(grep -c "^version = \"$VERSION\"" Cargo.toml)" -ne 2 ]; then
+            echo "::error::expected 2 version lines at $VERSION, got:"
+            grep -n '^version' Cargo.toml
+            exit 1
+          fi
+          grep -n '^version' Cargo.toml
+
+          # Syncs Cargo.lock's poopman entry without compiling and without
+          # touching dependency versions. `cargo metadata` does NOT rewrite the
+          # lock here, and `cargo generate-lockfile` would re-resolve everything.
+          cargo update --workspace
+
+      - name: Commit and push
+        id: commit
+        run: |
+          VERSION="${{ inputs.version }}"
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          if git diff --quiet; then
+            echo "::error::Cargo.toml is already at $VERSION — nothing to release"
+            exit 1
+          fi
+          git add Cargo.toml Cargo.lock
+          git commit -m "chore: release v$VERSION"
+          git push origin main
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build ${{ matrix.target }}
+    needs: bump
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -30,8 +111,12 @@ jobs:
             asset_name: Poopman-windows-x86_64
 
     steps:
-      - name: Checkout code
+      # The bump commit, not main's tip — the binaries must carry the version
+      # that was just written, and main may have moved on.
+      - name: Checkout the bump commit
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump.outputs.sha }}
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -103,15 +188,16 @@ jobs:
 
   release:
     name: Create Release
-    needs: build
+    needs: [bump, build]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
     permissions:
       contents: write
 
     steps:
-      - name: Checkout code
+      - name: Checkout the bump commit
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.bump.outputs.sha }}
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -121,9 +207,13 @@ jobs:
       - name: Display structure of downloaded files
         run: ls -R artifacts
 
+      # Creates the tag as well, on the bump commit. Tagging here rather than
+      # in the bump job means a failed build leaves no dangling tag.
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: v${{ inputs.version }}
+          target_commitish: ${{ needs.bump.outputs.sha }}
           draft: false
           prerelease: false
           generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /gpui-component/
 .claude
 .superpowers/
+# Local scratch for preview HTML and verification screenshots.
+.preview/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4440,7 +4440,7 @@ checksum = "5da3b0203fd7ee5720aa0b5e790b591aa5d3f41c3ed2c34a3a393382198af2f7"
 
 [[package]]
 name = "poopman"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ name = "poopman"
 description = "A Postman-like API client built with GPUI Component."
 license = "Apache-2.0"
 publish = false
-version = "0.3.0"
+version = "0.3.2"
 
 [dependencies]
 anyhow = "1"
@@ -35,7 +35,7 @@ winresource = "0.1"
 name = "Poopman"
 identifier = "com.poopman.app"
 icon = ["assets/icons/logo.ico"]
-version = "0.3.0"
+version = "0.3.2"
 copyright = "Copyright (c) 2024"
 category = "Utility"
 short_description = "A Postman-like API client"


### PR DESCRIPTION
`Cargo.toml` has lagged the release tag twice — it read `0.3.0` at both `v0.3.1` and `v0.3.2`, so the shipped binaries under-reported their version. The tag was the only input and nothing tied it to the crate version.

## What changes

Releasing becomes dispatch-driven. You run the workflow with a version (`0.3.3`), and CI writes it into `Cargo.toml`, commits to `main`, builds from that commit, then tags and releases.

```
Actions → Build and Release → Run workflow → version: 0.3.3
```

| | before | after |
|---|---|---|
| trigger | `git tag v0.3.3 && git push --tags` | `workflow_dispatch` with a version input |
| `Cargo.toml` | bumped by hand, or forgotten | written by CI, always matches |
| tag | created by you, before the build | created by the release job, after the build succeeds |

## Things that had to be right

- **`release` lost `if: startsWith(github.ref, 'refs/tags/')`.** Under `workflow_dispatch` `github.ref` is `refs/heads/main`, so that condition would never fire and **no release would ever be created**. Easy to miss — the build jobs would go green and nothing would publish.
- **`build` and `release` check out the bump commit by sha**, not `main`'s tip, so artifacts cannot come from a different tree.
- **The tag is created by the release job**, not the bump job. A failed build leaves no dangling tag.
- **No `push: tags` trigger any more.** A hand-pushed tag would skip the bump and reintroduce the drift, so there is exactly one way to release.

## The version edit

Section-aware, because **two** versions must move together:

```toml
[package]
version = "0.3.2"                  # the crate

[package.metadata.bundle]
version = "0.3.2"                  # what cargo-bundle stamps into the macOS .app/.dmg
```

A first-match-only edit would have left macOS on `0.3.0` forever; a blanket `sed` would have rewritten dependency versions. It also strips the trailing `\r` from section headers — `Cargo.toml` is CRLF in this repo and the comparison silently matched nothing without it, which a dry run caught. A post-edit assertion fails the job unless exactly two lines carry the new version.

Lock sync uses `cargo update --workspace`. `cargo metadata` does **not** rewrite `Cargo.lock` (verified locally — the file was untouched), and `cargo generate-lockfile` would re-resolve every dependency.

## Also included

Syncs `Cargo.toml` and `Cargo.lock` to `0.3.2` to clear the drift that already exists.

## Verification

- YAML parses; job graph is `bump → build → release`, with `contents: write` on the two jobs that need it
- The awk edit was dry-run against the real `Cargo.toml`: both versions bumped, CRLF preserved, every other line byte-identical
- `cargo update --workspace` confirmed to touch only the `poopman` entry (42 dependencies unchanged)
- **Not yet exercised end to end** — the first real dispatch is the actual test. If something is wrong it will most likely be in the push permission to `main`, which depends on branch-protection settings I cannot see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)