### PR TITLE
fix(macos): quit on Cmd+Q via an application menu

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -18,7 +18,7 @@ use crate::theme::{
     REQUEST_INITIAL_HEIGHT, REQUEST_MAX, REQUEST_MIN, SIDEBAR_MAX, SIDEBAR_MIN, SIDEBAR_WIDTH,
 };
 
-actions!(poopman, [SendRequest, NewTab, CloseTab, NextTab, PrevTab, FocusUrl]);
+actions!(poopman, [SendRequest, NewTab, CloseTab, NextTab, PrevTab, FocusUrl, Quit]);
 
 /// Main application view
 pub struct PoopmanApp {

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,15 @@ fn main() {
         gpui_component::init(cx);
         crate::theme::apply_theme(cx);
 
+        // macOS routes Cmd+Q through the application menu bar, so a keybinding
+        // alone is not enough: without a menu item bound to this action the
+        // keystroke has nowhere to dispatch and the app cannot be quit. Register
+        // the handler (which also makes the menu item enabled — gpui gates that on
+        // the action being available), bind the key so the menu item carries the
+        // Cmd+Q equivalent, and install the menu below. `set_menus` is a harmless
+        // no-op on Windows/Linux, which quit via the window's close button.
+        cx.on_action(|_: &crate::app::Quit, cx| cx.quit());
+
         // Late binding on purpose: gpui gives later-added bindings precedence,
         // so the "Input"-context ctrl-enter shadows gpui-component's own
         // secondary-enter input binding (its PressEnter{secondary:true} event
@@ -125,7 +134,13 @@ fn main() {
             KeyBinding::new("ctrl-tab", crate::app::NextTab, None),
             KeyBinding::new("ctrl-shift-tab", crate::app::PrevTab, None),
             KeyBinding::new("ctrl-l", crate::app::FocusUrl, None),
+            KeyBinding::new("cmd-q", crate::app::Quit, None),
         ]);
+
+        cx.set_menus(vec![Menu {
+            name: "Poopman".into(),
+            items: vec![MenuItem::action("Quit Poopman", crate::app::Quit)],
+        }]);
 
         cx.spawn(async move |cx| {
             let window_options = WindowOptions {


### PR DESCRIPTION
## Summary
- `Cmd+Q` did nothing on macOS: the app had no application menu, no `Quit` action, and no `cmd-q` binding. macOS delivers `Cmd+Q` through the NSApplication menu bar, so with no menu item bound to a quit action the keystroke had nowhere to dispatch.
- Register a global `Quit` handler (`cx.quit`), bind `cmd-q`, and install a **Poopman → Quit Poopman ⌘Q** menu via `cx.set_menus`.

## Why all three pieces are required (traced through gpui 0.2.2)
- The menu item's `⌘Q` equivalent is derived from the **keybinding** bound to its action (`platform/mac/platform.rs:322`).
- `Cmd+Q` → `handleGPUIMenuItem:` → `App::dispatch_action` → the global `Quit` handler (`platform/app_menu.rs:246`).
- The menu item is only *enabled* when the action is available, which the global `cx.on_action` handler satisfies (`app.rs:1834`).

`set_menus` merely stores the list on Windows/Linux (used there for the dock/jump list); those platforms quit via the window close button, so there is no menu-bar regression.

## Test Plan
- [x] `cargo check` clean (WSL)
- [x] Full test suite green on Windows — 149 passed, 0 failed
- [ ] macOS: menu bar shows **Poopman → Quit Poopman ⌘Q**; both the menu item and `⌘Q` quit the app (no Mac available to the author — needs a reviewer with a Mac)

🤖 Generated with [Claude Code](https://claude.com/claude-code)