### PR TITLE
fix(headers): use Postman's User-Agent as the default

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -41,7 +41,7 @@ impl PredefinedHeader {
             PredefinedHeader::CacheControl => "no-cache",
             PredefinedHeader::ContentType => "application/json",
             PredefinedHeader::Accept => "*/*",
-            PredefinedHeader::UserAgent => "Poopman/1.0",
+            PredefinedHeader::UserAgent => "PostmanRuntime/7.48.0",
             PredefinedHeader::Connection => "keep-alive",
             PredefinedHeader::ContentLength => "0",
         }


### PR DESCRIPTION
## Summary

The default `User-Agent` predefined header sent `Poopman/1.0`. Some APIs, gateways and WAFs behave differently for unknown clients, so requests that work in Postman could fail here. Now the default matches what Postman sends: `PostmanRuntime/7.48.0`.

One-line change in `src/types.rs` (`PredefinedHeader::default_value`).

## Note on the version number

`PostmanRuntime/<version>` is the real format Postman uses. `7.48.0` was picked as a plausible current version, not verified against a live Postman install — say the word if you want it pinned to a specific release.

## Testing

- `cargo check` clean (WSL)
- `cargo build --release` clean on Windows (`target/release/poopman.exe`, 3m35s)
- Not verified at runtime that an outgoing request carries the new header — the value comes from the same `default_value()` path as the other predefined headers, which is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)