### PR TITLE
feat(headers): standard header-name autocomplete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4451,6 +4451,7 @@ dependencies = [
  "gpui",
  "gpui-component",
  "log",
+ "lsp-types",
  "mime_guess",
  "quick-xml 0.40.1",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,10 @@ gpui = "0.2.2"
 gpui-component = { version = "0.5", features = ["tree-sitter-languages"] }
 log = "0.4"
 env_logger = "0.11"
+# Only for the header-key completion provider: gpui-component's CompletionProvider
+# trait is LSP-shaped and it re-exports only `Position`, not the crate. The version
+# must track gpui-component's own lsp-types or the trait will not be satisfied.
+lsp-types = "0.97"
 
 base64 = "0.22"
 chrono = { version = "0.4", features = ["serde"] }

--- a/docs/superpowers/specs/2026-07-20-header-key-autocomplete-design.md
+++ b/docs/superpowers/specs/2026-07-20-header-key-autocomplete-design.md
@@ -1,0 +1,137 @@
+# Spec: header key autocomplete (typeahead)
+
+Date: 2026-07-20
+Status: Approved (design and acceptance criteria confirmed by user)
+
+## Goal
+
+Typing `Au` in a custom header's name field should surface a dropdown suggesting
+`Authorization`, the way Postman does. Today the full header name must be typed by
+hand.
+
+## Fact base
+
+Three findings from reading the current code, each of which constrains the design:
+
+1. **The key input is disabled for predefined rows** (`request_editor.rs:1248`,
+   `.disabled(is_predefined)`). Autocomplete can therefore only ever apply to
+   `HeaderType::Custom` rows.
+
+2. **Six predefined headers already own dedicated rows** (`types.rs:17-69`):
+   `Cache-Control`, `Content-Type`, `Accept`, `User-Agent`, `Connection`,
+   `Content-Length`. Suggesting them again would let the user create a duplicate
+   header that goes out on the wire twice.
+
+3. **gpui-component 0.5.1 ships a completion mechanism.** `InputState` exposes a
+   public `CompletionProvider` trait (`src/input/lsp/completions.rs:20`) and a
+   `CompletionMenu` popover with keyboard navigation, query filtering and insertion
+   already implemented. The trigger sits in `replace_text_in_range`
+   (`src/input/state.rs:2007`) and is **not** gated on multi-line or code-editor
+   mode, so a single-line input can drive it.
+
+One risk was investigated and dismissed: the menu renders through `deferred(...)`
+(`completion_menu.rs:420`), and gpui's `defer_draw` records only an `absolute_offset`
+without capturing a content mask (`gpui-0.2.2/src/window.rs:2756-2775`). Deferred
+draws therefore escape ancestor clipping — both the `overflow_x_hidden` on the
+input-state div (`state.rs:2172`) and the headers list's scroll container. Position
+correctness remains unverified and is a Tier 0 gate item.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Candidate source | Static in-code table of standard HTTP request header names |
+| Predefined six | Excluded from suggestions, including when their row is unchecked — the row still exists, the user can re-tick it |
+| Matching | Case-insensitive **prefix** match; insertion uses canonical casing |
+| Trigger | 1 or more characters typed; empty input suggests nothing |
+| After selection | Focus moves to the same row's value input |
+| Value suggestions | Out of scope this round |
+| Coverage | Headers tab only |
+| Implementation | gpui-component's `CompletionProvider` (approach A), behind a spike gate |
+
+`Select`/`SearchableVec` was rejected: its value domain is closed, but a header name
+must accept free-form input (`X-My-Internal-Thing` is normal).
+
+Approach A costs a new dependency — `lsp-types = "0.97"` — because the trait
+signature names `lsp_types::CompletionResponse` and gpui-component re-exports only
+`Position` (`src/input/mod.rs:31`), not the crate.
+
+## Architecture
+
+**`src/header_names.rs` (new)** — no gpui dependency, fully unit-testable:
+
+```rust
+pub fn suggest(prefix: &str) -> Vec<&'static str>
+```
+
+Holds the static, deduplicated, lexicographically sorted name table with the six
+predefined names excluded at the source. This function is shared by approach A and
+approach B, so it retains its value if the spike gate fails.
+
+**`HeaderCompletionProvider`** — implements `CompletionProvider`, wrapping `suggest`
+and mapping results to `CompletionItem`s.
+
+**Wiring** — custom header rows are constructed in **three** places
+(`request_editor.rs:228`, `:401`, `:448`), corresponding to loading a request,
+restoring header state, and appending the trailing blank row. All three must attach
+the provider; wiring only one produces a feature that works on the path you happen to
+test and is dead on the others.
+
+## Acceptance criteria
+
+### Tier 0 — spike gate (user-verified on Windows)
+
+Minimal wiring, three hard-coded candidates, no full table and no focus jump.
+
+- [ ] Typing `A` in the trailing blank row's key field opens a menu
+- [ ] The menu appears directly below that input, not offset or in a window corner
+- [ ] The menu is not clipped by the headers list scroll container (retest with the
+      list scrolled to a middle position)
+- [ ] Up/Down move the highlight, Enter inserts, Esc closes
+- [ ] Enter with the menu open does **not** send the request
+
+**If any item fails, stop and switch to approach B.** Report the symptom rather than
+working around it.
+
+### Tier 1 — automated (`cargo test`, `cargo clippy`)
+
+- [ ] `suggest("Au")` contains `Authorization`
+- [ ] Case-insensitive: `suggest("au")`, `suggest("AU")`, `suggest("Au")` agree
+- [ ] `suggest("")` is empty
+- [ ] `suggest("Type")` is empty (prefix, not substring)
+- [ ] `suggest("Zzz")` is empty and does not panic
+- [ ] `suggest("X-")` is non-empty and every result starts with `X-`
+- [ ] None of the six predefined names is ever returned — asserted individually
+- [ ] The static table has no duplicates and is sorted
+- [ ] `suggest("accept")` excludes `Accept` but includes `Accept-Encoding`
+- [ ] `cargo clippy` reports 0 warnings (currently 0; must not regress)
+
+### Tier 2 — user-verified (GUI)
+
+- [ ] `Au` suggests `Authorization`; the field ends up holding canonical casing
+- [ ] Focus lands on the same row's value input after selection
+- [ ] A new blank header row is still appended automatically after completion
+- [ ] The six predefined rows' key fields remain disabled and never open a menu
+- [ ] Loading a request from history: its custom header rows autocomplete too
+- [ ] Switching tabs or requests and returning: autocomplete still works
+- [ ] A name absent from the table (`X-My-Thing`) can still be typed and sent
+- [ ] Headers actually sent match what the UI shows — no duplicates or residue
+
+The history-load, tab-switch and three-call-site items exist specifically to catch
+partial wiring. See the `mechanism-exists-is-not-feature-works` lesson.
+
+### Tier 3 — explicitly out of scope
+
+Value-side completion, fuzzy/substring matching, learning from history, Params tab
+completion, duplicate detection across custom rows.
+
+## Test gate
+
+WSL2 cannot build or run the GUI. `cargo check` and `cargo clippy` run locally;
+the full suite runs on the Windows side via:
+
+```
+pwsh.exe -NoProfile -Command "cd E:\code\poopman; cargo test"
+```
+
+Every Tier 0 and Tier 2 item requires the user at a Windows desktop.

--- a/docs/superpowers/specs/2026-07-20-header-key-autocomplete-design.md
+++ b/docs/superpowers/specs/2026-07-20-header-key-autocomplete-design.md
@@ -155,16 +155,32 @@ entry as an accepted completion. Manual typing advances one character at a time,
 it cannot false-positive; pasting a complete header name can, and jumping focus is
 the desired behaviour there anyway. To be implemented after the Tier 0 gate passes.
 
-## Progress
+## Progress — complete
 
 - **Tier 1: passed, with evidence.** `cargo test` on Windows reports 144 passed /
   0 failed, including the 10 new assertions. `cargo clippy --all-targets` recompiles
   clean with no warning lines, exit 0.
-- **Tier 0 and Tier 2: not yet run.** WSL2 cannot type into the GUI. The Windows
-  binary builds and launches without regression (headers list renders, six predefined
-  rows present), but that screenshot proves startup only — it says nothing about
-  whether the menu opens.
-- **Focus jump: not implemented**, per the sequencing above.
+- **Tier 0: passed, user-verified** on the release build. The menu opens on the first
+  character, sits below the input, is not clipped when the list scrolls, Enter/Escape
+  and arrow navigation all work, and Enter with the menu open does not send.
+- **Tier 2: passed, user-verified.** `Au` → `Authorization` with canonical casing;
+  focus lands on the value field; the trailing blank row is still appended; the six
+  predefined rows stay disabled with no menu; custom rows loaded from history and
+  restored after a tab switch both autocomplete; a name absent from the table can be
+  typed and sent; Escape closes the menu without sending.
+- **Focus jump: implemented and verified.**
+
+### One bug the spike gate caught
+
+The gate did its job. First user test: the menu opened but the Down arrow did not move
+the highlight. Root cause was in the library, not our code: gpui-component registers
+the up/down action handlers only for multi-line inputs
+(`input.rs` `.when(state.mode.is_multi_line())`), so on a single-line field the arrow
+actions dispatched with no listener and never reached the menu — while Enter/Escape
+worked because their handlers are unconditional. Fixed by forwarding `MoveUp`/`MoveDown`
+from the wrapping div to the library's public `handle_action_for_context_menu`. Had we
+skipped the gate and shipped on the strength of "it compiles and the menu renders,"
+this would have gone out broken. See [[gpui-focus-dispatch-gotchas]].
 
 Commits live on `feat/header-key-autocomplete`.
 

--- a/docs/superpowers/specs/2026-07-20-header-key-autocomplete-design.md
+++ b/docs/superpowers/specs/2026-07-20-header-key-autocomplete-design.md
@@ -125,6 +125,49 @@ partial wiring. See the `mechanism-exists-is-not-feature-works` lesson.
 Value-side completion, fuzzy/substring matching, learning from history, Params tab
 completion, duplicate detection across custom rows.
 
+## The focus jump has no clean hook
+
+"Focus moves to the value input after selection" is an approved criterion that the
+library does not support directly. Three candidate hooks were checked and all three
+are closed:
+
+- **No completion-accepted event.** `InputEvent` is only
+  `Change | PressEnter | Focus | Blur` (`state.rs:93-98`).
+- **No way to observe the menu.** `InputState::context_menu` is `pub(crate)` and there
+  is no public accessor.
+- **`CompletionItem.command` is ignored.** LSP's standard post-insert hook is not read
+  anywhere in `completion_menu.rs` or `lsp/completions.rs`.
+
+Two related facts, both from reading the insertion path in
+`completion_menu.rs:229-273`:
+
+- `replace_text_in_range_silent` suppresses only the re-trigger check
+  (`state.rs:2006`); `cx.emit(InputEvent::Change)` sits outside that guard
+  (`:2009`) and still fires. The editor's existing "append a blank row" subscription
+  therefore survives completion insertion.
+- The library re-focuses the key input itself after inserting, under a standing
+  `// FIXME: Input not get the focus` (`completion_menu.rs:266-267`). Anything that
+  moves focus elsewhere is racing that call.
+
+**Decision (user, 2026-07-20):** accept a heuristic — treat a `Change` that grows the
+text by more than one character *and* leaves it exactly equal to a canonical table
+entry as an accepted completion. Manual typing advances one character at a time, so
+it cannot false-positive; pasting a complete header name can, and jumping focus is
+the desired behaviour there anyway. To be implemented after the Tier 0 gate passes.
+
+## Progress
+
+- **Tier 1: passed, with evidence.** `cargo test` on Windows reports 144 passed /
+  0 failed, including the 10 new assertions. `cargo clippy --all-targets` recompiles
+  clean with no warning lines, exit 0.
+- **Tier 0 and Tier 2: not yet run.** WSL2 cannot type into the GUI. The Windows
+  binary builds and launches without regression (headers list renders, six predefined
+  rows present), but that screenshot proves startup only — it says nothing about
+  whether the menu opens.
+- **Focus jump: not implemented**, per the sequencing above.
+
+Commits live on `feat/header-key-autocomplete`.
+
 ## Test gate
 
 WSL2 cannot build or run the GUI. `cargo check` and `cargo clippy` run locally;

--- a/src/header_completion.rs
+++ b/src/header_completion.rs
@@ -1,0 +1,67 @@
+//! Typeahead for custom header name fields.
+//!
+//! Wraps [`crate::header_names::suggest`] in gpui-component's LSP-shaped
+//! [`CompletionProvider`] so the library's completion menu (keyboard navigation,
+//! prefix highlighting, insertion) drives the UI. All matching logic lives in
+//! `header_names`; this file only adapts it.
+
+use anyhow::Result;
+use gpui::{Context, Task, Window};
+use gpui_component::input::{CompletionProvider, InputState, Rope, RopeExt};
+use lsp_types::{
+    CompletionContext, CompletionItem, CompletionItemKind, CompletionResponse, CompletionTextEdit,
+    TextEdit,
+};
+
+use crate::header_names::suggest;
+
+/// Suggests standard HTTP header names in a single-line header-name input.
+pub struct HeaderCompletionProvider;
+
+impl CompletionProvider for HeaderCompletionProvider {
+    fn completions(
+        &self,
+        rope: &Rope,
+        _offset: usize,
+        _trigger: CompletionContext,
+        _window: &mut Window,
+        _cx: &mut Context<InputState>,
+    ) -> Task<Result<CompletionResponse>> {
+        // The field holds nothing but the header name, so the whole text is the
+        // prefix regardless of where the cursor sits. Using the full range also
+        // means the edit replaces what was typed rather than appending to it,
+        // which is what puts canonical casing in the field after "au".
+        let prefix = rope.to_string();
+        let range = lsp_types::Range {
+            start: rope.offset_to_position(0),
+            end: rope.offset_to_position(rope.len()),
+        };
+
+        let items = suggest(&prefix)
+            .into_iter()
+            .map(|name| CompletionItem {
+                label: name.to_string(),
+                kind: Some(CompletionItemKind::FIELD),
+                filter_text: Some(prefix.clone()),
+                text_edit: Some(CompletionTextEdit::Edit(TextEdit {
+                    range,
+                    new_text: name.to_string(),
+                })),
+                ..Default::default()
+            })
+            .collect::<Vec<_>>();
+
+        Task::ready(Ok(CompletionResponse::Array(items)))
+    }
+
+    fn is_completion_trigger(
+        &self,
+        _offset: usize,
+        _new_text: &str,
+        _cx: &mut Context<InputState>,
+    ) -> bool {
+        // Every keystroke is a candidate trigger; `suggest` returns nothing for an
+        // empty field, which is what keeps the menu shut on a merely-focused row.
+        true
+    }
+}

--- a/src/header_names.rs
+++ b/src/header_names.rs
@@ -1,0 +1,190 @@
+//! Standard HTTP request header names for the header-key typeahead.
+//!
+//! Pure functions and a static table, so the whole matching rule is unit-tested
+//! without a GPUI window. The UI layer wraps `suggest` in a
+//! `gpui_component::input::CompletionProvider`; keeping the logic here means it
+//! survives unchanged if that mechanism is ever swapped for a hand-rolled popup.
+
+/// Common HTTP request header names offered as completions.
+///
+/// Byte-sorted and deduplicated — `suggest` returns candidates in table order, so
+/// the table's order *is* the menu's order. The six headers that already own
+/// dedicated rows in the editor (`Cache-Control`, `Content-Type`, `Accept`,
+/// `User-Agent`, `Connection`, `Content-Length`) are deliberately absent: they
+/// cannot be typed into a custom row without sending a duplicate header on the
+/// wire. See `PredefinedHeader` in `types.rs`.
+pub const HEADER_NAMES: &[&str] = &[
+    "Accept-Charset",
+    "Accept-Encoding",
+    "Accept-Language",
+    "Access-Control-Request-Headers",
+    "Access-Control-Request-Method",
+    "Age",
+    "Allow",
+    "Authorization",
+    "Content-Disposition",
+    "Content-Encoding",
+    "Content-Language",
+    "Content-Location",
+    "Content-MD5",
+    "Content-Range",
+    "Cookie",
+    "Date",
+    "ETag",
+    "Expect",
+    "Expires",
+    "Forwarded",
+    "From",
+    "Host",
+    "If-Match",
+    "If-Modified-Since",
+    "If-None-Match",
+    "If-Range",
+    "If-Unmodified-Since",
+    "Keep-Alive",
+    "Last-Modified",
+    "Link",
+    "Location",
+    "Max-Forwards",
+    "Origin",
+    "Pragma",
+    "Prefer",
+    "Proxy-Authorization",
+    "Range",
+    "Referer",
+    "Retry-After",
+    "Server",
+    "TE",
+    "Trailer",
+    "Transfer-Encoding",
+    "Upgrade",
+    "Via",
+    "WWW-Authenticate",
+    "Warning",
+    "X-Api-Key",
+    "X-CSRF-Token",
+    "X-Correlation-Id",
+    "X-Forwarded-For",
+    "X-Forwarded-Host",
+    "X-Forwarded-Proto",
+    "X-Frame-Options",
+    "X-HTTP-Method-Override",
+    "X-Request-Id",
+    "X-Requested-With",
+];
+
+/// Header names whose completion is a case-insensitive prefix match on `prefix`.
+///
+/// An empty `prefix` yields nothing: the trailing blank header row is always
+/// present, so suggesting the entire table whenever it takes focus would fire a
+/// large menu at a user who is merely tabbing past.
+pub fn suggest(prefix: &str) -> Vec<&'static str> {
+    if prefix.is_empty() {
+        return Vec::new();
+    }
+
+    HEADER_NAMES
+        .iter()
+        .copied()
+        .filter(|name| starts_with_ignore_ascii_case(name, prefix))
+        .collect()
+}
+
+fn starts_with_ignore_ascii_case(name: &str, prefix: &str) -> bool {
+    name.len() >= prefix.len()
+        && name.as_bytes()[..prefix.len()].eq_ignore_ascii_case(prefix.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The names that own dedicated rows in the editor and must never be suggested.
+    const PREDEFINED: &[&str] = &[
+        "Cache-Control",
+        "Content-Type",
+        "Accept",
+        "User-Agent",
+        "Connection",
+        "Content-Length",
+    ];
+
+    #[test]
+    fn suggests_authorization_for_au() {
+        assert!(suggest("Au").contains(&"Authorization"));
+    }
+
+    #[test]
+    fn matching_is_case_insensitive() {
+        let canonical = suggest("Au");
+        assert_eq!(suggest("au"), canonical);
+        assert_eq!(suggest("AU"), canonical);
+        assert_eq!(suggest("aU"), canonical);
+    }
+
+    #[test]
+    fn empty_prefix_suggests_nothing() {
+        assert!(suggest("").is_empty());
+    }
+
+    #[test]
+    fn matching_is_prefix_not_substring() {
+        // "Type" appears inside "Content-Type" but is not a prefix of anything.
+        assert!(suggest("Type").is_empty());
+        assert!(suggest("Encoding").is_empty());
+    }
+
+    #[test]
+    fn unknown_prefix_is_empty_and_does_not_panic() {
+        assert!(suggest("Zzz").is_empty());
+        assert!(suggest("X-No-Such-Header-Really").is_empty());
+    }
+
+    #[test]
+    fn prefix_longer_than_any_name_is_empty() {
+        let longest = HEADER_NAMES.iter().map(|n| n.len()).max().unwrap();
+        assert!(suggest(&"A".repeat(longest + 1)).is_empty());
+    }
+
+    #[test]
+    fn x_dash_yields_only_x_dash_names() {
+        let results = suggest("X-");
+        assert!(results.len() > 1, "expected several X- headers, got {:?}", results);
+        assert!(results.iter().all(|name| name.starts_with("X-")));
+    }
+
+    #[test]
+    fn predefined_headers_are_never_suggested() {
+        for predefined in PREDEFINED {
+            assert!(
+                !HEADER_NAMES.contains(predefined),
+                "{predefined} is in the table but owns a dedicated row"
+            );
+            // Also unreachable through its own name as a query.
+            assert!(
+                !suggest(predefined).contains(predefined),
+                "{predefined} was suggested for its own name"
+            );
+        }
+    }
+
+    #[test]
+    fn table_is_sorted_and_deduplicated() {
+        for pair in HEADER_NAMES.windows(2) {
+            assert!(
+                pair[0] < pair[1],
+                "table is unsorted or contains a duplicate: {:?} then {:?}",
+                pair[0],
+                pair[1]
+            );
+        }
+    }
+
+    #[test]
+    fn accept_prefix_excludes_the_predefined_accept_but_keeps_its_relatives() {
+        let results = suggest("accept");
+        assert!(!results.contains(&"Accept"));
+        assert!(results.contains(&"Accept-Encoding"));
+        assert!(results.contains(&"Accept-Language"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,8 @@ mod curl_import;
 mod db;
 mod environment_manager;
 mod format;
+mod header_completion;
+mod header_names;
 mod history_panel;
 mod http_client;
 mod menu_bar;

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -60,6 +60,10 @@ struct HeaderRow {
     value_input: Entity<InputState>,
     header_type: HeaderType,
     predefined: Option<PredefinedHeader>,
+    /// Character count of the key field at the previous change, used to tell an
+    /// accepted completion (a multi-character replacement) from manual typing (one
+    /// character at a time). See `maybe_advance_after_completion`.
+    last_key_len: usize,
 }
 
 /// Query parameter row with key-value inputs and enabled checkbox
@@ -185,6 +189,7 @@ impl RequestEditor {
                 value_input,
                 header_type,
                 predefined: Some(predefined),
+                last_key_len: predefined.name().chars().count(),
             });
         }
     }
@@ -262,6 +267,7 @@ impl RequestEditor {
                     value_input,
                     header_type: HeaderType::Custom,
                     predefined: None,
+                    last_key_len: key.chars().count(),
                 });
             }
         }
@@ -438,13 +444,16 @@ impl RequestEditor {
                 }),
                 header_type: header_state.header_type,
                 predefined: header_state.predefined,
+                last_key_len: header_state.key.chars().count(),
             };
 
             // Subscribe to key input change if it's a custom header
             if matches!(header_state.header_type, HeaderType::Custom) {
                 let key_input = header_row.key_input.clone();
                 let key_input_for_closure = key_input.clone();
-                let sub = cx.subscribe_in(&key_input, window, move |this, _, _event: &InputEvent, window, cx| {
+                let sub = cx.subscribe_in(&key_input, window, move |this, emitter, _event: &InputEvent, window, cx| {
+                    this.maybe_advance_after_completion(emitter, window, cx);
+
                     if let Some(last) = this.headers.last() {
                         let has_key = !last.key_input.read(cx).value().is_empty();
                         if has_key
@@ -470,6 +479,40 @@ impl RequestEditor {
         cx.notify();
     }
 
+    /// Detect an accepted header-name completion and move focus to the value field.
+    ///
+    /// The library exposes no "completion accepted" hook, so we infer one: a change
+    /// that grows the key by more than one character and leaves it exactly equal to a
+    /// standard header name is a menu insertion (or a paste of a full name), never
+    /// manual typing, which advances one character at a time. This fires after the
+    /// library re-focuses the key input (both run off the same Change), so focusing
+    /// the value input here wins.
+    fn maybe_advance_after_completion(
+        &mut self,
+        changed: &Entity<InputState>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let changed_id = Entity::entity_id(changed);
+        let Some(idx) = self
+            .headers
+            .iter()
+            .position(|h| Entity::entity_id(&h.key_input) == changed_id)
+        else {
+            return;
+        };
+
+        let value = self.headers[idx].key_input.read(cx).value().to_string();
+        let cur_len = value.chars().count();
+        let grew_by_more_than_one = cur_len > self.headers[idx].last_key_len + 1;
+        self.headers[idx].last_key_len = cur_len;
+
+        if grew_by_more_than_one && crate::header_names::HEADER_NAMES.contains(&value.as_str()) {
+            let value_input = self.headers[idx].value_input.clone();
+            value_input.update(cx, |input, cx| input.focus(window, cx));
+        }
+    }
+
     fn add_custom_header_row(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let new_row = HeaderRow {
             enabled: true,
@@ -477,12 +520,15 @@ impl RequestEditor {
             value_input: cx.new(|cx| InputState::new(window, cx).placeholder("Value")),
             header_type: HeaderType::Custom,
             predefined: None,
+            last_key_len: 0,
         };
 
         // Subscribe to the key input change
         let key_input = new_row.key_input.clone();
         let key_input_for_closure = key_input.clone();
-        let sub = cx.subscribe_in(&key_input, window, move |this, _, _event: &InputEvent, window, cx| {
+        let sub = cx.subscribe_in(&key_input, window, move |this, emitter, _event: &InputEvent, window, cx| {
+            this.maybe_advance_after_completion(emitter, window, cx);
+
             // Check if this was the last row and it now has content
             if let Some(last) = this.headers.last() {
                 let has_key = !last.key_input.read(cx).value().is_empty();

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -9,6 +9,7 @@ use gpui_component::{
 use gpui_component::input::InputEvent;
 
 use crate::body_editor::{BodyEditor, BodyTypeChanged};
+use crate::header_completion::HeaderCompletionProvider;
 use crate::types::{HeaderType, HttpMethod, PredefinedHeader, RequestData, ResponseData};
 use crate::url_params::{self, QueryParam};
 use crate::theme::METHOD_SELECT_WIDTH;
@@ -28,6 +29,29 @@ pub struct OpenCodeSnippet;
 /// Event emitted when the user cancels an in-flight request.
 #[derive(Clone)]
 pub struct RequestCancelled;
+
+/// Create a header-name input carrying the standard-header typeahead.
+///
+/// Custom rows get built in three places — loading a request, restoring saved
+/// header state, and appending the trailing blank row. Routing all of them through
+/// this helper is what stops the completion from being live on one path and dead on
+/// the others.
+fn custom_header_key_input<T: 'static>(
+    value: &str,
+    window: &mut Window,
+    cx: &mut Context<T>,
+) -> Entity<InputState> {
+    // Owned because `cx.new` takes a 'static closure.
+    let value = value.to_string();
+    cx.new(move |cx| {
+        let mut input = InputState::new(window, cx).placeholder("Header name");
+        input.lsp.completion_provider = Some(std::rc::Rc::new(HeaderCompletionProvider));
+        if !value.is_empty() {
+            input.set_value(&value, window, cx);
+        }
+        input
+    })
+}
 
 /// Header row with key-value inputs and enabled checkbox
 struct HeaderRow {
@@ -225,11 +249,7 @@ impl RequestEditor {
                 }
             } else {
                 // Add as custom header
-                let key_input = cx.new(|cx| {
-                    let mut input = InputState::new(window, cx);
-                    input.set_value(key, window, cx);
-                    input
-                });
+                let key_input = custom_header_key_input(key, window, cx);
                 let value_input = cx.new(|cx| {
                     let mut input = InputState::new(window, cx);
                     input.set_value(value, window, cx);
@@ -396,13 +416,21 @@ impl RequestEditor {
 
         // Rebuild headers from saved state
         for header_state in state {
-            let header_row = HeaderRow {
-                enabled: header_state.enabled,
-                key_input: cx.new(|cx| {
+            // Predefined rows render their key field disabled, so only custom rows
+            // get the typeahead.
+            let key_input = if matches!(header_state.header_type, HeaderType::Custom) {
+                custom_header_key_input(&header_state.key, window, cx)
+            } else {
+                cx.new(|cx| {
                     let mut input = InputState::new(window, cx);
                     input.set_value(&header_state.key, window, cx);
                     input
-                }),
+                })
+            };
+
+            let header_row = HeaderRow {
+                enabled: header_state.enabled,
+                key_input,
                 value_input: cx.new(|cx| {
                     let mut input = InputState::new(window, cx);
                     input.set_value(&header_state.value, window, cx);
@@ -445,7 +473,7 @@ impl RequestEditor {
     fn add_custom_header_row(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let new_row = HeaderRow {
             enabled: true,
-            key_input: cx.new(|cx| InputState::new(window, cx).placeholder("Header name")),
+            key_input: custom_header_key_input("", window, cx),
             value_input: cx.new(|cx| InputState::new(window, cx).placeholder("Value")),
             header_type: HeaderType::Custom,
             predefined: None,

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -1269,12 +1269,38 @@ impl Render for RequestEditor {
                                                             ))
                                                     )
                                                 )
-                                                .child(
-                                                    // Key input - disabled for predefined headers
+                                                .child({
+                                                    // Key input - disabled for predefined headers.
+                                                    //
+                                                    // gpui-component registers the up/down action
+                                                    // handlers only for multi-line inputs (input.rs
+                                                    // `.when(is_multi_line)`), so on a single-line
+                                                    // field the arrow keys never reach the completion
+                                                    // menu and the highlight cannot move. Enter/Escape
+                                                    // work because their handlers are unconditional.
+                                                    // We bridge the two arrow actions to the menu via
+                                                    // the public `handle_action_for_context_menu`; the
+                                                    // single-line Input ignores them, so they bubble
+                                                    // up to this wrapper.
+                                                    let key_input = header.key_input.clone();
                                                     div()
                                                         .flex_1()
-                                                        .child(Input::new(&header.key_input).disabled(is_predefined)),
-                                                )
+                                                        .when(is_custom, |this| {
+                                                            let down_input = key_input.clone();
+                                                            let up_input = key_input.clone();
+                                                            this.on_action(move |_: &MoveDown, window, cx| {
+                                                                down_input.update(cx, |state, cx| {
+                                                                    state.handle_action_for_context_menu(Box::new(MoveDown), window, cx);
+                                                                });
+                                                            })
+                                                            .on_action(move |_: &MoveUp, window, cx| {
+                                                                up_input.update(cx, |state, cx| {
+                                                                    state.handle_action_for_context_menu(Box::new(MoveUp), window, cx);
+                                                                });
+                                                            })
+                                                        })
+                                                        .child(Input::new(&header.key_input).disabled(is_predefined))
+                                                })
                                                 .child(
                                                     // Value input - disabled for auto-calculated headers and Content-Type
                                                     // Delete button embedded as suffix for custom headers


### PR DESCRIPTION
## Summary

Typing a prefix in a custom header's name field now opens a completion menu of
standard HTTP header names (Postman-style: `Au` → `Authorization`). Selecting one
fills the canonical casing and moves focus to that row's value input.

- **`header_names.rs`** — a static, sorted, deduplicated table of ~57 common request
  header names with a `suggest(prefix)` doing case-insensitive **prefix** matching. No
  gpui dependency, so the whole rule is unit-tested (10 tests). The six headers that
  already own dedicated editor rows are excluded, so completion can't create a
  duplicate that goes out on the wire twice.
- **`header_completion.rs`** — wraps `suggest` in gpui-component's `CompletionProvider`;
  the edit replaces the whole field, which is what yields canonical casing after `au`.
- **Wiring** — all three custom-row construction sites route through one helper, so the
  feature is live whether a row is new, loaded from history, or restored after a tab
  switch.
- **Arrow-key fix** — gpui-component registers up/down action handlers only for
  multi-line inputs, so the menu couldn't be navigated on a single-line field. Bridged
  `MoveUp`/`MoveDown` to the library's public `handle_action_for_context_menu`.
- **Focus jump** — no "completion accepted" event exists, so it's inferred: a change
  that grows the key by >1 char and lands exactly on a table entry is a completion (or
  a paste), never manual typing.

Approach, decisions and acceptance criteria:
`docs/superpowers/specs/2026-07-20-header-key-autocomplete-design.md`.

Adds one dependency: `lsp-types = "0.97"` (the provider trait is LSP-shaped; must track
gpui-component's own version).

## Test Plan

- [x] `cargo test` on Windows — 144 passed / 0 failed (incl. 10 new `header_names` tests)
- [x] `cargo clippy --all-targets` — 0 warnings
- [x] Tier 0 (spike gate), user-verified on the release build: menu opens on first
      char, positioned below the input, not clipped when the list scrolls, arrow
      navigation works, Enter/Escape work, Enter with the menu open does not send
- [x] Tier 2, user-verified: `Au` → `Authorization` canonical casing; focus lands on
      value; trailing blank row still appended; predefined rows stay disabled with no
      menu; history-loaded and tab-restored custom rows autocomplete; a name absent
      from the table can be typed and sent; Escape closes the menu without sending

🤖 Generated with [Claude Code](https://claude.com/claude-code)