### PR TITLE
fix(tabs): fill a blank tab from history instead of spawning a sibling

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -482,11 +482,24 @@ impl PoopmanApp {
         // Save current tab state
         self.save_current_tab_state(cx);
 
-        // Create new tab from history
-        let new_tab = RequestTab::from_history(self.next_tab_id, item);
-        self.next_tab_id += 1;
-        self.request_tabs.push(new_tab.clone());
-        self.active_tab_index = self.request_tabs.len() - 1;
+        // If the active tab is a pristine scratch tab (e.g. the default tab at
+        // startup), fill it in place instead of spawning a sibling.
+        let new_tab = if self
+            .request_tabs
+            .get(self.active_tab_index)
+            .is_some_and(RequestTab::is_blank)
+        {
+            let id = self.request_tabs[self.active_tab_index].id;
+            let tab = RequestTab::from_history(id, item);
+            self.request_tabs[self.active_tab_index] = tab.clone();
+            tab
+        } else {
+            let tab = RequestTab::from_history(self.next_tab_id, item);
+            self.next_tab_id += 1;
+            self.request_tabs.push(tab.clone());
+            self.active_tab_index = self.request_tabs.len() - 1;
+            tab
+        };
 
         // Load into editor
         self.request_editor.update(cx, |editor, cx| {

--- a/src/request_tab.rs
+++ b/src/request_tab.rs
@@ -74,4 +74,94 @@ impl RequestTab {
     pub fn update_title(&mut self) {
         self.title = Self::generate_title(&self.request);
     }
+
+    /// A pristine scratch tab — the default tab at startup, or an untouched
+    /// "New Request". Opening a history item fills such a tab in place instead
+    /// of spawning a sibling.
+    ///
+    /// Headers are ignored on purpose: a fresh tab's saved request always
+    /// carries the enabled predefined headers (Content-Type, Cache-Control,
+    /// ...), so those are not a signal that the user has done anything. What
+    /// marks a tab as used is a typed URL, body content, a response, or having
+    /// been opened from history.
+    pub fn is_blank(&self) -> bool {
+        self.history_id.is_none()
+            && self.response.is_none()
+            && self.request.url.trim().is_empty()
+            && match &self.request.body {
+                BodyType::None => true,
+                BodyType::Raw { content, .. } => content.trim().is_empty(),
+                BodyType::FormData(rows) => rows.is_empty(),
+            }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{BodyType, RawSubtype, ResponseData};
+
+    fn empty_request() -> RequestData {
+        RequestData {
+            method: HttpMethod::GET,
+            url: String::new(),
+            headers: vec![],
+            body: BodyType::default(),
+        }
+    }
+
+    #[test]
+    fn new_empty_tab_is_blank() {
+        assert!(RequestTab::new_empty(0).is_blank());
+    }
+
+    #[test]
+    fn tab_with_url_is_not_blank() {
+        let mut tab = RequestTab::new_empty(0);
+        tab.request.url = "https://api.test/x".to_string();
+        assert!(!tab.is_blank());
+    }
+
+    #[test]
+    fn tab_opened_from_history_is_not_blank() {
+        // Even a history item with an empty URL is not a scratch tab.
+        let item = HistoryItem::new(7, "t".to_string(), empty_request(), None);
+        assert!(!RequestTab::from_history(1, &item).is_blank());
+    }
+
+    #[test]
+    fn tab_with_a_response_is_not_blank() {
+        let mut tab = RequestTab::new_empty(0);
+        tab.response = Some(Arc::new(ResponseData {
+            status: Some(200),
+            duration_ms: 0,
+            headers: vec![],
+            body: vec![],
+            is_text: true,
+        }));
+        assert!(!tab.is_blank());
+    }
+
+    #[test]
+    fn tab_with_body_content_is_not_blank() {
+        let mut tab = RequestTab::new_empty(0);
+        tab.request.body = BodyType::Raw {
+            content: "{}".to_string(),
+            subtype: RawSubtype::Json,
+        };
+        assert!(!tab.is_blank());
+    }
+
+    #[test]
+    fn default_predefined_headers_do_not_count_as_used() {
+        // A fresh tab's saved request always carries the enabled predefined
+        // headers (Content-Type, Cache-Control, ...). Those must not make the
+        // tab look "used", or history would never reuse the startup tab.
+        let mut tab = RequestTab::new_empty(0);
+        tab.request.headers = vec![
+            ("Content-Type".to_string(), "application/json".to_string()),
+            ("Cache-Control".to_string(), "no-cache".to_string()),
+        ];
+        assert!(tab.is_blank());
+    }
 }


### PR DESCRIPTION
## Problem

Opening a history item always pushed a **new** tab. So right after startup — when the only tab is the default empty **New Request** (index 0) — clicking a history entry left that blank tab behind and made the history request land in tab index 1.

## Fix

When the active tab is a pristine scratch tab, the history item now fills it **in place** (keeping its slot and id) instead of spawning a sibling. Otherwise the previous behaviour (open a new tab) is unchanged.

`RequestTab::is_blank()` decides "pristine": **not** opened from history, no response, empty URL, empty body. Headers are deliberately ignored — a fresh tab's saved request always carries the enabled predefined headers (`Content-Type`, `Cache-Control`, …), which are not a signal that the user did anything.

## Behaviour

- Startup blank tab + click history → **fills index 0** (the reported case).
- Active tab already has a response / URL / body / is from history → **opens a new tab** (unchanged), so real work is never clobbered.
- History item already open in a tab → still switches to it (unchanged).

## Tests

`request_tab::tests` covers `is_blank` across new / url / from-history / response / body, plus the predefined-headers-still-blank case. Full suite green on Windows: **155 passed, 0 failed**.

The in-app reuse path is GUI glue (not unit-covered); the behaviour was **verified by the user in the release build**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)