### PR TITLE
fix(collections): toggle request bookmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ cargo test                # unit tests (pure modules: code_gen, variables, url_p
 5. **History** — sent requests are saved automatically; click one to reload it, or Clear.
 6. **Collections** — switch the sidebar to **Collections**, create a collection or
    folder, then click the bookmark button beside the request actions. New saves ask
-   for a request name and destination; clicking the bookmark on an existing saved
-   request updates it.
+   for a request name and destination; clicking the filled bookmark on a saved
+   request removes it from the collection while keeping the current tab open.
 7. **Postman** — use **Import** in the Collections sidebar, or use a collection's
    context menu to export a v2.1 JSON file.
 

--- a/assets/icons/bookmark-filled.svg
+++ b/assets/icons/bookmark-filled.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+  <path d="M7.75 2h8.5A1.75 1.75 0 0 1 18 3.75V21l-6-3.75L6 21V3.75A1.75 1.75 0 0 1 7.75 2Z"/>
+</svg>

--- a/src/app.rs
+++ b/src/app.rs
@@ -17,7 +17,8 @@ use crate::db::Database;
 use crate::environment_manager::{EnvironmentManager, EnvironmentsChanged};
 use crate::history_panel::{HistoryItemClicked, HistoryPanel};
 use crate::request_editor::{
-    OpenCodeSnippet, RequestCancelled, RequestCompleted, RequestEditor, SaveRequestRequested,
+    OpenCodeSnippet, RequestCancelled, RequestCompleted, RequestEditor,
+    ToggleRequestBookmarkRequested,
 };
 use crate::request_tab::RequestTab;
 use crate::response_viewer::ResponseViewer;
@@ -243,11 +244,11 @@ impl PoopmanApp {
             },
         );
 
-        let save_request_sub = cx.subscribe_in(
+        let bookmark_toggle_sub = cx.subscribe_in(
             &request_editor,
             window,
-            move |this, _, _event: &SaveRequestRequested, window, cx| {
-                this.save_request_requested(window, cx);
+            move |this, _, _event: &ToggleRequestBookmarkRequested, window, cx| {
+                this.toggle_request_bookmark(window, cx);
             },
         );
 
@@ -292,7 +293,7 @@ impl PoopmanApp {
                 env_changed_sub,
                 open_code_sub,
                 cancel_sub,
-                save_request_sub,
+                bookmark_toggle_sub,
             ],
         }
     }
@@ -442,9 +443,7 @@ impl PoopmanApp {
         self.active_tab_index = self.request_tabs.len() - 1;
 
         // Load new tab into editor
-        self.request_editor.update(cx, |editor, cx| {
-            editor.load_request(&new_tab.request, window, cx);
-        });
+        self.load_tab_into_editor(&new_tab, window, cx);
 
         // Clear response for new tab
         self.response_viewer.update(cx, |viewer, cx| {
@@ -463,9 +462,8 @@ impl PoopmanApp {
             self.next_tab_id += 1;
             self.active_tab_index = 0;
 
-            self.request_editor.update(cx, |editor, cx| {
-                editor.load_request(&self.request_tabs[0].request, window, cx);
-            });
+            let reset_tab = self.request_tabs[0].clone();
+            self.load_tab_into_editor(&reset_tab, window, cx);
 
             // Clear response for reset tab
             self.response_viewer.update(cx, |viewer, cx| {
@@ -549,9 +547,7 @@ impl PoopmanApp {
         };
 
         // Load into editor
-        self.request_editor.update(cx, |editor, cx| {
-            editor.load_request(&new_tab.request, window, cx);
-        });
+        self.load_tab_into_editor(&new_tab, window, cx);
 
         // Load response from history
         self.response_viewer.update(cx, |viewer, cx| {
@@ -618,6 +614,7 @@ impl PoopmanApp {
     ) {
         self.request_editor.update(cx, |editor, cx| {
             editor.load_request(&tab.request, window, cx);
+            editor.set_is_saved_request(tab.saved_request_id.is_some(), cx);
             if let Some(params_state) = &tab.params_state
                 && !params_state.is_empty()
             {
@@ -663,11 +660,18 @@ impl PoopmanApp {
                 Err(error) => log::error!("Failed to refresh saved request metadata: {}", error),
             }
         }
+        let active_is_saved = self
+            .request_tabs
+            .get(self.active_tab_index)
+            .is_some_and(|tab| tab.saved_request_id.is_some());
+        self.request_editor.update(cx, |editor, cx| {
+            editor.set_is_saved_request(active_is_saved, cx);
+        });
         self.update_tab_bar(cx);
         cx.notify();
     }
 
-    fn save_request_requested(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    fn toggle_request_bookmark(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.save_current_tab_state(cx);
         let Some(tab) = self.request_tabs.get(self.active_tab_index).cloned() else {
             return;
@@ -675,23 +679,26 @@ impl PoopmanApp {
         let params_state = tab.params_state.clone().unwrap_or_default();
         let headers_state = tab.headers_state.clone().unwrap_or_default();
 
-        if let (Some(saved_id), Some(collection_id), Some(name)) =
-            (tab.saved_request_id, tab.collection_id, tab.saved_name.clone())
-        {
-            match self.db.update_saved_request(
-                saved_id,
-                collection_id,
-                tab.folder_id,
-                &name,
-                &tab.request,
-                &params_state,
-                &headers_state,
-            ) {
+        if let Some(saved_id) = tab.saved_request_id {
+            match self.db.delete_saved_request(saved_id) {
                 Ok(()) => {
+                    if let Some(active_tab) = self.request_tabs.get_mut(self.active_tab_index) {
+                        active_tab.saved_request_id = None;
+                        active_tab.collection_id = None;
+                        active_tab.folder_id = None;
+                        active_tab.saved_name = None;
+                        active_tab.update_title();
+                    }
+                    self.request_editor.update(cx, |editor, cx| {
+                        editor.set_is_saved_request(false, cx);
+                    });
                     self.collections_panel.update(cx, |panel, cx| panel.reload(cx));
+                    self.update_tab_bar(cx);
                     cx.notify();
                 }
-                Err(error) => app_notice(window, cx, "Save failed", error.to_string()),
+                Err(error) => {
+                    app_notice(window, cx, "Remove bookmark failed", error.to_string())
+                }
             }
             return;
         }
@@ -862,6 +869,15 @@ impl PoopmanApp {
             tab.folder_id = target.folder_id;
             tab.saved_name = Some(name.to_string());
             tab.update_title_from_saved_name();
+        }
+        let active_is_saved = self
+            .request_tabs
+            .get(self.active_tab_index)
+            .is_some_and(|tab| tab.id == tab_id && tab.saved_request_id.is_some());
+        if active_is_saved {
+            self.request_editor.update(cx, |editor, cx| {
+                editor.set_is_saved_request(true, cx);
+            });
         }
         self.collections_panel.update(cx, |panel, cx| panel.reload(cx));
         self.update_tab_bar(cx);

--- a/src/db.rs
+++ b/src/db.rs
@@ -728,6 +728,7 @@ impl Database {
 
     /// Update a saved request, including moving it to another folder.
     #[allow(clippy::too_many_arguments)]
+    #[allow(dead_code)] // Retained for database callers and CRUD round-trip tests.
     pub fn update_saved_request(
         &self,
         id: i64,

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -31,10 +31,10 @@ pub struct OpenCodeSnippet;
 #[derive(Clone)]
 pub struct RequestCancelled;
 
-/// Emitted when the user explicitly saves the current request to a collection.
-/// The app decides whether this is a new save or an update to an existing row.
+/// Emitted when the user toggles the current request's collection bookmark.
+/// The app saves an unbookmarked request or removes an existing bookmark.
 #[derive(Clone)]
-pub struct SaveRequestRequested;
+pub struct ToggleRequestBookmarkRequested;
 
 /// Create a header-name input carrying the standard-header typeahead.
 ///
@@ -101,6 +101,9 @@ pub struct RequestEditor {
     _row_subscriptions: Vec<Subscription>,   // Header/param row subscriptions; rebuilt on load
     /// Active environment variables, pushed by PoopmanApp; used at send time.
     env_vars: std::collections::HashMap<String, String>,
+    /// Whether the active tab is associated with a request in a collection.
+    /// Saved requests use a filled bookmark in the request bar.
+    is_saved_request: bool,
 }
 
 impl RequestEditor {
@@ -141,6 +144,7 @@ impl RequestEditor {
             _subscriptions: vec![],
             _row_subscriptions: vec![],
             env_vars: std::collections::HashMap::new(),
+            is_saved_request: false,
         };
 
         // Subscribe to URL input changes: a pasted `curl …` command imports the
@@ -173,6 +177,14 @@ impl RequestEditor {
         editor.add_param_row(window, cx);
 
         editor
+    }
+
+    /// Update the collection state represented by the bookmark button.
+    pub fn set_is_saved_request(&mut self, is_saved: bool, cx: &mut Context<Self>) {
+        if self.is_saved_request != is_saved {
+            self.is_saved_request = is_saved;
+            cx.notify();
+        }
     }
 
     /// Initialize all predefined headers
@@ -1178,7 +1190,7 @@ impl RequestEditor {
 impl EventEmitter<RequestCompleted> for RequestEditor {}
 impl EventEmitter<OpenCodeSnippet> for RequestEditor {}
 impl EventEmitter<RequestCancelled> for RequestEditor {}
-impl EventEmitter<SaveRequestRequested> for RequestEditor {}
+impl EventEmitter<ToggleRequestBookmarkRequested> for RequestEditor {}
 
 impl Render for RequestEditor {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
@@ -1218,16 +1230,23 @@ impl Render for RequestEditor {
                                 .child(Input::new(&self.url_input)),
                         )
                         .child(
-                            // Explicit collection save. The bookmark icon keeps
-                            // the request bar compact; the tooltip explains the
-                            // action without repeating the old "Saved" status.
+                            // Collection bookmark toggle. A filled icon means
+                            // clicking it removes the request from its collection.
                             div().flex_shrink_0().child(
                                 Button::new("save-request-btn")
                                     .ghost()
-                                    .icon(Icon::empty().path("icons/bookmark.svg"))
-                                    .tooltip("Save request")
+                                    .icon(Icon::empty().path(if self.is_saved_request {
+                                        "icons/bookmark-filled.svg"
+                                    } else {
+                                        "icons/bookmark.svg"
+                                    }))
+                                    .tooltip(if self.is_saved_request {
+                                        "Remove from collection"
+                                    } else {
+                                        "Save request"
+                                    })
                                     .on_click(cx.listener(|_this, _ev, _window, cx| {
-                                        cx.emit(SaveRequestRequested);
+                                        cx.emit(ToggleRequestBookmarkRequested);
                                     })),
                             ),
                         )


### PR DESCRIPTION
## Summary

- show a filled bookmark for requests saved in a collection
- remove the saved collection record when the filled bookmark is clicked again, while keeping the current tab open
- keep bookmark state synchronized across tab switches, saves, and collection deletion
- update the bookmark tooltip and usage documentation

## Tests

- `cargo check --tests`
- `cargo.exe test` (184 passed)