### PR TITLE
perf: move blocking work off the UI thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2132,6 +2132,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "generator"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3497,6 +3512,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "loop9"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3624,6 +3652,15 @@ dependencies = [
  "markup5ever",
  "tendril",
  "xml5ever",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -3887,6 +3924,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4453,6 +4499,7 @@ dependencies = [
  "log",
  "lsp-types",
  "mime_guess",
+ "profiling",
  "quick-xml 0.40.1",
  "reqwest",
  "rusqlite",
@@ -4578,6 +4625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
 dependencies = [
  "profiling-procmacros",
+ "tracy-client",
 ]
 
 [[package]]
@@ -5635,6 +5683,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6243,6 +6300,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tiff"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6536,6 +6602,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
+name = "tracy-client"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f6fc3baeac5d86ab90c772e9e30620fc653bf1864295029921a15ef478e6a5"
+dependencies = [
+ "loom",
+ "once_cell",
+ "tracy-client-sys",
+]
+
+[[package]]
+name = "tracy-client-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5f7c95348f20c1c913d72157b3c6dee6ea3e30b3d19502c5a7f6d3f160dacbf"
+dependencies = [
+ "cc",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -7098,6 +7215,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "value-bag"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,20 @@ license = "Apache-2.0"
 publish = false
 version = "0.5.0"
 
+[features]
+default = []
+# Enable Tracy spans in both Poopman and GPUI. GPUI already uses the same
+# `profiling` facade, so Cargo feature unification activates its built-in
+# layout/render/frame instrumentation as well.
+profile = ["dep:profiling", "profiling/profile-with-tracy"]
+
 [dependencies]
 anyhow = "1"
 gpui = "0.2.2"
 gpui-component = { version = "0.5", features = ["tree-sitter-languages"] }
 log = "0.4"
 env_logger = "0.11"
+profiling = { version = "1", optional = true }
 # Only for the header-key completion provider: gpui-component's CompletionProvider
 # trait is LSP-shaped and it re-exports only `Position`, not the crate. The version
 # must track gpui-component's own lsp-types or the trait will not be satisfied.
@@ -49,3 +57,10 @@ minimum_system_version = "11.0"
 
 [package.metadata.bundle.windows]
 wix = true
+
+# Profiling should reflect optimized behavior while retaining symbols for
+# native sampling tools used alongside Tracy.
+[profile.profiling]
+inherits = "release"
+debug = 1
+strip = false

--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ cargo build --release     # optimized binary at target/release/poopman[.exe]
 cargo test                # unit tests (pure modules: code_gen, variables, url_params, db, …)
 ```
 
+### Profiling
+
+Poopman has an opt-in Tracy profiling feature. It enables both the application's
+hot-path spans and GPUI's existing layout/render/frame instrumentation. Use the
+optimized profiling build so timings are representative while native debug
+symbols remain available:
+
+```bash
+cargo run --profile profiling --features profile
+```
+
+Start the Tracy profiler before or after launching Poopman and connect to the
+running process. The default build does not compile in the Tracy backend or the
+application profiling spans.
+
 ## Usage
 
 1. **Send a request** — pick a method, enter a URL (e.g. `https://api.github.com/zen`),

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,11 +1,14 @@
+use gpui::px;
 use gpui::*;
 use gpui_component::{
-    button::{Button, ButtonVariants},
-    h_flex, input::{Input, InputState}, select::{Select, SelectState}, v_flex,
     ActiveTheme as _, IndexPath, Root, Sizable as _, TitleBar, WindowExt,
+    button::{Button, ButtonVariants},
+    h_flex,
+    input::{Input, InputState},
     resizable::{h_resizable, resizable_panel, v_resizable},
+    select::{Select, SelectState},
+    v_flex,
 };
-use gpui::px;
 use std::sync::Arc;
 
 use crate::code_snippet_panel::CodeSnippetPanel;
@@ -27,12 +30,51 @@ use crate::theme::{
     REQUEST_INITIAL_HEIGHT, REQUEST_MAX, REQUEST_MIN, SIDEBAR_MAX, SIDEBAR_MIN, SIDEBAR_WIDTH,
 };
 
-actions!(poopman, [SendRequest, NewTab, CloseTab, NextTab, PrevTab, FocusUrl, Quit]);
+actions!(
+    poopman,
+    [
+        SendRequest,
+        NewTab,
+        CloseTab,
+        NextTab,
+        PrevTab,
+        FocusUrl,
+        Quit
+    ]
+);
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum SidebarView {
     Collections,
     History,
+}
+
+/// Data loaded before the first window is opened. Startup disk and SQLite work
+/// is performed on GPUI's background executor, so even schema migration cannot
+/// stall an already-running UI event loop.
+pub(crate) struct AppInitialState {
+    db: Arc<Database>,
+    environments: Vec<crate::types::Environment>,
+    active_environment_id: Option<i64>,
+    history: Vec<crate::types::HistoryItem>,
+    collections: Vec<crate::types::Collection>,
+}
+
+impl AppInitialState {
+    pub(crate) fn load() -> anyhow::Result<Self> {
+        let db = Arc::new(Database::new()?);
+        let environments = db.load_environments()?;
+        let active_environment_id = db.get_active_environment_id()?;
+        let history = db.load_recent_history(crate::history_panel::HISTORY_LIMIT)?;
+        let collections = db.load_collections()?;
+        Ok(Self {
+            db,
+            environments,
+            active_environment_id,
+            history,
+            collections,
+        })
+    }
 }
 
 /// Main application view
@@ -64,25 +106,38 @@ pub struct PoopmanApp {
     active_environment_id: Option<i64>,
     env_manager: Entity<EnvironmentManager>,
     code_panel: Entity<CodeSnippetPanel>,
+    collections_reconcile_generation: u64,
     _subscriptions: Vec<Subscription>,
 }
 
 impl PoopmanApp {
-    pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
-        // Initialize database
-        let db = Arc::new(Database::new().expect("Failed to initialize database"));
-
-        // Load environments + active selection
-        let environments = db.load_environments().unwrap_or_default();
-        let active_environment_id = db.get_active_environment_id().unwrap_or(None);
+    pub fn new(initial: AppInitialState, window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let AppInitialState {
+            db,
+            environments,
+            active_environment_id,
+            history,
+            collections,
+        } = initial;
+        db.register_ui_thread();
 
         // Create components
         let request_editor = cx.new(|cx| RequestEditor::new(window, cx));
         let response_viewer = cx.new(|cx| ResponseViewer::new(window, cx));
-        let history_panel = cx.new(|cx| HistoryPanel::new(db.clone(), window, cx));
-        let collections_panel = cx.new(|cx| CollectionsPanel::new(db.clone(), window, cx));
+        let history_panel = cx.new(|cx| HistoryPanel::new(db.clone(), history, window, cx));
+        let collections_panel =
+            cx.new(|cx| CollectionsPanel::new(db.clone(), collections, window, cx));
         let tab_bar = cx.new(|cx| TabBar::new(window, cx));
-        let env_manager = cx.new(|cx| EnvironmentManager::new(db.clone(), window, cx));
+        let manager_environments = environments.clone();
+        let env_manager = cx.new(|cx| {
+            EnvironmentManager::new(
+                db.clone(),
+                manager_environments,
+                active_environment_id,
+                window,
+                cx,
+            )
+        });
         let code_panel = cx.new(|cx| CodeSnippetPanel::new(window, cx));
 
         // Push the active environment's variables into the request editor.
@@ -103,17 +158,12 @@ impl PoopmanApp {
             &request_editor,
             window,
             move |this, _, event: &RequestCompleted, window, cx| {
-                // Postman behavior: every send is logged to History, including a
-                // re-send of a request opened from history (so edits like added
-                // auth are captured as a new entry).
-                if let Err(e) = Self::persist_send(&db_clone, &event.request) {
-                    log::error!("Failed to save history: {}", e);
-                }
-                history_panel_clone.update(cx, |panel, cx| {
-                    panel.reload(window, cx);
-                });
+                #[cfg(feature = "profile")]
+                profiling::scope!("handle request completed");
 
-                // Update response viewer (always)
+                // Paint the response first. Persistence is intentionally not on
+                // this callback's critical path: Telegram-style UI work submits
+                // storage work and receives completion back on the main loop.
                 response_viewer_clone.update(cx, |viewer, cx| {
                     viewer.set_response(event.response.clone(), window, cx);
                 });
@@ -127,6 +177,26 @@ impl PoopmanApp {
                     tab.update_title_from_saved_name();
                     this.update_tab_bar(cx);
                 }
+
+                // Postman behavior: every send is logged to History, including a
+                // re-send of a request opened from history. Database::call is
+                // synchronous by design, so run it only on GPUI's background
+                // executor and refresh the panel after the write has completed.
+                let db = db_clone.clone();
+                let request = event.request.clone();
+                let history_panel = history_panel_clone.clone();
+                let persist = cx.background_spawn(async move { Self::persist_send(&db, &request) });
+                cx.spawn_in(window, async move |_this, cx| {
+                    match persist.await {
+                        Ok(_) => {
+                            history_panel
+                                .update_in(cx, |panel, window, cx| panel.reload(window, cx))?;
+                        }
+                        Err(error) => log::error!("Failed to save history: {}", error),
+                    }
+                    Ok::<_, anyhow::Error>(())
+                })
+                .detach();
             },
         );
 
@@ -166,8 +236,8 @@ impl PoopmanApp {
         let collections_changed_sub = cx.subscribe_in(
             &collections_panel,
             window,
-            move |this, _, event: &CollectionsChanged, _window, cx| {
-                this.reconcile_collection_tabs(&event.deleted_request_ids, cx);
+            move |this, _, event: &CollectionsChanged, window, cx| {
+                this.reconcile_collection_tabs(&event.deleted_request_ids, window, cx);
             },
         );
 
@@ -200,8 +270,8 @@ impl PoopmanApp {
         let env_changed_sub = cx.subscribe_in(
             &env_manager,
             window,
-            move |this, _, _e: &EnvironmentsChanged, _window, cx| {
-                this.reload_environments(cx);
+            move |this, _, event: &EnvironmentsChanged, _window, cx| {
+                this.apply_environment_state(event.environments.clone(), event.active_id, cx);
             },
         );
 
@@ -213,7 +283,8 @@ impl PoopmanApp {
             window,
             move |this, editor, _e: &OpenCodeSnippet, window, cx| {
                 let req = editor.read(cx).resolved_request_data(cx);
-                this.code_panel.update(cx, |panel, cx| panel.set_request(req, window, cx));
+                this.code_panel
+                    .update(cx, |panel, cx| panel.set_request(req, window, cx));
                 let panel = code_panel_for_sub.clone();
                 window.open_dialog(cx, move |dialog, _window, cx| {
                     let theme = cx.theme();
@@ -281,6 +352,7 @@ impl PoopmanApp {
             active_environment_id,
             env_manager,
             code_panel,
+            collections_reconcile_generation: 0,
             _subscriptions: vec![
                 request_sub,
                 history_sub,
@@ -333,13 +405,19 @@ impl PoopmanApp {
         )
     }
 
-    /// Reload environments + active selection from the DB and push the active
-    /// variable map to the request editor.
-    fn reload_environments(&mut self, cx: &mut Context<Self>) {
-        self.environments = self.db.load_environments().unwrap_or_default();
-        self.active_environment_id = self.db.get_active_environment_id().unwrap_or(None);
+    /// Apply the environment manager's in-memory state immediately. Persistence
+    /// is asynchronous; reflecting an edit never requires a DB read-back.
+    fn apply_environment_state(
+        &mut self,
+        environments: Vec<crate::types::Environment>,
+        active_environment_id: Option<i64>,
+        cx: &mut Context<Self>,
+    ) {
+        self.environments = environments;
+        self.active_environment_id = active_environment_id;
         let vars = Self::active_env_vars(&self.environments, self.active_environment_id);
-        self.request_editor.update(cx, |editor, _| editor.set_env_vars(vars));
+        self.request_editor
+            .update(cx, |editor, _| editor.set_env_vars(vars));
         cx.notify();
     }
 
@@ -373,15 +451,14 @@ impl PoopmanApp {
 
     /// Switch the active environment (or clear it) from the Edit menu, then
     /// reload + refresh the request editor's variable map.
-    pub(crate) fn set_active_environment(&mut self, id: Option<i64>, cx: &mut Context<Self>) {
-        if let Err(e) = self.db.set_active_environment_id(id) {
-            log::error!("Failed to set active environment: {}", e);
-            return;
-        }
-        self.reload_environments(cx);
-        self.env_manager.update(cx, |mgr, cx| {
-            mgr.reload();
-            cx.notify();
+    pub(crate) fn set_active_environment(
+        &mut self,
+        id: Option<i64>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.env_manager.update(cx, |manager, cx| {
+            manager.set_active(id, window, cx);
         });
     }
 
@@ -402,6 +479,7 @@ impl PoopmanApp {
     }
 
     /// Switch to a different tab
+    #[cfg_attr(feature = "profile", profiling::function)]
     fn switch_to_tab(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
         if index >= self.request_tabs.len() || index == self.active_tab_index {
             return;
@@ -606,6 +684,7 @@ impl PoopmanApp {
         cx.notify();
     }
 
+    #[cfg_attr(feature = "profile", profiling::function)]
     fn load_tab_into_editor(
         &mut self,
         tab: &RequestTab,
@@ -630,7 +709,15 @@ impl PoopmanApp {
 
     /// Keep tab metadata synchronized with collection-side rename/delete
     /// actions, while deliberately leaving the current editor values alone.
-    fn reconcile_collection_tabs(&mut self, deleted_ids: &[i64], cx: &mut Context<Self>) {
+    fn reconcile_collection_tabs(
+        &mut self,
+        deleted_ids: &[i64],
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.collections_reconcile_generation =
+            self.collections_reconcile_generation.wrapping_add(1);
+        let generation = self.collections_reconcile_generation;
         for tab in &mut self.request_tabs {
             let Some(saved_id) = tab.saved_request_id else {
                 continue;
@@ -641,25 +728,67 @@ impl PoopmanApp {
                 tab.folder_id = None;
                 tab.saved_name = None;
                 tab.update_title();
-                continue;
-            }
-            match self.db.load_saved_request(saved_id) {
-                Ok(Some(saved)) => {
-                    tab.collection_id = Some(saved.collection_id);
-                    tab.folder_id = saved.folder_id;
-                    tab.saved_name = Some(saved.name);
-                    tab.update_title_from_saved_name();
-                }
-                Ok(None) => {
-                    tab.saved_request_id = None;
-                    tab.collection_id = None;
-                    tab.folder_id = None;
-                    tab.saved_name = None;
-                    tab.update_title();
-                }
-                Err(error) => log::error!("Failed to refresh saved request metadata: {}", error),
             }
         }
+        self.refresh_saved_tab_ui(cx);
+
+        let mut saved_ids = self
+            .request_tabs
+            .iter()
+            .filter_map(|tab| tab.saved_request_id)
+            .collect::<Vec<_>>();
+        saved_ids.sort_unstable();
+        saved_ids.dedup();
+        if saved_ids.is_empty() {
+            return;
+        }
+        let db = self.db.clone();
+        let task = cx.background_spawn(async move {
+            saved_ids
+                .into_iter()
+                .map(|id| db.load_saved_request(id).map(|saved| (id, saved)))
+                .collect::<anyhow::Result<Vec<_>>>()
+        });
+        cx.spawn_in(window, async move |this, cx| {
+            match task.await {
+                Ok(saved_rows) => {
+                    this.update(cx, |this, cx| {
+                        if this.collections_reconcile_generation != generation {
+                            return;
+                        }
+                        for (saved_id, saved) in saved_rows {
+                            for tab in this
+                                .request_tabs
+                                .iter_mut()
+                                .filter(|tab| tab.saved_request_id == Some(saved_id))
+                            {
+                                if let Some(saved) = &saved {
+                                    tab.collection_id = Some(saved.collection_id);
+                                    tab.folder_id = saved.folder_id;
+                                    tab.saved_name = Some(saved.name.clone());
+                                    tab.update_title_from_saved_name();
+                                } else {
+                                    tab.saved_request_id = None;
+                                    tab.collection_id = None;
+                                    tab.folder_id = None;
+                                    tab.saved_name = None;
+                                    tab.update_title();
+                                }
+                            }
+                        }
+                        this.refresh_saved_tab_ui(cx);
+                    })?;
+                }
+                Err(error) => {
+                    log::error!("Failed to refresh saved request metadata: {}", error)
+                }
+            }
+            Ok::<_, anyhow::Error>(())
+        })
+        .detach();
+    }
+
+    fn refresh_saved_tab_ui(&mut self, cx: &mut Context<Self>) {
         let active_is_saved = self
             .request_tabs
             .get(self.active_tab_index)
@@ -680,41 +809,81 @@ impl PoopmanApp {
         let headers_state = tab.headers_state.clone().unwrap_or_default();
 
         if let Some(saved_id) = tab.saved_request_id {
-            match self.db.delete_saved_request(saved_id) {
-                Ok(()) => {
-                    if let Some(active_tab) = self.request_tabs.get_mut(self.active_tab_index) {
-                        active_tab.saved_request_id = None;
-                        active_tab.collection_id = None;
-                        active_tab.folder_id = None;
-                        active_tab.saved_name = None;
-                        active_tab.update_title();
+            let db = self.db.clone();
+            let task = cx.background_spawn(async move { db.delete_saved_request(saved_id) });
+            cx.spawn_in(window, async move |this, cx| {
+                match task.await {
+                    Ok(()) => {
+                        this.update_in(cx, |this, window, cx| {
+                            for tab in &mut this.request_tabs {
+                                if tab.saved_request_id == Some(saved_id) {
+                                    tab.saved_request_id = None;
+                                    tab.collection_id = None;
+                                    tab.folder_id = None;
+                                    tab.saved_name = None;
+                                    tab.update_title();
+                                }
+                            }
+                            this.refresh_saved_tab_ui(cx);
+                            this.collections_panel
+                                .update(cx, |panel, cx| panel.reload(window, cx));
+                        })?;
                     }
-                    self.request_editor.update(cx, |editor, cx| {
-                        editor.set_is_saved_request(false, cx);
-                    });
-                    self.collections_panel.update(cx, |panel, cx| panel.reload(cx));
-                    self.update_tab_bar(cx);
-                    cx.notify();
+                    Err(error) => {
+                        cx.update(|window, cx| {
+                            app_notice(window, cx, "Remove bookmark failed", error.to_string())
+                        })?;
+                    }
                 }
-                Err(error) => {
-                    app_notice(window, cx, "Remove bookmark failed", error.to_string())
-                }
-            }
+                Ok::<_, anyhow::Error>(())
+            })
+            .detach();
             return;
         }
 
-        let mut targets = self.collections_panel.read(cx).request_targets();
+        let targets = self.collections_panel.read(cx).request_targets();
         if targets.is_empty() {
-            match self.db.create_collection("My Collection") {
-                Ok(_) => {
-                    self.collections_panel.update(cx, |panel, cx| panel.reload(cx));
-                    targets = self.collections_panel.read(cx).request_targets();
+            let db = self.db.clone();
+            let selected = self.collections_panel.read(cx).selected_target();
+            let initial_name = if tab.title.trim().is_empty() || tab.title == "New Request" {
+                format!("{} request", tab.request.method.as_str())
+            } else {
+                tab.title.clone()
+            };
+            let task = cx.background_spawn(async move { db.create_collection("My Collection") });
+            cx.spawn_in(window, async move |this, cx| {
+                match task.await {
+                    Ok(collection_id) => {
+                        this.update_in(cx, |this, window, cx| {
+                            this.collections_panel
+                                .update(cx, |panel, cx| panel.reload(window, cx));
+                            this.open_new_save_dialog(
+                                tab.id,
+                                initial_name,
+                                tab.request,
+                                params_state,
+                                headers_state,
+                                vec![CollectionTarget {
+                                    collection_id,
+                                    folder_id: None,
+                                    label: "My Collection".to_string(),
+                                }],
+                                selected,
+                                window,
+                                cx,
+                            );
+                        })?;
+                    }
+                    Err(error) => {
+                        cx.update(|window, cx| {
+                            app_notice(window, cx, "Save failed", error.to_string())
+                        })?;
+                    }
                 }
-                Err(error) => {
-                    app_notice(window, cx, "Save failed", error.to_string());
-                    return;
-                }
-            }
+                Ok::<_, anyhow::Error>(())
+            })
+            .detach();
+            return;
         }
         let selected = self.collections_panel.read(cx).selected_target();
         let initial_name = if tab.title.trim().is_empty() || tab.title == "New Request" {
@@ -797,7 +966,12 @@ impl PoopmanApp {
                 .child(
                     v_flex()
                         .gap_3()
-                        .child(v_flex().gap_1().child(div().text_sm().child("Request name")).child(Input::new(&name_input)))
+                        .child(
+                            v_flex()
+                                .gap_1()
+                                .child(div().text_sm().child("Request name"))
+                                .child(Input::new(&name_input)),
+                        )
                         .child(
                             v_flex()
                                 .gap_1()
@@ -819,9 +993,8 @@ impl PoopmanApp {
                     let Some(target) = targets_for_ok.get(index).cloned() else {
                         return false;
                     };
-                    let mut succeeded = false;
                     app.update(cx, |app, cx| {
-                        succeeded = app.persist_new_saved_request(
+                        app.persist_new_saved_request(
                             tab_id,
                             &name,
                             target,
@@ -832,7 +1005,7 @@ impl PoopmanApp {
                             cx,
                         );
                     });
-                    succeeded
+                    true
                 })
         });
     }
@@ -848,44 +1021,55 @@ impl PoopmanApp {
         headers_state: &[crate::types::HeaderState],
         window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> bool {
-        let id = match self.db.insert_saved_request(
-            target.collection_id,
-            target.folder_id,
-            name,
-            request,
-            params_state,
-            headers_state,
-        ) {
-            Ok(id) => id,
-            Err(error) => {
-                app_notice(window, cx, "Save failed", error.to_string());
-                return false;
+    ) {
+        let db = self.db.clone();
+        let collection_id = target.collection_id;
+        let folder_id = target.folder_id;
+        let name = name.to_string();
+        let request = request.clone();
+        let params_state = params_state.to_vec();
+        let headers_state = headers_state.to_vec();
+        let name_for_db = name.clone();
+        let task = cx.background_spawn(async move {
+            db.insert_saved_request(
+                collection_id,
+                folder_id,
+                &name_for_db,
+                &request,
+                &params_state,
+                &headers_state,
+            )
+        });
+        cx.spawn_in(window, async move |this, cx| {
+            match task.await {
+                Ok(id) => {
+                    this.update_in(cx, |this, window, cx| {
+                        if let Some(tab) = this.request_tabs.iter_mut().find(|tab| tab.id == tab_id)
+                        {
+                            tab.saved_request_id = Some(id);
+                            tab.collection_id = Some(collection_id);
+                            tab.folder_id = folder_id;
+                            tab.saved_name = Some(name);
+                            tab.update_title_from_saved_name();
+                        }
+                        this.refresh_saved_tab_ui(cx);
+                        this.collections_panel
+                            .update(cx, |panel, cx| panel.reload(window, cx));
+                    })?;
+                }
+                Err(error) => {
+                    cx.update(|window, cx| {
+                        app_notice(window, cx, "Save failed", error.to_string())
+                    })?;
+                }
             }
-        };
-        if let Some(tab) = self.request_tabs.iter_mut().find(|tab| tab.id == tab_id) {
-            tab.saved_request_id = Some(id);
-            tab.collection_id = Some(target.collection_id);
-            tab.folder_id = target.folder_id;
-            tab.saved_name = Some(name.to_string());
-            tab.update_title_from_saved_name();
-        }
-        let active_is_saved = self
-            .request_tabs
-            .get(self.active_tab_index)
-            .is_some_and(|tab| tab.id == tab_id && tab.saved_request_id.is_some());
-        if active_is_saved {
-            self.request_editor.update(cx, |editor, cx| {
-                editor.set_is_saved_request(true, cx);
-            });
-        }
-        self.collections_panel.update(cx, |panel, cx| panel.reload(cx));
-        self.update_tab_bar(cx);
-        cx.notify();
-        true
+            Ok::<_, anyhow::Error>(())
+        })
+        .detach();
     }
 
     /// Update tab bar with current tabs
+    #[cfg_attr(feature = "profile", profiling::function)]
     fn update_tab_bar(&mut self, cx: &mut Context<Self>) {
         self.tab_bar.update(cx, |tab_bar, cx| {
             tab_bar.update_tabs(self.request_tabs.clone(), self.active_tab_index, cx);
@@ -894,6 +1078,7 @@ impl PoopmanApp {
 }
 
 impl Render for PoopmanApp {
+    #[cfg_attr(feature = "profile", profiling::function)]
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
 
@@ -1102,18 +1287,11 @@ impl Render for PoopmanApp {
     }
 }
 
-fn sidebar_switch<F>(
-    label: &'static str,
-    active: bool,
-    on_click: F,
-) -> impl IntoElement
+fn sidebar_switch<F>(label: &'static str, active: bool, on_click: F) -> impl IntoElement
 where
     F: Fn(&ClickEvent, &mut Window, &mut App) + 'static,
 {
-    let button = Button::new(label)
-        .small()
-        .label(label)
-        .on_click(on_click);
+    let button = Button::new(label).small().label(label).on_click(on_click);
     if active {
         button.primary()
     } else {
@@ -1121,12 +1299,22 @@ where
     }
 }
 
-fn app_notice(window: &mut Window, cx: &mut App, title: impl Into<String>, message: impl Into<String>) {
+fn app_notice(
+    window: &mut Window,
+    cx: &mut App,
+    title: impl Into<String>,
+    message: impl Into<String>,
+) {
     let title = title.into();
     let message = message.into();
     window.open_dialog(cx, move |dialog, _window, cx| {
         dialog
-            .title(div().text_lg().font_weight(FontWeight::BOLD).child(title.clone()))
+            .title(
+                div()
+                    .text_lg()
+                    .font_weight(FontWeight::BOLD)
+                    .child(title.clone()),
+            )
             .w(px(520.))
             .child(
                 div()

--- a/src/collections_panel.rs
+++ b/src/collections_panel.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use crate::db::Database;
-use crate::postman::{self, ImportResult, PostmanWarning};
+use crate::postman::{self, ImportResult};
 use crate::theme::method_color;
 use crate::types::{Collection, CollectionFolder, SavedRequest};
 
@@ -76,6 +76,7 @@ pub struct CollectionsPanel {
     expanded_folders: HashSet<i64>,
     search: Entity<InputState>,
     query: String,
+    reload_generation: u64,
     list_scroll_handle: ScrollHandle,
 }
 
@@ -84,8 +85,12 @@ impl EventEmitter<NewRequestRequested> for CollectionsPanel {}
 impl EventEmitter<CollectionsChanged> for CollectionsPanel {}
 
 impl CollectionsPanel {
-    pub fn new(db: Arc<Database>, window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let collections = db.load_collections().unwrap_or_default();
+    pub fn new(
+        db: Arc<Database>,
+        collections: Vec<Collection>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
         let expanded_collections = collections.iter().map(|collection| collection.id).collect();
         let search = cx.new(|cx| InputState::new(window, cx).placeholder("Search collections"));
         cx.subscribe(&search, Self::on_search_change).detach();
@@ -98,12 +103,35 @@ impl CollectionsPanel {
             expanded_folders: HashSet::new(),
             search,
             query: String::new(),
+            reload_generation: 0,
             list_scroll_handle: ScrollHandle::new(),
         }
     }
 
-    pub fn reload(&mut self, cx: &mut Context<Self>) {
-        self.collections = self.db.load_collections().unwrap_or_default();
+    #[cfg_attr(feature = "profile", profiling::function)]
+    pub fn reload(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.reload_generation = self.reload_generation.wrapping_add(1);
+        let generation = self.reload_generation;
+        let db = self.db.clone();
+        let task = cx.background_spawn(async move { db.load_collections() });
+        cx.spawn_in(window, async move |this, cx| {
+            let result = task.await;
+            this.update(cx, |this, cx| {
+                if this.reload_generation != generation {
+                    return;
+                }
+                match result {
+                    Ok(collections) => this.apply_loaded_collections(collections, cx),
+                    Err(error) => log::error!("Failed to reload collections: {}", error),
+                }
+            })?;
+            Ok::<_, anyhow::Error>(())
+        })
+        .detach();
+    }
+
+    fn apply_loaded_collections(&mut self, collections: Vec<Collection>, cx: &mut Context<Self>) {
+        self.collections = collections;
         let collection_ids: HashSet<i64> = self.collections.iter().map(|c| c.id).collect();
         self.expanded_collections
             .retain(|id| collection_ids.contains(id));
@@ -340,16 +368,15 @@ impl CollectionsPanel {
                 .w(px(420.))
                 .child(v_flex().gap_2().child(Input::new(&input)))
                 .confirm()
-                .on_ok(move |_, _window, cx: &mut App| {
+                .on_ok(move |_, window, cx: &mut App| {
                     let name = input_for_ok.read(cx).value().trim().to_string();
                     if name.is_empty() {
                         return false;
                     }
-                    let mut succeeded = false;
                     panel.update(cx, |panel, cx| {
-                        succeeded = panel.apply_name_action(action.clone(), &name, cx);
+                        panel.apply_name_action(action.clone(), &name, window, cx);
                     });
-                    succeeded
+                    true
                 })
         });
     }
@@ -358,40 +385,54 @@ impl CollectionsPanel {
         &mut self,
         action: NameAction,
         name: &str,
+        window: &mut Window,
         cx: &mut Context<Self>,
-    ) -> bool {
-        let result = match action {
-            NameAction::CreateCollection => self.db.create_collection(name).map(|id| {
-                self.selected = Some(NodeRef::Collection(id));
-            }),
-            NameAction::CreateFolder {
-                collection_id,
-                parent_id,
-            } => self
-                .db
-                .create_folder(collection_id, parent_id, name)
-                .map(|id| {
-                    self.selected = Some(NodeRef::Folder(id));
-                    self.expanded_collections.insert(collection_id);
-                    if let Some(parent_id) = parent_id {
-                        self.expanded_folders.insert(parent_id);
-                    }
-                }),
-            NameAction::RenameCollection(id) => self.db.rename_collection(id, name),
-            NameAction::RenameFolder(id) => self.db.rename_folder(id, name),
-            NameAction::RenameRequest(id) => self.db.rename_saved_request(id, name),
-        };
-        match result {
-            Ok(()) => {
-                self.reload(cx);
-                cx.emit(CollectionsChanged::default());
-                true
+    ) {
+        let db = self.db.clone();
+        let name = name.to_string();
+        let action_for_ui = action.clone();
+        let task = cx.background_spawn(async move {
+            match action {
+                NameAction::CreateCollection => db
+                    .create_collection(&name)
+                    .map(|id| Some(NodeRef::Collection(id))),
+                NameAction::CreateFolder {
+                    collection_id,
+                    parent_id,
+                } => db
+                    .create_folder(collection_id, parent_id, &name)
+                    .map(|id| Some(NodeRef::Folder(id))),
+                NameAction::RenameCollection(id) => db.rename_collection(id, &name).map(|()| None),
+                NameAction::RenameFolder(id) => db.rename_folder(id, &name).map(|()| None),
+                NameAction::RenameRequest(id) => db.rename_saved_request(id, &name).map(|()| None),
             }
-            Err(error) => {
-                log::error!("Failed to update collection tree: {}", error);
-                false
+        });
+        cx.spawn_in(window, async move |this, cx| {
+            match task.await {
+                Ok(selected) => {
+                    this.update_in(cx, |this, window, cx| {
+                        if let Some(selected) = selected {
+                            this.selected = Some(selected);
+                            if let NameAction::CreateFolder {
+                                collection_id,
+                                parent_id,
+                            } = action_for_ui
+                            {
+                                this.expanded_collections.insert(collection_id);
+                                if let Some(parent_id) = parent_id {
+                                    this.expanded_folders.insert(parent_id);
+                                }
+                            }
+                        }
+                        this.reload(window, cx);
+                        cx.emit(CollectionsChanged::default());
+                    })?;
+                }
+                Err(error) => log::error!("Failed to update collection tree: {}", error),
             }
-        }
+            Ok::<_, anyhow::Error>(())
+        })
+        .detach();
     }
 
     fn request_ids_in_folder(folder: &CollectionFolder, ids: &mut Vec<i64>) {
@@ -460,85 +501,93 @@ impl CollectionsPanel {
                         ),
                 )
                 .confirm()
-                .on_ok(move |_, _window, cx: &mut App| {
-                    let mut succeeded = false;
+                .on_ok(move |_, window, cx: &mut App| {
                     panel.update(cx, |panel, cx| {
-                        succeeded = panel.delete_node(node, cx);
+                        panel.delete_node(node, window, cx);
                     });
-                    succeeded
+                    true
                 })
         });
     }
 
-    fn delete_node(&mut self, node: NodeRef, cx: &mut Context<Self>) -> bool {
-        let (result, deleted_request_ids) = match node {
-            NodeRef::Collection(id) => {
-                let ids = self
-                    .collections
-                    .iter()
-                    .find(|collection| collection.id == id)
-                    .map(Self::request_ids_in_collection)
-                    .unwrap_or_default();
-                (self.db.delete_collection(id), ids)
-            }
-            NodeRef::Folder(id) => {
-                let ids = self
-                    .find_folder(id)
-                    .map(|folder| {
-                        let mut ids = Vec::new();
-                        Self::request_ids_in_folder(folder, &mut ids);
-                        ids
-                    })
-                    .unwrap_or_default();
-                (self.db.delete_folder(id), ids)
-            }
-            NodeRef::Request(id) => (self.db.delete_saved_request(id), vec![id]),
+    fn delete_node(&mut self, node: NodeRef, window: &mut Window, cx: &mut Context<Self>) {
+        let deleted_request_ids = match node {
+            NodeRef::Collection(id) => self
+                .collections
+                .iter()
+                .find(|collection| collection.id == id)
+                .map(Self::request_ids_in_collection)
+                .unwrap_or_default(),
+            NodeRef::Folder(id) => self
+                .find_folder(id)
+                .map(|folder| {
+                    let mut ids = Vec::new();
+                    Self::request_ids_in_folder(folder, &mut ids);
+                    ids
+                })
+                .unwrap_or_default(),
+            NodeRef::Request(id) => vec![id],
         };
-        match result {
-            Ok(()) => {
-                if self.selected == Some(node) {
-                    self.selected = None;
+        let db = self.db.clone();
+        let task = cx.background_spawn(async move {
+            match node {
+                NodeRef::Collection(id) => db.delete_collection(id),
+                NodeRef::Folder(id) => db.delete_folder(id),
+                NodeRef::Request(id) => db.delete_saved_request(id),
+            }
+        });
+        cx.spawn_in(window, async move |this, cx| {
+            match task.await {
+                Ok(()) => {
+                    this.update_in(cx, |this, window, cx| {
+                        if this.selected == Some(node) {
+                            this.selected = None;
+                        }
+                        this.reload(window, cx);
+                        cx.emit(CollectionsChanged {
+                            deleted_request_ids,
+                        });
+                    })?;
                 }
-                self.reload(cx);
-                cx.emit(CollectionsChanged {
-                    deleted_request_ids,
-                });
-                true
+                Err(error) => log::error!("Failed to delete collection item: {}", error),
             }
-            Err(error) => {
-                log::error!("Failed to delete collection item: {}", error);
-                false
-            }
-        }
+            Ok::<_, anyhow::Error>(())
+        })
+        .detach();
     }
 
-    fn duplicate_node(&mut self, node: NodeRef, cx: &mut Context<Self>) {
-        let result = match node {
-            NodeRef::Collection(id) => self.db.duplicate_collection(id),
-            NodeRef::Folder(id) => self.db.duplicate_folder(id),
-            NodeRef::Request(id) => self.db.duplicate_saved_request(id),
-        };
-        match result {
-            Ok(id) => {
-                self.selected = Some(match node {
-                    NodeRef::Collection(_) => NodeRef::Collection(id),
-                    NodeRef::Folder(_) => NodeRef::Folder(id),
-                    NodeRef::Request(_) => NodeRef::Request(id),
-                });
-                self.reload(cx);
-                cx.emit(CollectionsChanged::default());
+    fn duplicate_node(&mut self, node: NodeRef, window: &mut Window, cx: &mut Context<Self>) {
+        let db = self.db.clone();
+        let task = cx.background_spawn(async move {
+            match node {
+                NodeRef::Collection(id) => db.duplicate_collection(id),
+                NodeRef::Folder(id) => db.duplicate_folder(id),
+                NodeRef::Request(id) => db.duplicate_saved_request(id),
             }
-            Err(error) => log::error!("Failed to duplicate collection item: {}", error),
-        }
+        });
+        cx.spawn_in(window, async move |this, cx| {
+            match task.await {
+                Ok(id) => {
+                    this.update_in(cx, |this, window, cx| {
+                        this.selected = Some(match node {
+                            NodeRef::Collection(_) => NodeRef::Collection(id),
+                            NodeRef::Folder(_) => NodeRef::Folder(id),
+                            NodeRef::Request(_) => NodeRef::Request(id),
+                        });
+                        this.reload(window, cx);
+                        cx.emit(CollectionsChanged::default());
+                    })?;
+                }
+                Err(error) => log::error!("Failed to duplicate collection item: {}", error),
+            }
+            Ok::<_, anyhow::Error>(())
+        })
+        .detach();
     }
 
-    // The actual import implementation is kept separate from the file picker
-    // callback so it is easy to exercise and so one file read is sufficient.
-    fn import_data(
-        &mut self,
-        imported: ImportResult,
-        cx: &mut Context<Self>,
-    ) -> Result<(String, Vec<PostmanWarning>)> {
+    // The actual import implementation is kept separate from the file picker.
+    // Both parsing and SQLite insertion run away from the UI thread.
+    fn import_data(&mut self, imported: ImportResult, window: &mut Window, cx: &mut Context<Self>) {
         let base_name = if imported.collection.name.trim().is_empty() {
             "Imported Collection".to_string()
         } else {
@@ -554,47 +603,28 @@ impl CollectionsPanel {
             base_name
         };
         let warnings = imported.warnings.clone();
-        let id = self
-            .db
-            .insert_collection_tree(&imported.collection, &name)?;
-        self.reload(cx);
-        self.selected = Some(NodeRef::Collection(id));
-        self.expanded_collections.insert(id);
-        cx.emit(CollectionsChanged::default());
-        Ok((name, warnings))
-    }
-
-    fn start_import(&mut self, _event: &ClickEvent, window: &mut Window, cx: &mut Context<Self>) {
-        let receiver = cx.prompt_for_paths(PathPromptOptions {
-            files: true,
-            directories: false,
-            multiple: false,
-            prompt: Some("Import Postman collection".into()),
+        let db = self.db.clone();
+        let name_for_db = name.clone();
+        let task = cx.background_spawn(async move {
+            db.insert_collection_tree(&imported.collection, &name_for_db)
         });
-        let panel = cx.entity();
-        cx.spawn_in(window, async move |_, window| {
-            let result: Result<Option<ImportResult>> = async {
-                let paths = receiver.await??;
-                let Some(path) = paths.and_then(|paths| paths.into_iter().next()) else {
-                    return Ok(None);
-                };
-                let text = std::fs::read_to_string(path)?;
-                Ok(Some(postman::import_collection(&text)?))
-            }
-            .await;
-            let _ = window.update(|window, cx| match result {
-                Ok(Some(imported)) => {
-                    let outcome = panel.update(cx, |panel, cx| panel.import_data(imported, cx));
-                    match outcome {
-                        Ok((name, warnings)) if warnings.is_empty() => {
+        cx.spawn_in(window, async move |this, cx| {
+            match task.await {
+                Ok(id) => {
+                    this.update_in(cx, |this, window, cx| {
+                        this.selected = Some(NodeRef::Collection(id));
+                        this.expanded_collections.insert(id);
+                        this.reload(window, cx);
+                        cx.emit(CollectionsChanged::default());
+
+                        if warnings.is_empty() {
                             panel_notice(
                                 window,
                                 cx,
                                 "Collection imported",
                                 format!("Imported {}.", name),
                             );
-                        }
-                        Ok((name, warnings)) => {
+                        } else {
                             let details = warnings
                                 .iter()
                                 .take(8)
@@ -608,12 +638,48 @@ impl CollectionsPanel {
                                 format!("Imported {}.\n\n{}", name, details),
                             );
                         }
-                        Err(error) => panel_notice(window, cx, "Import failed", error.to_string()),
-                    }
+                    })?;
                 }
-                Ok(None) => {}
-                Err(error) => panel_notice(window, cx, "Import failed", error.to_string()),
+                Err(error) => {
+                    cx.update(|window, cx| {
+                        panel_notice(window, cx, "Import failed", error.to_string())
+                    })?;
+                }
+            }
+            Ok::<_, anyhow::Error>(())
+        })
+        .detach();
+    }
+
+    fn start_import(&mut self, _event: &ClickEvent, window: &mut Window, cx: &mut Context<Self>) {
+        let receiver = cx.prompt_for_paths(PathPromptOptions {
+            files: true,
+            directories: false,
+            multiple: false,
+            prompt: Some("Import Postman collection".into()),
+        });
+        let panel = cx.entity();
+        cx.spawn_in(window, async move |_, cx| {
+            let paths = receiver.await??;
+            let Some(path) = paths.and_then(|paths| paths.into_iter().next()) else {
+                return Ok(());
+            };
+            let parse = cx.background_spawn(async move {
+                let text = std::fs::read_to_string(path)?;
+                Ok::<_, anyhow::Error>(postman::import_collection(&text)?)
             });
+            match parse.await {
+                Ok(imported) => {
+                    panel.update_in(cx, |panel, window, cx| {
+                        panel.import_data(imported, window, cx)
+                    })?;
+                }
+                Err(error) => {
+                    cx.update(|window, cx| {
+                        panel_notice(window, cx, "Import failed", error.to_string())
+                    })?;
+                }
+            }
             Ok::<_, anyhow::Error>(())
         })
         .detach();
@@ -637,16 +703,19 @@ impl CollectionsPanel {
         };
         let suggested = format!("{}.json", safe_filename(&collection.name));
         let receiver = cx.prompt_for_new_path(Path::new(""), Some(&suggested));
-        cx.spawn_in(window, async move |_, window| {
-            let result: Result<()> = async {
-                if let Some(path) = receiver.await?? {
-                    std::fs::write(path, json)?;
+        cx.spawn_in(window, async move |_, cx| {
+            let result: Result<()> = match receiver.await?? {
+                Some(path) => {
+                    cx.background_spawn(async move {
+                        std::fs::write(path, json)?;
+                        Ok::<_, anyhow::Error>(())
+                    })
+                    .await
                 }
-                Ok(())
-            }
-            .await;
+                None => Ok(()),
+            };
             if let Err(error) = result {
-                let _ = window.update(|window, cx| {
+                let _ = cx.update(|window, cx| {
                     panel_notice(window, cx, "Export failed", error.to_string())
                 });
             }
@@ -909,6 +978,7 @@ impl CollectionsPanel {
 }
 
 impl Render for CollectionsPanel {
+    #[cfg_attr(feature = "profile", profiling::function)]
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
         let owner = cx.entity();
@@ -937,16 +1007,13 @@ impl Render for CollectionsPanel {
                             .child("Collections"),
                     )
                     .child(
-                        div()
-                            .flex_1()
-                            .min_w_0()
-                            .child(
-                                Input::new(&self.search)
-                                    .small()
-                                    .w_full()
-                                    .cleanable(true)
-                                    .prefix(Icon::empty().path("icons/search.svg")),
-                            ),
+                        div().flex_1().min_w_0().child(
+                            Input::new(&self.search)
+                                .small()
+                                .w_full()
+                                .cleanable(true)
+                                .prefix(Icon::empty().path("icons/search.svg")),
+                        ),
                     )
                     .child(
                         h_flex()
@@ -1116,11 +1183,13 @@ fn collection_menu(
             );
         });
     }))
-    .item(PopupMenuItem::new("Duplicate").on_click(move |_, _, cx| {
-        duplicate_panel.update(cx, |panel, cx| {
-            panel.duplicate_node(NodeRef::Collection(id), cx)
-        });
-    }))
+    .item(
+        PopupMenuItem::new("Duplicate").on_click(move |_, window, cx| {
+            duplicate_panel.update(cx, |panel, cx| {
+                panel.duplicate_node(NodeRef::Collection(id), window, cx)
+            });
+        }),
+    )
     .item(PopupMenuItem::separator())
     .item(
         PopupMenuItem::new("Export as Postman JSON").on_click(move |_, window, cx| {
@@ -1184,11 +1253,13 @@ fn folder_menu(
             );
         });
     }))
-    .item(PopupMenuItem::new("Duplicate").on_click(move |_, _, cx| {
-        duplicate_panel.update(cx, |panel, cx| {
-            panel.duplicate_node(NodeRef::Folder(id), cx)
-        });
-    }))
+    .item(
+        PopupMenuItem::new("Duplicate").on_click(move |_, window, cx| {
+            duplicate_panel.update(cx, |panel, cx| {
+                panel.duplicate_node(NodeRef::Folder(id), window, cx)
+            });
+        }),
+    )
     .item(PopupMenuItem::new("Delete").on_click(move |_, window, cx| {
         delete_panel.update(cx, |panel, cx| {
             panel.prompt_delete(NodeRef::Folder(id), window, cx)
@@ -1216,11 +1287,13 @@ fn request_menu(
             );
         });
     }))
-    .item(PopupMenuItem::new("Duplicate").on_click(move |_, _, cx| {
-        duplicate_panel.update(cx, |panel, cx| {
-            panel.duplicate_node(NodeRef::Request(id), cx)
-        });
-    }))
+    .item(
+        PopupMenuItem::new("Duplicate").on_click(move |_, window, cx| {
+            duplicate_panel.update(cx, |panel, cx| {
+                panel.duplicate_node(NodeRef::Request(id), window, cx)
+            });
+        }),
+    )
     .item(PopupMenuItem::new("Delete").on_click(move |_, window, cx| {
         delete_panel.update(cx, |panel, cx| {
             panel.prompt_delete(NodeRef::Request(id), window, cx)

--- a/src/db.rs
+++ b/src/db.rs
@@ -7,15 +7,19 @@
 //! the connection has exactly one owner, so data races are impossible by
 //! construction and a panic inside one query can't poison a lock for the others.
 
-use anyhow::{anyhow, Result};
-use rusqlite::{params, Connection, OptionalExtension, Transaction};
+use anyhow::{Result, anyhow};
+use rusqlite::{Connection, OptionalExtension, Transaction, params};
 use std::collections::HashMap;
 use std::path::PathBuf;
-use std::sync::mpsc::{self, Sender};
+use std::sync::{
+    Arc, OnceLock,
+    atomic::{AtomicU64, Ordering},
+    mpsc::{self, Sender},
+};
 use std::thread;
 
 use crate::types::{
-    AuthConfig, BodyType, Collection, CollectionFolder, Environment, EnvVar, HeaderState,
+    AuthConfig, BodyType, Collection, CollectionFolder, EnvVar, Environment, HeaderState,
     HistoryItem, HttpMethod, ParamState, RequestData, SavedRequest,
 };
 
@@ -35,8 +39,7 @@ fn row_to_history_item(row: &rusqlite::Row) -> rusqlite::Result<HistoryItem> {
     let request_body: String = row.get(5)?;
     let request_auth: Option<String> = row.get(6)?;
 
-    let headers: Vec<(String, String)> =
-        serde_json::from_str(&request_headers).unwrap_or_default();
+    let headers: Vec<(String, String)> = serde_json::from_str(&request_headers).unwrap_or_default();
     let body: BodyType = serde_json::from_str(&request_body).unwrap_or_default();
     let auth: crate::types::AuthConfig = request_auth
         .as_deref()
@@ -208,7 +211,11 @@ fn validate_folder_parent(
             |row| row.get(0),
         )?;
         if folder_collection != collection_id {
-            return Err(anyhow!("folder {} does not belong to collection {}", folder_id, collection_id));
+            return Err(anyhow!(
+                "folder {} does not belong to collection {}",
+                folder_id,
+                collection_id
+            ));
         }
     }
     Ok(())
@@ -358,6 +365,7 @@ fn find_folder(folders: &[CollectionFolder], id: i64) -> Option<&CollectionFolde
 /// (wrapped in `Arc` by the app); dropping every handle stops the thread.
 pub struct Database {
     tx: Sender<Job>,
+    ui_thread: OnceLock<thread::ThreadId>,
 }
 
 impl Database {
@@ -379,13 +387,21 @@ impl Database {
     fn spawn(mut conn: Connection) -> Self {
         let (tx, rx) = mpsc::channel::<Job>();
         thread::spawn(move || {
+            #[cfg(feature = "profile")]
+            profiling::register_thread!("database");
+
             // Run jobs until every handle (and thus every Sender) is dropped, at
             // which point recv() errors and the thread exits cleanly.
             while let Ok(job) = rx.recv() {
+                #[cfg(feature = "profile")]
+                profiling::scope!("database job");
                 job(&mut conn);
             }
         });
-        Self { tx }
+        Self {
+            tx,
+            ui_thread: OnceLock::new(),
+        }
     }
 
     /// Test-only: an in-memory database with the schema initialized. Shared by
@@ -398,11 +414,21 @@ impl Database {
     }
 
     /// Send `f` to the owning thread and block until it returns a result.
+    #[cfg_attr(feature = "profile", profiling::function)]
     fn call<T, F>(&self, f: F) -> Result<T>
     where
         T: Send + 'static,
         F: FnOnce(&mut Connection) -> Result<T> + Send + 'static,
     {
+        if self
+            .ui_thread
+            .get()
+            .is_some_and(|ui_thread| *ui_thread == thread::current().id())
+        {
+            return Err(anyhow!(
+                "blocking database operation attempted on the GPUI thread"
+            ));
+        }
         let (reply_tx, reply_rx) = mpsc::channel();
         self.tx
             .send(Box::new(move |conn| {
@@ -412,6 +438,12 @@ impl Database {
         reply_rx
             .recv()
             .map_err(|_| anyhow!("database thread dropped the response"))?
+    }
+
+    /// Permanently identify the GPUI thread so a future call site cannot
+    /// accidentally reintroduce a synchronous `recv()` into an event handler.
+    pub(crate) fn register_ui_thread(&self) {
+        let _ = self.ui_thread.set(thread::current().id());
     }
 
     /// Create all tables + indexes if missing. Shared by the real DB and tests
@@ -532,6 +564,7 @@ impl Database {
     }
 
     /// Load recent history items (request only, no response - aligned with Postman)
+    #[cfg_attr(feature = "profile", profiling::function)]
     pub fn load_recent_history(&self, limit: usize) -> Result<Vec<HistoryItem>> {
         self.call(move |conn| {
             let mut stmt = conn.prepare(
@@ -554,6 +587,7 @@ impl Database {
 
     /// Search history by URL or method (case-insensitive substring), newest
     /// first, up to `limit` rows. An empty query matches everything.
+    #[cfg_attr(feature = "profile", profiling::function)]
     pub fn search_history(&self, query: &str, limit: usize) -> Result<Vec<HistoryItem>> {
         let pattern = format!("%{}%", escape_like(query));
         self.call(move |conn| {
@@ -594,7 +628,8 @@ impl Database {
     #[allow(dead_code)]
     pub fn get_history_count(&self) -> Result<usize> {
         self.call(|conn| {
-            let count: i64 = conn.query_row("SELECT COUNT(*) FROM history", [], |row| row.get(0))?;
+            let count: i64 =
+                conn.query_row("SELECT COUNT(*) FROM history", [], |row| row.get(0))?;
             Ok(count as usize)
         })
     }
@@ -602,6 +637,7 @@ impl Database {
     // ===== Collections =====
 
     /// Load the complete collection/folder/request tree in display order.
+    #[cfg_attr(feature = "profile", profiling::function)]
     pub fn load_collections(&self) -> Result<Vec<Collection>> {
         self.call(|conn| {
             let collection_rows = conn
@@ -805,8 +841,13 @@ impl Database {
     pub fn rename_collection(&self, id: i64, name: &str) -> Result<()> {
         let name = require_name(name)?;
         self.call(move |conn| {
-            let changed = conn.execute("UPDATE collections SET name = ?1 WHERE id = ?2", params![name, id])?;
-            if changed == 0 { return Err(anyhow!("collection {} does not exist", id)); }
+            let changed = conn.execute(
+                "UPDATE collections SET name = ?1 WHERE id = ?2",
+                params![name, id],
+            )?;
+            if changed == 0 {
+                return Err(anyhow!("collection {} does not exist", id));
+            }
             Ok(())
         })
     }
@@ -814,8 +855,13 @@ impl Database {
     pub fn rename_folder(&self, id: i64, name: &str) -> Result<()> {
         let name = require_name(name)?;
         self.call(move |conn| {
-            let changed = conn.execute("UPDATE collection_folders SET name = ?1 WHERE id = ?2", params![name, id])?;
-            if changed == 0 { return Err(anyhow!("folder {} does not exist", id)); }
+            let changed = conn.execute(
+                "UPDATE collection_folders SET name = ?1 WHERE id = ?2",
+                params![name, id],
+            )?;
+            if changed == 0 {
+                return Err(anyhow!("folder {} does not exist", id));
+            }
             Ok(())
         })
     }
@@ -827,7 +873,9 @@ impl Database {
                 "UPDATE saved_requests SET name = ?1, updated_at = ?2 WHERE id = ?3",
                 params![name, chrono::Utc::now().to_rfc3339(), id],
             )?;
-            if changed == 0 { return Err(anyhow!("saved request {} does not exist", id)); }
+            if changed == 0 {
+                return Err(anyhow!("saved request {} does not exist", id));
+            }
             Ok(())
         })
     }
@@ -938,7 +986,11 @@ impl Database {
                         })
                     })?
                     .collect::<rusqlite::Result<Vec<_>>>()?;
-                result.push(Environment { id, name, variables });
+                result.push(Environment {
+                    id,
+                    name,
+                    variables,
+                });
             }
             Ok(result)
         })
@@ -957,10 +1009,14 @@ impl Database {
         })
     }
 
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn rename_environment(&self, id: i64, name: &str) -> Result<()> {
         let name = name.to_string();
         self.call(move |conn| {
-            conn.execute("UPDATE environments SET name = ?1 WHERE id = ?2", params![name, id])?;
+            conn.execute(
+                "UPDATE environments SET name = ?1 WHERE id = ?2",
+                params![name, id],
+            )?;
             Ok(())
         })
     }
@@ -974,6 +1030,7 @@ impl Database {
     }
 
     /// Replace all variables of an environment in a single transaction.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn replace_variables(&self, environment_id: i64, vars: &[EnvVar]) -> Result<()> {
         let vars = vars.to_vec();
         self.call(move |conn| {
@@ -986,7 +1043,58 @@ impl Database {
                 tx.execute(
                     "INSERT INTO env_variables (environment_id, enabled, key, value, position)
                      VALUES (?1, ?2, ?3, ?4, ?5)",
-                    params![environment_id, v.enabled as i64, v.key, v.value, position as i64],
+                    params![
+                        environment_id,
+                        v.enabled as i64,
+                        v.key,
+                        v.value,
+                        position as i64
+                    ],
+                )?;
+            }
+            tx.commit()?;
+            Ok(())
+        })
+    }
+
+    /// Persist one editor snapshot in a transaction, but only if it is still
+    /// current when the serialized database thread reaches this job.
+    pub fn save_environment_if_current(
+        &self,
+        environment_id: i64,
+        name: &str,
+        vars: &[EnvVar],
+        epoch: Arc<AtomicU64>,
+        generation: u64,
+    ) -> Result<()> {
+        let name = name.to_string();
+        let vars = vars.to_vec();
+        self.call(move |conn| {
+            if epoch.load(Ordering::Acquire) != generation {
+                return Ok(());
+            }
+            let tx = conn.transaction()?;
+            if !name.is_empty() {
+                tx.execute(
+                    "UPDATE environments SET name = ?1 WHERE id = ?2",
+                    params![name, environment_id],
+                )?;
+            }
+            tx.execute(
+                "DELETE FROM env_variables WHERE environment_id = ?1",
+                params![environment_id],
+            )?;
+            for (position, variable) in vars.iter().enumerate() {
+                tx.execute(
+                    "INSERT INTO env_variables (environment_id, enabled, key, value, position)
+                     VALUES (?1, ?2, ?3, ?4, ?5)",
+                    params![
+                        environment_id,
+                        variable.enabled as i64,
+                        variable.key,
+                        variable.value,
+                        position as i64
+                    ],
                 )?;
             }
             tx.commit()?;
@@ -1019,7 +1127,10 @@ impl Database {
                     )?;
                 }
                 None => {
-                    conn.execute("DELETE FROM app_meta WHERE key = 'active_environment_id'", [])?;
+                    conn.execute(
+                        "DELETE FROM app_meta WHERE key = 'active_environment_id'",
+                        [],
+                    )?;
                 }
             }
             Ok(())
@@ -1035,6 +1146,60 @@ mod tests {
 
     fn mem_db() -> Database {
         Database::new_in_memory()
+    }
+
+    #[test]
+    fn registered_ui_thread_cannot_wait_for_database() {
+        let db = mem_db();
+        db.register_ui_thread();
+
+        let error = db
+            .load_recent_history(1)
+            .expect_err("UI-thread database calls must fail before recv");
+        assert!(
+            error
+                .to_string()
+                .contains("blocking database operation attempted on the GPUI thread")
+        );
+    }
+
+    #[test]
+    fn stale_environment_snapshot_is_not_persisted() {
+        let db = mem_db();
+        let id = db.create_environment("original").unwrap();
+        let epoch = Arc::new(AtomicU64::new(2));
+
+        db.save_environment_if_current(
+            id,
+            "stale",
+            &[EnvVar {
+                enabled: true,
+                key: "token".into(),
+                value: "old".into(),
+            }],
+            epoch.clone(),
+            1,
+        )
+        .unwrap();
+        let environment = db.load_environments().unwrap().remove(0);
+        assert_eq!(environment.name, "original");
+        assert!(environment.variables.is_empty());
+
+        db.save_environment_if_current(
+            id,
+            "current",
+            &[EnvVar {
+                enabled: true,
+                key: "token".into(),
+                value: "new".into(),
+            }],
+            epoch,
+            2,
+        )
+        .unwrap();
+        let environment = db.load_environments().unwrap().remove(0);
+        assert_eq!(environment.name, "current");
+        assert_eq!(environment.variables[0].value, "new");
     }
 
     #[test]
@@ -1076,7 +1241,8 @@ mod tests {
             bearer_token: "abc".into(),
             ..Default::default()
         };
-        db.insert_history("GET", "https://x", "[]", &BodyType::None, &auth).unwrap();
+        db.insert_history("GET", "https://x", "[]", &BodyType::None, &auth)
+            .unwrap();
         let items = db.load_recent_history(10).unwrap();
         assert_eq!(items[0].request.auth.auth_type, AuthType::Bearer);
         assert_eq!(items[0].request.auth.bearer_token, "abc");
@@ -1089,8 +1255,16 @@ mod tests {
         db.replace_variables(
             id,
             &[
-                EnvVar { enabled: true, key: "baseUrl".into(), value: "http://x".into() },
-                EnvVar { enabled: false, key: "token".into(), value: "abc".into() },
+                EnvVar {
+                    enabled: true,
+                    key: "baseUrl".into(),
+                    value: "http://x".into(),
+                },
+                EnvVar {
+                    enabled: false,
+                    key: "token".into(),
+                    value: "abc".into(),
+                },
             ],
         )
         .unwrap();
@@ -1118,8 +1292,14 @@ mod tests {
     #[test]
     fn history_roundtrip() {
         let db = mem_db();
-        db.insert_history("GET", "https://api.test/x", "[]", &crate::types::BodyType::None, &crate::types::AuthConfig::default())
-            .unwrap();
+        db.insert_history(
+            "GET",
+            "https://api.test/x",
+            "[]",
+            &crate::types::BodyType::None,
+            &crate::types::AuthConfig::default(),
+        )
+        .unwrap();
         let items = db.load_recent_history(10).unwrap();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].request.url, "https://api.test/x");
@@ -1130,12 +1310,30 @@ mod tests {
     #[test]
     fn search_history_matches_url_and_method_newest_first() {
         let db = mem_db();
-        db.insert_history("GET", "https://api.test/users", "[]", &crate::types::BodyType::None, &crate::types::AuthConfig::default())
-            .unwrap();
-        db.insert_history("POST", "https://api.test/login", "[]", &crate::types::BodyType::None, &crate::types::AuthConfig::default())
-            .unwrap();
-        db.insert_history("DELETE", "https://api.test/orders/1", "[]", &crate::types::BodyType::None, &crate::types::AuthConfig::default())
-            .unwrap();
+        db.insert_history(
+            "GET",
+            "https://api.test/users",
+            "[]",
+            &crate::types::BodyType::None,
+            &crate::types::AuthConfig::default(),
+        )
+        .unwrap();
+        db.insert_history(
+            "POST",
+            "https://api.test/login",
+            "[]",
+            &crate::types::BodyType::None,
+            &crate::types::AuthConfig::default(),
+        )
+        .unwrap();
+        db.insert_history(
+            "DELETE",
+            "https://api.test/orders/1",
+            "[]",
+            &crate::types::BodyType::None,
+            &crate::types::AuthConfig::default(),
+        )
+        .unwrap();
 
         // URL substring
         let r = db.search_history("login", 10).unwrap();
@@ -1156,12 +1354,30 @@ mod tests {
     #[test]
     fn search_history_escapes_wildcards() {
         let db = mem_db();
-        db.insert_history("GET", "https://api.test/a%b", "[]", &crate::types::BodyType::None, &crate::types::AuthConfig::default())
-            .unwrap();
-        db.insert_history("GET", "https://api.test/a_b", "[]", &crate::types::BodyType::None, &crate::types::AuthConfig::default())
-            .unwrap();
-        db.insert_history("GET", "https://api.test/axb", "[]", &crate::types::BodyType::None, &crate::types::AuthConfig::default())
-            .unwrap();
+        db.insert_history(
+            "GET",
+            "https://api.test/a%b",
+            "[]",
+            &crate::types::BodyType::None,
+            &crate::types::AuthConfig::default(),
+        )
+        .unwrap();
+        db.insert_history(
+            "GET",
+            "https://api.test/a_b",
+            "[]",
+            &crate::types::BodyType::None,
+            &crate::types::AuthConfig::default(),
+        )
+        .unwrap();
+        db.insert_history(
+            "GET",
+            "https://api.test/axb",
+            "[]",
+            &crate::types::BodyType::None,
+            &crate::types::AuthConfig::default(),
+        )
+        .unwrap();
 
         // '%' must be treated literally: matches only the URL with a literal '%'
         let r = db.search_history("a%b", 10).unwrap();
@@ -1178,13 +1394,22 @@ mod tests {
     #[test]
     fn search_history_empty_query_matches_all() {
         let db = mem_db();
-        db.insert_history("GET", "https://api.test/users", "[]", &crate::types::BodyType::None, &crate::types::AuthConfig::default())
-            .unwrap();
+        db.insert_history(
+            "GET",
+            "https://api.test/users",
+            "[]",
+            &crate::types::BodyType::None,
+            &crate::types::AuthConfig::default(),
+        )
+        .unwrap();
         let r = db.search_history("", 10).unwrap();
         assert_eq!(r.len(), 1);
     }
 
-    fn saved_request_fixture(name: &str, url: &str) -> (RequestData, Vec<ParamState>, Vec<HeaderState>) {
+    fn saved_request_fixture(
+        name: &str,
+        url: &str,
+    ) -> (RequestData, Vec<ParamState>, Vec<HeaderState>) {
         let request = RequestData {
             method: HttpMethod::POST,
             url: url.to_string(),
@@ -1200,8 +1425,16 @@ mod tests {
             },
         };
         let params = vec![
-            ParamState { enabled: true, key: "page".into(), value: "1".into() },
-            ParamState { enabled: false, key: "debug".into(), value: "true".into() },
+            ParamState {
+                enabled: true,
+                key: "page".into(),
+                value: "1".into(),
+            },
+            ParamState {
+                enabled: false,
+                key: "debug".into(),
+                value: "true".into(),
+            },
         ];
         let headers = vec![
             HeaderState {
@@ -1228,13 +1461,30 @@ mod tests {
         let db = mem_db();
         let collection_id = db.create_collection("Demo").unwrap();
         let root_folder_id = db.create_folder(collection_id, None, "Root").unwrap();
-        let child_folder_id = db.create_folder(collection_id, Some(root_folder_id), "Child").unwrap();
-        let (request, params, headers) = saved_request_fixture("Nested", "https://api.test/items?page=1");
+        let child_folder_id = db
+            .create_folder(collection_id, Some(root_folder_id), "Child")
+            .unwrap();
+        let (request, params, headers) =
+            saved_request_fixture("Nested", "https://api.test/items?page=1");
         let root_request_id = db
-            .insert_saved_request(collection_id, None, "Root request", &request, &params, &headers)
+            .insert_saved_request(
+                collection_id,
+                None,
+                "Root request",
+                &request,
+                &params,
+                &headers,
+            )
             .unwrap();
         let nested_request_id = db
-            .insert_saved_request(collection_id, Some(child_folder_id), "Nested", &request, &params, &headers)
+            .insert_saved_request(
+                collection_id,
+                Some(child_folder_id),
+                "Nested",
+                &request,
+                &params,
+                &headers,
+            )
             .unwrap();
 
         let collections = db.load_collections().unwrap();
@@ -1256,7 +1506,14 @@ mod tests {
         let folder_id = db.create_folder(collection_id, None, "Folder").unwrap();
         let (request, params, headers) = saved_request_fixture("Request", "https://api.test/a");
         let request_id = db
-            .insert_saved_request(collection_id, Some(folder_id), "Request", &request, &params, &headers)
+            .insert_saved_request(
+                collection_id,
+                Some(folder_id),
+                "Request",
+                &request,
+                &params,
+                &headers,
+            )
             .unwrap();
 
         let mut changed = request.clone();
@@ -1277,16 +1534,32 @@ mod tests {
         assert!(updated.params_state.is_empty());
 
         let copied_request_id = db.duplicate_saved_request(request_id).unwrap();
-        assert_eq!(db.load_saved_request(copied_request_id).unwrap().unwrap().name, "Updated (Copy)");
+        assert_eq!(
+            db.load_saved_request(copied_request_id)
+                .unwrap()
+                .unwrap()
+                .name,
+            "Updated (Copy)"
+        );
         let copied_folder_id = db.duplicate_folder(folder_id).unwrap();
         let copied_tree = db.load_collections().unwrap();
-        assert!(copied_tree[0].folders.iter().any(|folder| folder.id == copied_folder_id));
+        assert!(
+            copied_tree[0]
+                .folders
+                .iter()
+                .any(|folder| folder.id == copied_folder_id)
+        );
 
         // Folder deletion cascades to both the original and its copied request;
         // the unrelated root collection remains intact.
         db.delete_folder(folder_id).unwrap();
         assert!(db.load_saved_request(request_id).unwrap().is_none());
-        assert!(db.load_collections().unwrap()[0].folders.iter().all(|folder| folder.id != folder_id));
+        assert!(
+            db.load_collections().unwrap()[0]
+                .folders
+                .iter()
+                .all(|folder| folder.id != folder_id)
+        );
         db.delete_collection(collection_id).unwrap();
         assert!(db.load_collections().unwrap().is_empty());
     }
@@ -1294,7 +1567,8 @@ mod tests {
     #[test]
     fn inserting_a_collection_tree_rebuilds_real_parent_ids_transactionally() {
         let db = mem_db();
-        let (request, params, headers) = saved_request_fixture("Imported", "https://api.test/imported");
+        let (request, params, headers) =
+            saved_request_fixture("Imported", "https://api.test/imported");
         let imported = Collection {
             id: 0,
             name: "Imported".into(),

--- a/src/environment_manager.rs
+++ b/src/environment_manager.rs
@@ -5,19 +5,27 @@
 
 use gpui::prelude::FluentBuilder as _;
 use gpui::*;
-use gpui_component::{
-    button::*, checkbox::Checkbox, h_flex, input::*, scroll::ScrollableElement as _, v_flex,
-    ActiveTheme as _, Sizable as _,
-};
 use gpui_component::input::InputEvent;
-use std::sync::Arc;
+use gpui_component::{
+    ActiveTheme as _, Sizable as _, button::*, checkbox::Checkbox, h_flex, input::*,
+    scroll::ScrollableElement as _, v_flex,
+};
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
+use std::time::Duration;
 
 use crate::db::Database;
-use crate::types::{Environment, EnvVar};
+use crate::types::{EnvVar, Environment};
 
-/// Emitted whenever environments or the active selection change, so the app reloads.
+/// Emitted with the manager's current in-memory state. The UI never has to
+/// synchronously read SQLite merely to reflect an edit it already owns.
 #[derive(Clone)]
-pub struct EnvironmentsChanged;
+pub struct EnvironmentsChanged {
+    pub environments: Vec<Environment>,
+    pub active_id: Option<i64>,
+}
 
 struct VarRow {
     enabled: bool,
@@ -37,6 +45,11 @@ pub struct EnvironmentManager {
     /// True while programmatically loading inputs, so their `Change` events don't
     /// trigger an auto-save of values we just set.
     suspend_autosave: bool,
+    /// Invalidates delayed auto-saves when another keystroke arrives.
+    save_generation: u64,
+    /// Also checked on the database thread, closing the small race between a
+    /// timer's foreground generation check and background task scheduling.
+    save_epoch: Arc<AtomicU64>,
     /// Live input-change subscriptions (name + each var row), rewired on load.
     _subs: Vec<Subscription>,
 }
@@ -44,9 +57,13 @@ pub struct EnvironmentManager {
 impl EventEmitter<EnvironmentsChanged> for EnvironmentManager {}
 
 impl EnvironmentManager {
-    pub fn new(db: Arc<Database>, window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let environments = db.load_environments().unwrap_or_default();
-        let active_id = db.get_active_environment_id().unwrap_or(None);
+    pub fn new(
+        db: Arc<Database>,
+        environments: Vec<Environment>,
+        active_id: Option<i64>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
         let selected_id = environments.first().map(|e| e.id);
         let name_input = cx.new(|cx| InputState::new(window, cx).placeholder("Environment name"));
 
@@ -60,6 +77,8 @@ impl EnvironmentManager {
             env_list_scroll_handle: ScrollHandle::new(),
             var_list_scroll_handle: ScrollHandle::new(),
             suspend_autosave: false,
+            save_generation: 0,
+            save_epoch: Arc::new(AtomicU64::new(0)),
             _subs: vec![],
         };
         this.load_selected_into_editor(window, cx);
@@ -76,25 +95,31 @@ impl EnvironmentManager {
             .collect();
 
         let mut subs = Vec::with_capacity(inputs.len() + 1);
-        subs.push(cx.subscribe_in(&name, window, |this, _, ev: &InputEvent, _w, cx| {
-            if matches!(ev, InputEvent::Change) && !this.suspend_autosave {
-                this.commit(cx);
-            }
-        }));
-        for input in &inputs {
-            subs.push(cx.subscribe_in(input, window, |this, _, ev: &InputEvent, _w, cx| {
+        subs.push(
+            cx.subscribe_in(&name, window, |this, _, ev: &InputEvent, window, cx| {
                 if matches!(ev, InputEvent::Change) && !this.suspend_autosave {
-                    this.commit(cx);
+                    this.commit(window, cx);
                 }
-            }));
+            }),
+        );
+        for input in &inputs {
+            subs.push(
+                cx.subscribe_in(input, window, |this, _, ev: &InputEvent, window, cx| {
+                    if matches!(ev, InputEvent::Change) && !this.suspend_autosave {
+                        this.commit(window, cx);
+                    }
+                }),
+            );
         }
         // Assigning drops the previous subscriptions (unsubscribing stale inputs).
         self._subs = subs;
     }
 
-    pub(crate) fn reload(&mut self) {
-        self.environments = self.db.load_environments().unwrap_or_default();
-        self.active_id = self.db.get_active_environment_id().unwrap_or(None);
+    fn changed_event(&self) -> EnvironmentsChanged {
+        EnvironmentsChanged {
+            environments: self.environments.clone(),
+            active_id: self.active_id,
+        }
     }
 
     /// Populate name_input + var_rows from the currently selected environment.
@@ -108,7 +133,10 @@ impl EnvironmentManager {
         // loading; suspend autosave for the duration.
         self.suspend_autosave = true;
 
-        let name = selected.as_ref().map(|e| e.name.clone()).unwrap_or_default();
+        let name = selected
+            .as_ref()
+            .map(|e| e.name.clone())
+            .unwrap_or_default();
         self.name_input.update(cx, |input, cx| {
             input.set_value(&name, window, cx);
         });
@@ -116,7 +144,8 @@ impl EnvironmentManager {
         self.var_rows.clear();
         if let Some(env) = selected {
             for v in &env.variables {
-                self.var_rows.push(self.make_var_row(v.enabled, &v.key, &v.value, window, cx));
+                self.var_rows
+                    .push(self.make_var_row(v.enabled, &v.key, &v.value, window, cx));
             }
         }
 
@@ -150,59 +179,109 @@ impl EnvironmentManager {
     }
 
     fn select(&mut self, id: i64, window: &mut Window, cx: &mut Context<Self>) {
-        // Edits auto-save as they happen, so switching just reloads + reselects.
-        self.reload();
+        // Edits update the in-memory model immediately and persist in the
+        // background, so selection never needs a read-back round trip.
         self.selected_id = Some(id);
         self.load_selected_into_editor(window, cx);
         cx.notify();
     }
 
     fn add_environment(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        match self.db.create_environment("New Environment") {
-            Ok(id) => {
-                self.reload();
-                self.selected_id = Some(id);
-                self.load_selected_into_editor(window, cx);
-                cx.emit(EnvironmentsChanged);
-                cx.notify();
+        let db = self.db.clone();
+        let task = cx.background_spawn(async move { db.create_environment("New Environment") });
+        cx.spawn_in(window, async move |this, cx| {
+            match task.await {
+                Ok(id) => {
+                    this.update_in(cx, |this, window, cx| {
+                        this.environments.push(Environment {
+                            id,
+                            name: "New Environment".to_string(),
+                            variables: Vec::new(),
+                        });
+                        this.selected_id = Some(id);
+                        this.load_selected_into_editor(window, cx);
+                        cx.emit(this.changed_event());
+                        cx.notify();
+                    })?;
+                }
+                Err(error) => log::error!("Failed to create environment: {}", error),
             }
-            Err(e) => log::error!("Failed to create environment: {}", e),
-        }
+            Ok::<_, anyhow::Error>(())
+        })
+        .detach();
     }
 
     fn delete_environment(&mut self, id: i64, window: &mut Window, cx: &mut Context<Self>) {
-        if let Err(e) = self.db.delete_environment(id) {
-            log::error!("Failed to delete environment: {}", e);
-            return;
-        }
-        self.reload();
-        if self.selected_id == Some(id) {
-            self.selected_id = self.environments.first().map(|e| e.id);
-            self.load_selected_into_editor(window, cx);
-        }
-        cx.emit(EnvironmentsChanged);
-        cx.notify();
+        self.save_generation = self.save_generation.wrapping_add(1);
+        self.save_epoch
+            .store(self.save_generation, Ordering::Release);
+        let was_active = self.active_id == Some(id);
+        let db = self.db.clone();
+        let task = cx.background_spawn(async move {
+            db.delete_environment(id)?;
+            if was_active {
+                db.set_active_environment_id(None)?;
+            }
+            Ok::<_, anyhow::Error>(())
+        });
+        cx.spawn_in(window, async move |this, cx| {
+            match task.await {
+                Ok(()) => {
+                    this.update_in(cx, |this, window, cx| {
+                        this.environments.retain(|environment| environment.id != id);
+                        if was_active {
+                            this.active_id = None;
+                        }
+                        if this.selected_id == Some(id) {
+                            this.selected_id = this.environments.first().map(|env| env.id);
+                            this.load_selected_into_editor(window, cx);
+                        }
+                        cx.emit(this.changed_event());
+                        cx.notify();
+                    })?;
+                }
+                Err(error) => log::error!("Failed to delete environment: {}", error),
+            }
+            Ok::<_, anyhow::Error>(())
+        })
+        .detach();
     }
 
-    fn set_active(&mut self, id: Option<i64>, cx: &mut Context<Self>) {
-        if let Err(e) = self.db.set_active_environment_id(id) {
-            log::error!("Failed to set active environment: {}", e);
-            return;
-        }
+    pub(crate) fn set_active(
+        &mut self,
+        id: Option<i64>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let previous = self.active_id;
         self.active_id = id;
-        cx.emit(EnvironmentsChanged);
+        cx.emit(self.changed_event());
         cx.notify();
+
+        let db = self.db.clone();
+        let task = cx.background_spawn(async move { db.set_active_environment_id(id) });
+        cx.spawn_in(window, async move |this, cx| {
+            if let Err(error) = task.await {
+                log::error!("Failed to set active environment: {}", error);
+                this.update(cx, |this, cx| {
+                    if this.active_id == id {
+                        this.active_id = previous;
+                        cx.emit(this.changed_event());
+                        cx.notify();
+                    }
+                })?;
+            }
+            Ok::<_, anyhow::Error>(())
+        })
+        .detach();
     }
 
-    /// Persist the currently selected environment's name + variables.
-    fn save(&mut self, cx: &mut Context<Self>) {
+    /// Snapshot the editor into the local model before persistence.
+    fn snapshot_selected(&mut self, cx: &mut Context<Self>) -> Option<(i64, String, Vec<EnvVar>)> {
         let Some(id) = self.selected_id else {
-            return;
+            return None;
         };
         let name = self.name_input.read(cx).value().to_string();
-        if !name.is_empty() {
-            let _ = self.db.rename_environment(id, &name);
-        }
         let vars: Vec<EnvVar> = self
             .var_rows
             .iter()
@@ -213,17 +292,49 @@ impl EnvironmentManager {
             })
             .filter(|v| !v.key.is_empty() || !v.value.is_empty())
             .collect();
-        let _ = self.db.replace_variables(id, &vars);
+        if let Some(environment) = self.environments.iter_mut().find(|env| env.id == id) {
+            if !name.is_empty() {
+                environment.name = name.clone();
+            }
+            environment.variables = vars.clone();
+        }
+        Some((id, name, vars))
     }
 
-    /// Persist the selected environment + reload + broadcast so the rest of the
-    /// app (request editor's `{{var}}` map, the list) reflects the change. This is
-    /// the single auto-save entry point.
-    fn commit(&mut self, cx: &mut Context<Self>) {
-        self.save(cx);
-        self.reload();
-        cx.emit(EnvironmentsChanged);
+    /// Update the UI immediately, then coalesce rapid edits into one background
+    /// persistence job. The generation check prevents stale timers from writing.
+    fn commit(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some((id, name, vars)) = self.snapshot_selected(cx) else {
+            return;
+        };
+        self.save_generation = self.save_generation.wrapping_add(1);
+        let generation = self.save_generation;
+        self.save_epoch.store(generation, Ordering::Release);
+        cx.emit(self.changed_event());
         cx.notify();
+
+        let db = self.db.clone();
+        let save_epoch = self.save_epoch.clone();
+        cx.spawn_in(window, async move |this, cx| {
+            cx.background_executor()
+                .timer(Duration::from_millis(180))
+                .await;
+            let is_current = this
+                .update(cx, |this, _| this.save_generation == generation)
+                .unwrap_or(false);
+            if !is_current {
+                return Ok(());
+            }
+
+            let task = cx.background_spawn(async move {
+                db.save_environment_if_current(id, &name, &vars, save_epoch, generation)
+            });
+            if let Err(error) = task.await {
+                log::error!("Failed to save environment: {}", error);
+            }
+            Ok::<_, anyhow::Error>(())
+        })
+        .detach();
     }
 
     fn add_var_row(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -235,17 +346,17 @@ impl EnvironmentManager {
         cx.notify();
     }
 
-    fn remove_var_row(&mut self, index: usize, cx: &mut Context<Self>) {
+    fn remove_var_row(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
         if index < self.var_rows.len() {
             self.var_rows.remove(index);
-            self.commit(cx);
+            self.commit(window, cx);
         }
     }
 
-    fn toggle_var(&mut self, index: usize, cx: &mut Context<Self>) {
+    fn toggle_var(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
         if let Some(row) = self.var_rows.get_mut(index) {
             row.enabled = !row.enabled;
-            self.commit(cx);
+            self.commit(window, cx);
         }
     }
 }
@@ -350,14 +461,14 @@ impl Render for EnvironmentManager {
                                             .items_center()
                                             .justify_center()
                                             .cursor_pointer()
-                                            .on_click(cx.listener(move |this, _, _window, cx| {
+                                            .on_click(cx.listener(move |this, _, window, cx| {
                                                 cx.stop_propagation();
                                                 let new = if this.active_id == Some(id) {
                                                     None
                                                 } else {
                                                     Some(id)
                                                 };
-                                                this.set_active(new, cx);
+                                                this.set_active(new, window, cx);
                                             }))
                                             .child(
                                                 div()
@@ -471,8 +582,8 @@ impl Render for EnvironmentManager {
                                                 div().w(px(20.)).flex_shrink_0().flex().justify_center().child(
                                                     Checkbox::new(("var-check", index))
                                                         .checked(row.enabled)
-                                                        .on_click(cx.listener(move |this, _, _window, cx| {
-                                                            this.toggle_var(index, cx);
+                                                        .on_click(cx.listener(move |this, _, window, cx| {
+                                                            this.toggle_var(index, window, cx);
                                                         })),
                                                 ),
                                             )
@@ -484,8 +595,8 @@ impl Render for EnvironmentManager {
                                                         .ghost()
                                                         .xsmall()
                                                         .label("×")
-                                                        .on_click(cx.listener(move |this, _, _window, cx| {
-                                                            this.remove_var_row(index, cx);
+                                                        .on_click(cx.listener(move |this, _, window, cx| {
+                                                            this.remove_var_row(index, window, cx);
                                                         })),
                                                 ),
                                             )

--- a/src/history_panel.rs
+++ b/src/history_panel.rs
@@ -1,18 +1,21 @@
 use gpui::prelude::FluentBuilder as _;
 use gpui::*;
 use gpui_component::{
-    button::*, h_flex,
+    ActiveTheme as _, Icon, Sizable as _,
+    button::*,
+    h_flex,
     input::{Input, InputEvent, InputState},
     scroll::ScrollableElement as _,
-    v_flex, ActiveTheme as _, Icon, Sizable as _,
+    v_flex,
 };
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::db::Database;
 use crate::types::HistoryItem;
 
 /// Maximum number of history rows loaded/searched at a time.
-const HISTORY_LIMIT: usize = 100;
+pub(crate) const HISTORY_LIMIT: usize = 100;
 
 /// Event emitted when a history item is clicked
 #[derive(Clone)]
@@ -27,16 +30,22 @@ pub struct HistoryPanel {
     selected_id: Option<i64>,
     search: Entity<InputState>,
     query: String,
+    /// Invalidates stale search/reload completions. Database work is serialized,
+    /// but foreground tasks may resume after a newer query has been entered.
+    refresh_generation: u64,
     list_scroll_handle: ScrollHandle,
 }
 
 impl HistoryPanel {
-    pub fn new(db: Arc<Database>, window: &mut Window, cx: &mut Context<Self>) -> Self {
-        // Load initial history from database
-        let history = db.load_recent_history(HISTORY_LIMIT).unwrap_or_default();
-
+    pub fn new(
+        db: Arc<Database>,
+        history: Vec<HistoryItem>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
         let search = cx.new(|cx| InputState::new(window, cx).placeholder("Search history"));
-        cx.subscribe(&search, Self::on_search_change).detach();
+        cx.subscribe_in(&search, window, Self::on_search_change)
+            .detach();
 
         Self {
             db,
@@ -44,38 +53,76 @@ impl HistoryPanel {
             selected_id: None,
             search,
             query: String::new(),
+            refresh_generation: 0,
             list_scroll_handle: ScrollHandle::new(),
         }
     }
 
-    /// Re-query the list to honor the current query: recent when empty,
-    /// search otherwise. Shared by typing and by `reload`.
-    fn refresh_list(&mut self) {
-        let q = self.query.trim();
-        self.history = if q.is_empty() {
-            self.db.load_recent_history(HISTORY_LIMIT).unwrap_or_default()
-        } else {
-            self.db.search_history(q, HISTORY_LIMIT).unwrap_or_default()
-        };
+    /// Re-query without ever waiting for SQLite on the UI thread.
+    ///
+    /// Search changes are coalesced for a short interval, matching the pattern
+    /// used by Telegram Desktop for delayed storage writes: rapid UI changes
+    /// produce one useful database operation instead of a queue of stale work.
+    fn refresh_list(&mut self, debounce: bool, window: &mut Window, cx: &mut Context<Self>) {
+        self.refresh_generation = self.refresh_generation.wrapping_add(1);
+        let generation = self.refresh_generation;
+        let query = self.query.trim().to_string();
+        let db = self.db.clone();
+
+        cx.spawn_in(window, async move |this, cx| {
+            if debounce {
+                cx.background_executor()
+                    .timer(Duration::from_millis(150))
+                    .await;
+                let is_current = this
+                    .update(cx, |this, _| this.refresh_generation == generation)
+                    .unwrap_or(false);
+                if !is_current {
+                    return Ok(());
+                }
+            }
+
+            let query_for_db = query.clone();
+            let task = cx.background_spawn(async move {
+                if query_for_db.is_empty() {
+                    db.load_recent_history(HISTORY_LIMIT)
+                } else {
+                    db.search_history(&query_for_db, HISTORY_LIMIT)
+                }
+            });
+            let result = task.await;
+
+            this.update(cx, |this, cx| {
+                if this.refresh_generation != generation {
+                    return;
+                }
+                match result {
+                    Ok(history) => this.history = history,
+                    Err(error) => log::error!("Failed to refresh history: {}", error),
+                }
+                cx.notify();
+            })?;
+            Ok::<_, anyhow::Error>(())
+        })
+        .detach();
     }
 
     fn on_search_change(
         &mut self,
-        _state: Entity<InputState>,
+        _state: &Entity<InputState>,
         event: &InputEvent,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         if matches!(event, InputEvent::Change) {
             self.query = self.search.read(cx).value().to_string();
-            self.refresh_list();
-            cx.notify();
+            self.refresh_list(true, window, cx);
         }
     }
 
     /// Reload history from database, honoring the active search query.
-    pub fn reload(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
-        self.refresh_list();
-        cx.notify();
+    pub fn reload(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.refresh_list(false, window, cx);
     }
 
     fn on_item_click(&mut self, item: &HistoryItem, _window: &mut Window, cx: &mut Context<Self>) {
@@ -90,17 +137,25 @@ impl HistoryPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if let Err(e) = self.db.clear_all_history() {
-            log::error!("Failed to clear history: {}", e);
-            return;
-        }
-
+        self.refresh_generation = self.refresh_generation.wrapping_add(1);
         self.history.clear();
         self.selected_id = None;
         self.query = String::new();
         self.search
             .update(cx, |state, cx| state.set_value("", window, cx));
         cx.notify();
+
+        let db = self.db.clone();
+        let task = cx.background_spawn(async move { db.clear_all_history() });
+        cx.spawn_in(window, async move |this, cx| {
+            if let Err(error) = task.await {
+                log::error!("Failed to clear history: {}", error);
+                // Restore authoritative state if the optimistic clear failed.
+                this.update_in(cx, |this, window, cx| this.refresh_list(false, window, cx))?;
+            }
+            Ok::<_, anyhow::Error>(())
+        })
+        .detach();
     }
 
     /// Render one history row. Split out of `render` so the list body stays
@@ -185,6 +240,7 @@ impl HistoryPanel {
 impl EventEmitter<HistoryItemClicked> for HistoryPanel {}
 
 impl Render for HistoryPanel {
+    #[cfg_attr(feature = "profile", profiling::function)]
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
 
@@ -205,19 +261,16 @@ impl Render for HistoryPanel {
                             .flex_shrink_0()
                             .font_weight(FontWeight::SEMIBOLD)
                             .text_color(theme.foreground)
-                            .child("History")
+                            .child("History"),
                     )
                     .child(
-                        div()
-                            .flex_1()
-                            .min_w_0()
-                            .child(
-                                Input::new(&self.search)
-                                    .small()
-                                    .w_full()
-                                    .cleanable(true)
-                                    .prefix(Icon::empty().path("icons/search.svg")),
-                            ),
+                        div().flex_1().min_w_0().child(
+                            Input::new(&self.search)
+                                .small()
+                                .w_full()
+                                .cleanable(true)
+                                .prefix(Icon::empty().path("icons/search.svg")),
+                        ),
                     )
                     .child(
                         Button::new("clear-btn")

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,8 +24,8 @@ mod tab_bar;
 mod theme;
 mod types;
 mod ui;
-mod variables;
 mod url_params;
+mod variables;
 
 use gpui::*;
 use gpui_component::Root;
@@ -97,7 +97,8 @@ fn setup_logger() {
                 timestamp,
                 record.level(),
                 record.args()
-            ).ok();
+            )
+            .ok();
 
             Ok(())
         })
@@ -107,6 +108,9 @@ fn setup_logger() {
 }
 
 fn main() {
+    #[cfg(feature = "profile")]
+    profiling::register_thread!("main");
+
     // Initialize logger to write to both console and file
     setup_logger();
 
@@ -145,14 +149,16 @@ fn main() {
             items: vec![MenuItem::action("Quit Poopman", crate::app::Quit)],
         }]);
 
+        let initial = cx.background_spawn(async { crate::app::AppInitialState::load() });
         cx.spawn(async move |cx| {
+            let initial = initial.await?;
             let window_options = WindowOptions {
                 titlebar: Some(gpui_component::TitleBar::title_bar_options()),
                 window_min_size: Some(size(px(720.), px(480.))),
                 ..Default::default()
             };
             cx.open_window(window_options, |window, cx| {
-                let view = cx.new(|cx| PoopmanApp::new(window, cx));
+                let view = cx.new(|cx| PoopmanApp::new(initial, window, cx));
                 cx.new(|cx| Root::new(view, window, cx))
             })?;
             Ok::<_, anyhow::Error>(())

--- a/src/menu_bar.rs
+++ b/src/menu_bar.rs
@@ -4,9 +4,9 @@
 
 use gpui::*;
 use gpui_component::{
+    Sizable as _,
     button::{Button, ButtonVariants as _},
     menu::{DropdownMenu as _, PopupMenuItem},
-    Sizable as _,
 };
 
 use crate::app::PoopmanApp;
@@ -32,9 +32,9 @@ pub fn edit_menu(
                 menu = menu.item(
                     PopupMenuItem::new(env.name.clone())
                         .checked(is_active)
-                        .on_click(move |_, _window, cx| {
+                        .on_click(move |_, window, cx| {
                             app.update(cx, |app, cx| {
-                                app.set_active_environment(Some(id), cx);
+                                app.set_active_environment(Some(id), window, cx);
                             });
                         }),
                 );
@@ -45,9 +45,9 @@ pub fn edit_menu(
                 menu = menu.item(
                     PopupMenuItem::new("No Environment")
                         .checked(active_id.is_none())
-                        .on_click(move |_, _window, cx| {
+                        .on_click(move |_, window, cx| {
                             app.update(cx, |app, cx| {
-                                app.set_active_environment(None, cx);
+                                app.set_active_environment(None, window, cx);
                             });
                         }),
                 );
@@ -57,15 +57,13 @@ pub fn edit_menu(
 
             {
                 let app = app.clone();
-                menu = menu.item(
-                    PopupMenuItem::new("Manage Environments\u{2026}").on_click(
-                        move |_, window, cx| {
-                            app.update(cx, |app, cx| {
-                                app.open_env_manager(window, cx);
-                            });
-                        },
-                    ),
-                );
+                menu = menu.item(PopupMenuItem::new("Manage Environments\u{2026}").on_click(
+                    move |_, window, cx| {
+                        app.update(cx, |app, cx| {
+                            app.open_env_manager(window, cx);
+                        });
+                    },
+                ));
             }
 
             menu

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -1,19 +1,18 @@
 use gpui::prelude::FluentBuilder as _;
-use gpui::*;
 use gpui::px;
-use gpui_component::{
-    button::*, checkbox::Checkbox, input::*,
-    scroll::ScrollableElement as _,
-    select::*, v_flex, ActiveTheme as _, Disableable as _, Icon, IndexPath, Sizable as _,
-};
+use gpui::*;
 use gpui_component::input::InputEvent;
+use gpui_component::{
+    ActiveTheme as _, Disableable as _, Icon, IndexPath, Sizable as _, button::*,
+    checkbox::Checkbox, input::*, scroll::ScrollableElement as _, select::*, v_flex,
+};
 
 use crate::auth_editor::AuthEditor;
 use crate::body_editor::{BodyEditor, BodyTypeChanged};
 use crate::header_completion::HeaderCompletionProvider;
+use crate::theme::METHOD_SELECT_WIDTH;
 use crate::types::{HeaderType, HttpMethod, PredefinedHeader, RequestData, ResponseData};
 use crate::url_params::{self, QueryParam};
-use crate::theme::METHOD_SELECT_WIDTH;
 
 /// Event emitted when a request is sent and response is received.
 /// The response is `Arc`-shared so subscribers can store it without copying the body.
@@ -97,8 +96,8 @@ pub struct RequestEditor {
     /// generation and bail out if it no longer matches, so a stale task can
     /// never clobber state owned by a newer send.
     send_generation: u64,
-    _subscriptions: Vec<Subscription>,       // Permanent: URL input + body editor subscriptions
-    _row_subscriptions: Vec<Subscription>,   // Header/param row subscriptions; rebuilt on load
+    _subscriptions: Vec<Subscription>, // Permanent: URL input + body editor subscriptions
+    _row_subscriptions: Vec<Subscription>, // Header/param row subscriptions; rebuilt on load
     /// Active environment variables, pushed by PoopmanApp; used at send time.
     env_vars: std::collections::HashMap<String, String>,
     /// Whether the active tab is associated with a request in a collection.
@@ -124,9 +123,13 @@ impl RequestEditor {
         let auth_editor = cx.new(|cx| AuthEditor::new(window, cx));
 
         // Subscribe to body type changes to auto-update Content-Type header
-        let body_sub = cx.subscribe_in(&body_editor, window, |this: &mut RequestEditor, _, event: &BodyTypeChanged, window, cx| {
-            this.update_content_type_from_body(&event.content_type, window, cx);
-        });
+        let body_sub = cx.subscribe_in(
+            &body_editor,
+            window,
+            |this: &mut RequestEditor, _, event: &BodyTypeChanged, window, cx| {
+                this.update_content_type_from_body(&event.content_type, window, cx);
+            },
+        );
 
         let mut editor = Self {
             url_input: url_input.clone(),
@@ -149,21 +152,25 @@ impl RequestEditor {
 
         // Subscribe to URL input changes: a pasted `curl …` command imports the
         // whole request; anything else just re-parses query params.
-        let url_sub = cx.subscribe_in(&url_input, window, |this, _, event: &InputEvent, window, cx| {
-            if matches!(event, InputEvent::Change) {
-                let value = this.url_input.read(cx).value().to_string();
-                if value.trim_start().starts_with("curl ")
-                    && let Some(request) = crate::curl_import::parse_curl(&value)
-                {
-                    // load_request rewrites the URL input, which re-fires
-                    // Change — the new value no longer starts with "curl",
-                    // so there is no loop.
-                    this.load_request(&request, window, cx);
-                    return;
+        let url_sub = cx.subscribe_in(
+            &url_input,
+            window,
+            |this, _, event: &InputEvent, window, cx| {
+                if matches!(event, InputEvent::Change) {
+                    let value = this.url_input.read(cx).value().to_string();
+                    if value.trim_start().starts_with("curl ")
+                        && let Some(request) = crate::curl_import::parse_curl(&value)
+                    {
+                        // load_request rewrites the URL input, which re-fires
+                        // Change — the new value no longer starts with "curl",
+                        // so there is no loop.
+                        this.load_request(&request, window, cx);
+                        return;
+                    }
                 }
-            }
-            this.parse_url_to_params(window, cx);
-        });
+                this.parse_url_to_params(window, cx);
+            },
+        );
         editor._subscriptions.push(url_sub);
         editor._subscriptions.push(body_sub);
 
@@ -310,7 +317,9 @@ impl RequestEditor {
         let content_type = match &request.body {
             crate::types::BodyType::None => None,
             crate::types::BodyType::Raw { subtype, .. } => Some(subtype.content_type().to_string()),
-            crate::types::BodyType::FormData(_) => Some("multipart/form-data; boundary=<auto>".to_string()),
+            crate::types::BodyType::FormData(_) => {
+                Some("multipart/form-data; boundary=<auto>".to_string())
+            }
         };
         self.update_content_type_from_body(&content_type, window, cx);
 
@@ -331,9 +340,13 @@ impl RequestEditor {
         let method_index = self
             .method_select
             .read(cx)
-            .selected_index(cx).map(|idx| idx.row)
+            .selected_index(cx)
+            .map(|idx| idx.row)
             .unwrap_or(0);
-        let method = HttpMethod::all().get(method_index).copied().unwrap_or(HttpMethod::GET);
+        let method = HttpMethod::all()
+            .get(method_index)
+            .copied()
+            .unwrap_or(HttpMethod::GET);
 
         // Get headers (only enabled ones, excluding empty custom headers)
         let mut headers = Vec::new();
@@ -403,7 +416,12 @@ impl RequestEditor {
     }
 
     /// Load params state (including disabled params)
-    pub fn load_params_state(&mut self, state: &[crate::types::ParamState], window: &mut Window, cx: &mut Context<Self>) {
+    pub fn load_params_state(
+        &mut self,
+        state: &[crate::types::ParamState],
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         // Clear existing params and subscriptions related to params
         self.params.clear();
 
@@ -424,12 +442,20 @@ impl RequestEditor {
             };
 
             // Subscribe to changes for syncing back to URL
-            let sub1 = cx.subscribe_in(&param_row.key_input, window, |this, _, _event: &InputEvent, window, cx| {
-                this.sync_params_to_url(window, cx);
-            });
-            let sub2 = cx.subscribe_in(&param_row.value_input, window, |this, _, _event: &InputEvent, window, cx| {
-                this.sync_params_to_url(window, cx);
-            });
+            let sub1 = cx.subscribe_in(
+                &param_row.key_input,
+                window,
+                |this, _, _event: &InputEvent, window, cx| {
+                    this.sync_params_to_url(window, cx);
+                },
+            );
+            let sub2 = cx.subscribe_in(
+                &param_row.value_input,
+                window,
+                |this, _, _event: &InputEvent, window, cx| {
+                    this.sync_params_to_url(window, cx);
+                },
+            );
 
             self._row_subscriptions.push(sub1);
             self._row_subscriptions.push(sub2);
@@ -443,7 +469,12 @@ impl RequestEditor {
     }
 
     /// Load headers state (including disabled headers)
-    pub fn load_headers_state(&mut self, state: &[crate::types::HeaderState], window: &mut Window, cx: &mut Context<Self>) {
+    pub fn load_headers_state(
+        &mut self,
+        state: &[crate::types::HeaderState],
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         // Clear existing headers and subscriptions
         self.headers.clear();
 
@@ -478,19 +509,24 @@ impl RequestEditor {
             if matches!(header_state.header_type, HeaderType::Custom) {
                 let key_input = header_row.key_input.clone();
                 let key_input_for_closure = key_input.clone();
-                let sub = cx.subscribe_in(&key_input, window, move |this, emitter, _event: &InputEvent, window, cx| {
-                    this.maybe_advance_after_completion(emitter, window, cx);
+                let sub = cx.subscribe_in(
+                    &key_input,
+                    window,
+                    move |this, emitter, _event: &InputEvent, window, cx| {
+                        this.maybe_advance_after_completion(emitter, window, cx);
 
-                    if let Some(last) = this.headers.last() {
-                        let has_key = !last.key_input.read(cx).value().is_empty();
-                        if has_key
-                            && matches!(last.header_type, HeaderType::Custom)
-                            && this.headers.last().map(|h| Entity::entity_id(&h.key_input)) == Some(Entity::entity_id(&key_input_for_closure))
-                        {
-                            this.add_custom_header_row(window, cx);
+                        if let Some(last) = this.headers.last() {
+                            let has_key = !last.key_input.read(cx).value().is_empty();
+                            if has_key
+                                && matches!(last.header_type, HeaderType::Custom)
+                                && this.headers.last().map(|h| Entity::entity_id(&h.key_input))
+                                    == Some(Entity::entity_id(&key_input_for_closure))
+                            {
+                                this.add_custom_header_row(window, cx);
+                            }
                         }
-                    }
-                });
+                    },
+                );
                 self._row_subscriptions.push(sub);
             }
 
@@ -560,60 +596,75 @@ impl RequestEditor {
         // Subscribe to the key input change
         let key_input = new_row.key_input.clone();
         let key_input_for_closure = key_input.clone();
-        let sub = cx.subscribe_in(&key_input, window, move |this, emitter, _event: &InputEvent, window, cx| {
-            this.maybe_advance_after_completion(emitter, window, cx);
+        let sub = cx.subscribe_in(
+            &key_input,
+            window,
+            move |this, emitter, _event: &InputEvent, window, cx| {
+                this.maybe_advance_after_completion(emitter, window, cx);
 
-            // Check if this was the last row and it now has content
-            if let Some(last) = this.headers.last() {
-                let has_key = !last.key_input.read(cx).value().is_empty();
-                // Only auto-add if the last row is a custom row
-                if has_key
-                    && matches!(last.header_type, HeaderType::Custom)
-                    && this.headers.last().map(|h| Entity::entity_id(&h.key_input)) == Some(Entity::entity_id(&key_input_for_closure))
-                {
-                    this.add_custom_header_row(window, cx);
+                // Check if this was the last row and it now has content
+                if let Some(last) = this.headers.last() {
+                    let has_key = !last.key_input.read(cx).value().is_empty();
+                    // Only auto-add if the last row is a custom row
+                    if has_key
+                        && matches!(last.header_type, HeaderType::Custom)
+                        && this.headers.last().map(|h| Entity::entity_id(&h.key_input))
+                            == Some(Entity::entity_id(&key_input_for_closure))
+                    {
+                        this.add_custom_header_row(window, cx);
 
-                    // Scroll to bottom after adding new row
-                    let scroll_handle = this.headers_scroll_handle.clone();
-                    cx.spawn_in(window, async move |_this, cx| {
-                        // Wait for layout to stabilize by checking max_offset changes
-                        let mut last_offset = px(0.);
-                        let mut stable_count = 0;
+                        // Scroll to bottom after adding new row
+                        let scroll_handle = this.headers_scroll_handle.clone();
+                        cx.spawn_in(window, async move |_this, cx| {
+                            // Wait for layout to stabilize by checking max_offset changes
+                            let mut last_offset = px(0.);
+                            let mut stable_count = 0;
 
-                        for _ in 0..20 {  // Max 20 attempts (~20ms)
-                            cx.background_executor().timer(std::time::Duration::from_millis(1)).await;
+                            for _ in 0..20 {
+                                // Max 20 attempts (~20ms)
+                                cx.background_executor()
+                                    .timer(std::time::Duration::from_millis(1))
+                                    .await;
 
-                            let current = scroll_handle.max_offset().height;
-                            if (current - last_offset).abs() < px(0.1) {
-                                stable_count += 1;
-                                if stable_count >= 2 {
-                                    // Offset stable for 2 checks, layout likely complete
-                                    break;
+                                let current = scroll_handle.max_offset().height;
+                                if (current - last_offset).abs() < px(0.1) {
+                                    stable_count += 1;
+                                    if stable_count >= 2 {
+                                        // Offset stable for 2 checks, layout likely complete
+                                        break;
+                                    }
+                                } else {
+                                    stable_count = 0;
                                 }
-                            } else {
-                                stable_count = 0;
+                                last_offset = current;
                             }
-                            last_offset = current;
-                        }
 
-                        // Scroll to bottom
-                        let _ = cx.update(|_, _cx| {
-                            let max_offset = scroll_handle.max_offset();
-                            scroll_handle.set_offset(point(px(0.), -max_offset.height));
-                        });
-                    }).detach();
+                            // Scroll to bottom
+                            let _ = cx.update(|_, _cx| {
+                                let max_offset = scroll_handle.max_offset();
+                                scroll_handle.set_offset(point(px(0.), -max_offset.height));
+                            });
+                        })
+                        .detach();
 
-                    cx.notify();
+                        cx.notify();
+                    }
                 }
-            }
-        });
+            },
+        );
 
         self._row_subscriptions.push(sub);
         self.headers.push(new_row);
         cx.notify();
     }
 
-    fn toggle_header(&mut self, index: usize, _checked: &bool, _window: &mut Window, cx: &mut Context<Self>) {
+    fn toggle_header(
+        &mut self,
+        index: usize,
+        _checked: &bool,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         if let Some(header) = self.headers.get_mut(index) {
             // Cannot disable mandatory headers (e.g., Cache-Control)
             if !matches!(header.header_type, HeaderType::Mandatory) {
@@ -637,7 +688,10 @@ impl RequestEditor {
             self.headers.remove(index);
 
             // Check if there are any custom headers left
-            let has_custom_headers = self.headers.iter().any(|h| matches!(h.header_type, HeaderType::Custom));
+            let has_custom_headers = self
+                .headers
+                .iter()
+                .any(|h| matches!(h.header_type, HeaderType::Custom));
 
             // If no custom headers remain, add an empty one
             if !has_custom_headers {
@@ -666,7 +720,12 @@ impl RequestEditor {
     }
 
     /// Update Content-Type header to match body type
-    fn update_content_type_from_body(&mut self, content_type: &Option<String>, window: &mut Window, cx: &mut Context<Self>) {
+    fn update_content_type_from_body(
+        &mut self,
+        content_type: &Option<String>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         // Find Content-Type header and update it
         let new_value = content_type.clone().unwrap_or_default();
         for header in &mut self.headers {
@@ -706,6 +765,7 @@ impl RequestEditor {
     /// Used by the focus-gated `parse_url_to_params` wrapper (live URL edits) and
     /// directly by `load_request`, where the URL is set programmatically and never
     /// holds focus — so it must populate params unconditionally.
+    #[cfg_attr(feature = "profile", profiling::function)]
     fn rebuild_params_from_url(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let url_str = self.url_input.read(cx).value().to_string();
         let new_params = url_params::parse_query_params(&url_str);
@@ -776,12 +836,20 @@ impl RequestEditor {
         };
 
         // Subscribe to changes for syncing back to URL
-        let sub1 = cx.subscribe_in(&param_row.key_input, window, |this, _, _event: &InputEvent, window, cx| {
-            this.sync_params_to_url(window, cx);
-        });
-        let sub2 = cx.subscribe_in(&param_row.value_input, window, |this, _, _event: &InputEvent, window, cx| {
-            this.sync_params_to_url(window, cx);
-        });
+        let sub1 = cx.subscribe_in(
+            &param_row.key_input,
+            window,
+            |this, _, _event: &InputEvent, window, cx| {
+                this.sync_params_to_url(window, cx);
+            },
+        );
+        let sub2 = cx.subscribe_in(
+            &param_row.value_input,
+            window,
+            |this, _, _event: &InputEvent, window, cx| {
+                this.sync_params_to_url(window, cx);
+            },
+        );
 
         self._row_subscriptions.push(sub1);
         self._row_subscriptions.push(sub2);
@@ -813,6 +881,7 @@ impl RequestEditor {
     /// and directly by button callbacks (toggle/remove), where no text input holds
     /// focus. The resulting `set_value` emits InputEvent::Change, but the URL input
     /// is not focused, so `parse_url_to_params` short-circuits — no loop.
+    #[cfg_attr(feature = "profile", profiling::function)]
     fn rebuild_url_from_params(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let current_url = self.url_input.read(cx).value().to_string();
         let new_url = self.rebuild_url_with_params(&current_url, cx);
@@ -831,13 +900,16 @@ impl RequestEditor {
         let base = url_params::extract_base_url(url_str);
 
         // Collect params as QueryParam structs
-        let params: Vec<QueryParam> = self.params
+        let params: Vec<QueryParam> = self
+            .params
             .iter()
-            .map(|p| QueryParam::new(
-                p.key_input.read(cx).value().to_string(),
-                p.value_input.read(cx).value().to_string(),
-                p.enabled,
-            ))
+            .map(|p| {
+                QueryParam::new(
+                    p.key_input.read(cx).value().to_string(),
+                    p.value_input.read(cx).value().to_string(),
+                    p.enabled,
+                )
+            })
             .collect();
 
         // Build URL using pure function
@@ -858,54 +930,66 @@ impl RequestEditor {
         // Subscribe to key input change for auto-add
         let key_input = new_row.key_input.clone();
         let key_input_for_closure = key_input.clone();
-        let sub_key = cx.subscribe_in(&key_input, window, move |this, _, _event: &InputEvent, window, cx| {
-            // Sync to URL
-            this.sync_params_to_url(window, cx);
+        let sub_key = cx.subscribe_in(
+            &key_input,
+            window,
+            move |this, _, _event: &InputEvent, window, cx| {
+                // Sync to URL
+                this.sync_params_to_url(window, cx);
 
-            // Auto-add new row if this is the last one and has content
-            if let Some(last) = this.params.last() {
-                let has_key = !last.key_input.read(cx).value().is_empty();
-                if has_key
-                    && this.params.last().map(|p| Entity::entity_id(&p.key_input)) == Some(Entity::entity_id(&key_input_for_closure))
-                {
-                    this.add_param_row(window, cx);
+                // Auto-add new row if this is the last one and has content
+                if let Some(last) = this.params.last() {
+                    let has_key = !last.key_input.read(cx).value().is_empty();
+                    if has_key
+                        && this.params.last().map(|p| Entity::entity_id(&p.key_input))
+                            == Some(Entity::entity_id(&key_input_for_closure))
+                    {
+                        this.add_param_row(window, cx);
 
-                    // Scroll to bottom
-                    let scroll_handle = this.params_scroll_handle.clone();
-                    cx.spawn_in(window, async move |_this, cx| {
-                        let mut last_offset = px(0.);
-                        let mut stable_count = 0;
+                        // Scroll to bottom
+                        let scroll_handle = this.params_scroll_handle.clone();
+                        cx.spawn_in(window, async move |_this, cx| {
+                            let mut last_offset = px(0.);
+                            let mut stable_count = 0;
 
-                        for _ in 0..20 {
-                            cx.background_executor().timer(std::time::Duration::from_millis(1)).await;
+                            for _ in 0..20 {
+                                cx.background_executor()
+                                    .timer(std::time::Duration::from_millis(1))
+                                    .await;
 
-                            let current = scroll_handle.max_offset().height;
-                            if (current - last_offset).abs() < px(0.1) {
-                                stable_count += 1;
-                                if stable_count >= 2 {
-                                    break;
+                                let current = scroll_handle.max_offset().height;
+                                if (current - last_offset).abs() < px(0.1) {
+                                    stable_count += 1;
+                                    if stable_count >= 2 {
+                                        break;
+                                    }
+                                } else {
+                                    stable_count = 0;
                                 }
-                            } else {
-                                stable_count = 0;
+                                last_offset = current;
                             }
-                            last_offset = current;
-                        }
 
-                        let _ = cx.update(|_, _cx| {
-                            let max_offset = scroll_handle.max_offset();
-                            scroll_handle.set_offset(point(px(0.), -max_offset.height));
-                        });
-                    }).detach();
+                            let _ = cx.update(|_, _cx| {
+                                let max_offset = scroll_handle.max_offset();
+                                scroll_handle.set_offset(point(px(0.), -max_offset.height));
+                            });
+                        })
+                        .detach();
 
-                    cx.notify();
+                        cx.notify();
+                    }
                 }
-            }
-        });
+            },
+        );
 
         // Subscribe to value input change for syncing
-        let sub_value = cx.subscribe_in(&new_row.value_input, window, |this, _, _event: &InputEvent, window, cx| {
-            this.sync_params_to_url(window, cx);
-        });
+        let sub_value = cx.subscribe_in(
+            &new_row.value_input,
+            window,
+            |this, _, _event: &InputEvent, window, cx| {
+                this.sync_params_to_url(window, cx);
+            },
+        );
 
         self._row_subscriptions.push(sub_key);
         self._row_subscriptions.push(sub_value);
@@ -977,7 +1061,8 @@ impl RequestEditor {
     /// is `pub(super)` in gpui-component and unreachable from this crate; the
     /// `SelectAll` action itself is public.
     pub fn focus_url(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        self.url_input.update(cx, |input, cx| input.focus(window, cx));
+        self.url_input
+            .update(cx, |input, cx| input.focus(window, cx));
         window.dispatch_action(Box::new(gpui_component::input::SelectAll), cx);
     }
 
@@ -988,7 +1073,13 @@ impl RequestEditor {
         if self.loading {
             return;
         }
-        let mut url = self.url_input.read(cx).value().to_string().trim().to_string();
+        let mut url = self
+            .url_input
+            .read(cx)
+            .value()
+            .to_string()
+            .trim()
+            .to_string();
         if url.is_empty() {
             log::warn!("Cannot send request: URL is empty");
             return;
@@ -1075,7 +1166,9 @@ impl RequestEditor {
                         row.key = crate::variables::substitute(&row.key, env);
                         row.value = match row.value {
                             crate::types::FormDataValue::Text(t) => {
-                                crate::types::FormDataValue::Text(crate::variables::substitute(&t, env))
+                                crate::types::FormDataValue::Text(crate::variables::substitute(
+                                    &t, env,
+                                ))
                             }
                             other => other, // file path left as-is
                         };
@@ -1089,7 +1182,8 @@ impl RequestEditor {
         // Resolve auth {{vars}} and compute the wire header. The saved request
         // keeps manual headers + the auth config; only the wire gets the merged
         // header set (auth wins over a manual same-name header).
-        let resolved_auth = crate::variables::substitute_auth(&self.auth_editor.read(cx).get_auth(cx), env);
+        let resolved_auth =
+            crate::variables::substitute_auth(&self.auth_editor.read(cx).get_auth(cx), env);
 
         let request = RequestData {
             method,
@@ -1118,7 +1212,9 @@ impl RequestEditor {
             let response = match inflight.wait().await {
                 Ok(r) => r,
                 Err(e) => {
-                    if e.downcast_ref::<crate::http_client::RequestCanceled>().is_some() {
+                    if e.downcast_ref::<crate::http_client::RequestCanceled>()
+                        .is_some()
+                    {
                         // cancel_request() already reset the UI and bumped the
                         // generation; nothing left to do.
                         return Ok(());
@@ -1155,10 +1251,18 @@ impl RequestEditor {
             let duration = start.elapsed();
             let status = response.status;
 
-            log::debug!("Request completed with status {} in {}ms", status, duration.as_millis());
+            log::debug!(
+                "Request completed with status {} in {}ms",
+                status,
+                duration.as_millis()
+            );
 
             let is_text = crate::types::is_text_response(&response.headers, &response.body);
-            log::debug!("Response body size: {} bytes (text={})", response.body.len(), is_text);
+            log::debug!(
+                "Response body size: {} bytes (text={})",
+                response.body.len(),
+                is_text
+            );
 
             let response_data = ResponseData {
                 status: Some(status),
@@ -1193,6 +1297,7 @@ impl EventEmitter<RequestCancelled> for RequestEditor {}
 impl EventEmitter<ToggleRequestBookmarkRequested> for RequestEditor {}
 
 impl Render for RequestEditor {
+    #[cfg_attr(feature = "profile", profiling::function)]
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
 
@@ -1557,4 +1662,3 @@ impl Render for RequestEditor {
         )
     }
 }
-

--- a/src/response_viewer.rs
+++ b/src/response_viewer.rs
@@ -1,15 +1,69 @@
 use gpui::prelude::FluentBuilder as _;
 use gpui::*;
 use gpui_component::{
-    button::*, h_flex, input::*,
+    ActiveTheme as _,
+    button::*,
+    h_flex,
+    input::*,
     menu::{ContextMenuExt as _, PopupMenuItem},
     scroll::ScrollableElement as _,
     text::{TextView, TextViewStyle},
-    v_flex, ActiveTheme as _,
+    v_flex,
 };
-use std::sync::Arc;
+use std::{collections::VecDeque, sync::Arc};
 
 use crate::types::ResponseData;
+
+const BODY_CACHE_ENTRIES: usize = 6;
+const BODY_CACHE_DISPLAY_BYTES: usize = 2 * 1024 * 1024;
+
+#[derive(Clone)]
+struct PreparedBody {
+    text: Arc<str>,
+}
+
+fn decode_response_text(body: &[u8]) -> String {
+    #[cfg(feature = "profile")]
+    let profile_data = format!("{} bytes", body.len());
+    #[cfg(feature = "profile")]
+    profiling::scope!("response utf8 decode", profile_data.as_str());
+    String::from_utf8_lossy(body).into_owned()
+}
+
+/// Prepare response text away from the UI thread.
+///
+/// Decode, parse, and pretty-print the complete response here. `InputState`
+/// virtualizes visible-line layout, but it has no incremental data-source API,
+/// so the complete prepared text is handed to it in one update.
+#[cfg_attr(feature = "profile", profiling::function)]
+fn prepare_response_body(body: &[u8]) -> PreparedBody {
+    let text = decode_response_text(body);
+    let display = if let Ok(json) = {
+        #[cfg(feature = "profile")]
+        let profile_data = format!("{} bytes", text.len());
+        #[cfg(feature = "profile")]
+        profiling::scope!("response json parse", profile_data.as_str());
+        serde_json::from_str::<serde_json::Value>(&text)
+    } {
+        #[cfg(feature = "profile")]
+        let profile_data = format!("{} bytes", text.len());
+        #[cfg(feature = "profile")]
+        profiling::scope!("response json pretty serialize", profile_data.as_str());
+        crate::code_formatter::pretty_json_4(&json).unwrap_or(text)
+    } else {
+        text
+    };
+    PreparedBody {
+        text: display.into(),
+    }
+}
+
+#[derive(Clone)]
+struct CachedBody {
+    response: Arc<ResponseData>,
+    text: Arc<str>,
+    display_bytes: usize,
+}
 
 /// Render headers as `key: value` lines — what "Copy all" puts on the clipboard.
 /// No trailing newline, so pasting into a single-line field stays clean.
@@ -102,7 +156,17 @@ pub struct ResponseViewer {
     /// Pre-built preview for image responses (constructed once per response —
     /// `Image::from_bytes` hashes the body for its asset id, too costly per frame).
     preview_image: Option<Arc<gpui::Image>>,
+    /// One editor is created with the window and reused for every response.
+    /// Creating an InputState per response makes its first syntax/layout pass a
+    /// cold path (30 ms even for 1.7 KiB in the new2 Tracy capture).
     body_display: Entity<InputState>,
+    body_ready: bool,
+    body_loading: bool,
+    body_generation: u64,
+    /// Small LRU of complete, background-prepared text. An entry larger than
+    /// the byte budget remains as the sole entry so revisiting it does not
+    /// repeat decode/parse/pretty work.
+    body_cache: VecDeque<CachedBody>,
     active_tab: usize,
     headers_scroll_handle: ScrollHandle,
 }
@@ -114,20 +178,27 @@ impl ResponseViewer {
                 .code_editor("json")
                 .line_number(true)
                 .multi_line(true)
-                .tab_size(TabSize { tab_size: 4, hard_tabs: false })
+                .tab_size(TabSize {
+                    tab_size: 4,
+                    hard_tabs: false,
+                })
         });
-
         Self {
             response: None,
             canceled: false,
             preview_image: None,
             body_display,
+            body_ready: false,
+            body_loading: false,
+            body_generation: 0,
+            body_cache: VecDeque::new(),
             active_tab: 0,
             headers_scroll_handle: ScrollHandle::new(),
         }
     }
 
     /// Set response data
+    #[cfg_attr(feature = "profile", profiling::function)]
     pub fn set_response(
         &mut self,
         response: Arc<ResponseData>,
@@ -146,25 +217,140 @@ impl ResponseViewer {
                 .and_then(|(_, v)| image_format_for_content_type(v))
                 .map(|format| Arc::new(gpui::Image::from_bytes(format, response.body.clone())))
         };
-        // Only feed the text editor for text responses; binary is shown in a
-        // dedicated panel and never decoded to (lossy) text.
-        let display = if response.is_text {
-            let text = response.body_text();
-            if let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) {
-                crate::code_formatter::pretty_json_4(&json).unwrap_or_else(|_| text.to_string())
-            } else {
-                text.to_string()
-            }
-        } else {
-            String::new()
-        };
+        self.body_generation = self.body_generation.wrapping_add(1);
+        self.body_loading = false;
+        self.body_ready = false;
+        self.response = Some(response.clone());
+        self.active_tab = 0; // Reset to Body tab
 
-        self.body_display.update(cx, |input, cx| {
-            input.set_value(&display, window, cx);
+        // Binary responses use their dedicated preview. Text response metadata
+        // is visible immediately; its expensive display representation arrives
+        // asynchronously or is restored from the prepared-state cache.
+        if response.is_text {
+            if let Some(cached) = self.take_cached_body(&response) {
+                #[cfg(feature = "profile")]
+                profiling::scope!("response body cache hit");
+                self.body_loading = true;
+                self.start_cached_body_apply(cached, window, cx);
+            } else {
+                #[cfg(feature = "profile")]
+                profiling::scope!("response body cache miss");
+                self.body_loading = true;
+                self.start_body_prepare(response, window, cx);
+            }
+        }
+        cx.notify();
+    }
+
+    fn take_cached_body(&mut self, response: &Arc<ResponseData>) -> Option<CachedBody> {
+        let index = self
+            .body_cache
+            .iter()
+            .position(|cached| Arc::ptr_eq(&cached.response, response))?;
+        self.body_cache.remove(index)
+    }
+
+    fn insert_cached_body(&mut self, cached: CachedBody) {
+        if let Some(index) = self
+            .body_cache
+            .iter()
+            .position(|entry| Arc::ptr_eq(&entry.response, &cached.response))
+        {
+            self.body_cache.remove(index);
+        }
+        self.body_cache.push_front(cached);
+
+        let mut display_bytes = self
+            .body_cache
+            .iter()
+            .map(|entry| entry.display_bytes)
+            .sum::<usize>();
+        while self.body_cache.len() > BODY_CACHE_ENTRIES
+            || (display_bytes > BODY_CACHE_DISPLAY_BYTES && self.body_cache.len() > 1)
+        {
+            if let Some(evicted) = self.body_cache.pop_back() {
+                display_bytes = display_bytes.saturating_sub(evicted.display_bytes);
+            }
+        }
+    }
+
+    fn start_cached_body_apply(
+        &mut self,
+        cached: CachedBody,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let generation = self.body_generation;
+        let response = cached.response.clone();
+        let prepared = PreparedBody {
+            text: cached.text.clone(),
+        };
+        // Keep the entry available if another tab action supersedes this
+        // scheduled UI commit before it runs.
+        self.body_cache.push_front(cached);
+        cx.spawn_in(window, async move |this, cx| {
+            this.update_in(cx, |this, window, cx| {
+                this.apply_prepared_body(response, generation, prepared, window, cx)
+            })?;
+            Ok::<_, anyhow::Error>(())
+        })
+        .detach();
+    }
+
+    fn start_body_prepare(
+        &mut self,
+        response: Arc<ResponseData>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let generation = self.body_generation;
+        let response_for_task = response.clone();
+        let task =
+            cx.background_spawn(async move { prepare_response_body(&response_for_task.body) });
+        cx.spawn_in(window, async move |this, cx| {
+            let prepared = task.await;
+            this.update_in(cx, |this, window, cx| {
+                this.apply_prepared_body(response, generation, prepared, window, cx)
+            })?;
+            Ok::<_, anyhow::Error>(())
+        })
+        .detach();
+    }
+
+    fn apply_prepared_body(
+        &mut self,
+        response: Arc<ResponseData>,
+        generation: u64,
+        prepared: PreparedBody,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let display_bytes = prepared.text.len();
+        self.insert_cached_body(CachedBody {
+            response: response.clone(),
+            text: prepared.text.clone(),
+            display_bytes,
         });
 
-        self.response = Some(response);
-        self.active_tab = 0; // Reset to Body tab
+        let is_current = self.body_generation == generation
+            && self
+                .response
+                .as_ref()
+                .is_some_and(|current| Arc::ptr_eq(current, &response));
+        if !is_current {
+            return;
+        }
+
+        let display_text = prepared.text.clone();
+        self.body_display.update(cx, move |input, cx| {
+            #[cfg(feature = "profile")]
+            let profile_data = format!("{} bytes", display_bytes);
+            #[cfg(feature = "profile")]
+            profiling::scope!("response InputState::set_value", profile_data.as_str());
+            input.set_value(display_text.clone(), window, cx);
+        });
+        self.body_ready = true;
+        self.body_loading = false;
         cx.notify();
     }
 
@@ -174,13 +360,13 @@ impl ResponseViewer {
     }
 
     /// Clear response data
-    pub fn clear_response(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    pub fn clear_response(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
         self.canceled = false;
+        self.body_generation = self.body_generation.wrapping_add(1);
         self.response = None;
         self.preview_image = None;
-        self.body_display.update(cx, |input, cx| {
-            input.set_value("", window, cx);
-        });
+        self.body_ready = false;
+        self.body_loading = false;
         self.active_tab = 0;
         cx.notify();
     }
@@ -193,7 +379,12 @@ impl ResponseViewer {
     }
 
     /// Save the (binary) response body to a file chosen via the OS dialog.
-    fn save_binary(&mut self, _event: &gpui::ClickEvent, window: &mut Window, cx: &mut Context<Self>) {
+    fn save_binary(
+        &mut self,
+        _event: &gpui::ClickEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         let Some(response) = self.response.clone() else {
             return;
         };
@@ -202,7 +393,13 @@ impl ResponseViewer {
             .headers
             .iter()
             .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
-            .map(|(_, v)| v.split(';').next().unwrap_or("").trim().to_ascii_lowercase())
+            .map(|(_, v)| {
+                v.split(';')
+                    .next()
+                    .unwrap_or("")
+                    .trim()
+                    .to_ascii_lowercase()
+            })
             .and_then(|ct| extension_for_content_type(&ct))
             .map(|ext| format!("response.{}", ext))
             .unwrap_or_else(|| "response.bin".to_string());
@@ -210,11 +407,14 @@ impl ResponseViewer {
             .or_else(dirs::home_dir)
             .unwrap_or_else(|| std::path::PathBuf::from("."));
         let rx = cx.prompt_for_new_path(&dir, Some(&suggested));
-        cx.spawn_in(window, async move |_this, _cx| {
-            if let Ok(Ok(Some(path))) = rx.await
-                && let Err(e) = std::fs::write(&path, &response.body)
-            {
-                log::error!("Failed to save response to {:?}: {}", path, e);
+        cx.spawn_in(window, async move |_this, cx| {
+            if let Ok(Ok(Some(path))) = rx.await {
+                let path_for_log = path.clone();
+                let write =
+                    cx.background_spawn(async move { std::fs::write(&path, &response.body) });
+                if let Err(error) = write.await {
+                    log::error!("Failed to save response to {:?}: {}", path_for_log, error);
+                }
             }
         })
         .detach();
@@ -260,17 +460,15 @@ impl ResponseViewer {
                         .text_color(status_color)
                         .child(status_text),
                 )
-                .child(
-                    div()
-                        .text_sm()
-                        .child(format!("Time: {}", crate::format::format_duration_ms(response.duration_ms))),
-                )
+                .child(div().text_sm().child(format!(
+                    "Time: {}",
+                    crate::format::format_duration_ms(response.duration_ms)
+                )))
                 .when(!response.is_network_error(), |this| {
-                    this.child(
-                        div()
-                            .text_sm()
-                            .child(format!("Size: {}", crate::format::format_size(response.body.len()))),
-                    )
+                    this.child(div().text_sm().child(format!(
+                        "Size: {}",
+                        crate::format::format_size(response.body.len())
+                    )))
                 })
         } else {
             h_flex()
@@ -279,7 +477,11 @@ impl ResponseViewer {
                 .border_b_1()
                 .border_color(cx.theme().border)
                 .text_color(cx.theme().muted_foreground)
-                .child(if self.canceled { "Request canceled" } else { "No response yet" })
+                .child(if self.canceled {
+                    "Request canceled"
+                } else {
+                    "No response yet"
+                })
         }
     }
 
@@ -339,6 +541,7 @@ impl ResponseViewer {
 }
 
 impl Render for ResponseViewer {
+    #[cfg_attr(feature = "profile", profiling::function)]
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         // Built before `theme` borrows cx immutably -- TextView needs &mut App.
         // Only while the tab is showing, so the HTML is not parsed for nothing.
@@ -411,27 +614,49 @@ impl Render for ResponseViewer {
                         .when(self.active_tab == 0, |this| {
                             let resp_is_text = self.response.as_ref().is_none_or(|r| r.is_text);
                             if resp_is_text {
-                                let is_error = self
-                                    .response
-                                    .as_ref()
-                                    .is_some_and(|r| r.is_network_error());
+                                let is_error =
+                                    self.response.as_ref().is_some_and(|r| r.is_network_error());
+                                let body_display = self.body_display.clone();
+                                let has_body_display = self.body_ready;
+                                let body_loading = self.body_loading;
                                 this.child(
-                                    div()
+                                    v_flex()
                                         .flex()
                                         .flex_col()
                                         .flex_1()
+                                        .min_h_0()
                                         .w_full()
                                         .rounded(theme.radius_lg)
                                         .border_1()
                                         .border_color(theme.border)
                                         .bg(theme.popover)
-                                        .child(
-                                            Input::new(&self.body_display)
-                                                .disabled(is_error)
-                                                .rounded(theme.radius_lg)
-                                                .w_full()
-                                                .h_full(),
-                                        ),
+                                        .when(has_body_display, |this| {
+                                            this.child(
+                                                div().flex_1().min_h_0().w_full().child(
+                                                    Input::new(&body_display)
+                                                        .disabled(is_error)
+                                                        .rounded(theme.radius_lg)
+                                                        .w_full()
+                                                        .h_full(),
+                                                ),
+                                            )
+                                        })
+                                        .when(!has_body_display, |this| {
+                                            this.child(
+                                                div()
+                                                    .flex_1()
+                                                    .flex()
+                                                    .items_center()
+                                                    .justify_center()
+                                                    .text_sm()
+                                                    .text_color(theme.muted_foreground)
+                                                    .child(if body_loading {
+                                                        "Preparing response…"
+                                                    } else {
+                                                        "No response body"
+                                                    }),
+                                            )
+                                        }),
                                 )
                             } else {
                                 // Binary response: don't decode to lossy text — show info + Save.
@@ -444,7 +669,9 @@ impl Render for ResponseViewer {
                                             .iter()
                                             .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
                                             .map(|(_, v)| v.clone())
-                                            .unwrap_or_else(|| "application/octet-stream".to_string());
+                                            .unwrap_or_else(|| {
+                                                "application/octet-stream".to_string()
+                                            });
                                         (ct, r.body.len())
                                     })
                                     .unwrap_or_else(|| ("application/octet-stream".to_string(), 0));
@@ -538,18 +765,81 @@ mod tests {
     use super::headers_to_html;
     use super::headers_to_text;
     use super::image_format_for_content_type;
+    use super::prepare_response_body;
     use gpui::ImageFormat;
 
     #[test]
+    fn prepares_small_json_with_pretty_indentation() {
+        let prepared = prepare_response_body(br#"{"a":1}"#);
+        assert_eq!(prepared.text.as_ref(), "{\n    \"a\": 1\n}");
+    }
+
+    #[test]
+    fn preserves_non_json_text() {
+        let prepared = prepare_response_body(b"plain text");
+        assert_eq!(prepared.text.as_ref(), "plain text");
+    }
+
+    #[test]
+    fn preserves_complete_large_non_json_body() {
+        let body = vec![b'x'; 128 * 1024 + 1];
+        let prepared = prepare_response_body(&body);
+        assert_eq!(prepared.text.len(), body.len());
+        assert_eq!(prepared.text.as_bytes(), body.as_slice());
+    }
+
+    #[test]
+    fn formats_complete_large_minified_json() {
+        let item_count = 75_000;
+        let body = format!("[{}]", vec!["0"; item_count].join(","));
+        let prepared = prepare_response_body(body.as_bytes());
+        assert!(prepared.text.starts_with("[\n"));
+        assert!(prepared.text.ends_with("\n]"));
+        assert_eq!(
+            prepared
+                .text
+                .lines()
+                .filter(|line| line.trim() == "0,")
+                .count(),
+            item_count - 1
+        );
+        assert!(prepared.text.len() > body.len());
+    }
+
+    #[test]
     fn maps_supported_image_content_types() {
-        assert_eq!(image_format_for_content_type("image/png"), Some(ImageFormat::Png));
-        assert_eq!(image_format_for_content_type("image/jpeg"), Some(ImageFormat::Jpeg));
-        assert_eq!(image_format_for_content_type("image/jpg"), Some(ImageFormat::Jpeg));
-        assert_eq!(image_format_for_content_type("image/webp"), Some(ImageFormat::Webp));
-        assert_eq!(image_format_for_content_type("image/gif"), Some(ImageFormat::Gif));
-        assert_eq!(image_format_for_content_type("image/svg+xml"), Some(ImageFormat::Svg));
-        assert_eq!(image_format_for_content_type("image/bmp"), Some(ImageFormat::Bmp));
-        assert_eq!(image_format_for_content_type("image/tiff"), Some(ImageFormat::Tiff));
+        assert_eq!(
+            image_format_for_content_type("image/png"),
+            Some(ImageFormat::Png)
+        );
+        assert_eq!(
+            image_format_for_content_type("image/jpeg"),
+            Some(ImageFormat::Jpeg)
+        );
+        assert_eq!(
+            image_format_for_content_type("image/jpg"),
+            Some(ImageFormat::Jpeg)
+        );
+        assert_eq!(
+            image_format_for_content_type("image/webp"),
+            Some(ImageFormat::Webp)
+        );
+        assert_eq!(
+            image_format_for_content_type("image/gif"),
+            Some(ImageFormat::Gif)
+        );
+        assert_eq!(
+            image_format_for_content_type("image/svg+xml"),
+            Some(ImageFormat::Svg)
+        );
+        assert_eq!(
+            image_format_for_content_type("image/bmp"),
+            Some(ImageFormat::Bmp)
+        );
+        assert_eq!(
+            image_format_for_content_type("image/tiff"),
+            Some(ImageFormat::Tiff)
+        );
     }
 
     #[test]
@@ -558,7 +848,10 @@ mod tests {
             image_format_for_content_type("Image/PNG; charset=binary"),
             Some(ImageFormat::Png)
         );
-        assert_eq!(image_format_for_content_type("  image/gif ; foo=bar"), Some(ImageFormat::Gif));
+        assert_eq!(
+            image_format_for_content_type("  image/gif ; foo=bar"),
+            Some(ImageFormat::Gif)
+        );
     }
 
     #[test]
@@ -572,7 +865,10 @@ mod tests {
     // ===== headers_to_text ("Copy all") =====
 
     fn hs(pairs: &[(&str, &str)]) -> Vec<(String, String)> {
-        pairs.iter().map(|(k, v)| (k.to_string(), v.to_string())).collect()
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
     }
 
     #[test]
@@ -596,7 +892,10 @@ mod tests {
 
     #[test]
     fn single_header_has_no_newline() {
-        assert_eq!(headers_to_text(&hs(&[("date", "Mon, 20 Jul 2026")])), "date: Mon, 20 Jul 2026");
+        assert_eq!(
+            headers_to_text(&hs(&[("date", "Mon, 20 Jul 2026")])),
+            "date: Mon, 20 Jul 2026"
+        );
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,4 +1,4 @@
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -150,7 +150,7 @@ impl RawSubtype {
     pub fn as_str(&self) -> &'static str {
         match self {
             RawSubtype::Json => "json",
-            RawSubtype::Xml => "plain",  // XML not supported, fallback to plain
+            RawSubtype::Xml => "plain", // XML not supported, fallback to plain
             RawSubtype::Text => "plain",
             RawSubtype::JavaScript => "javascript",
             RawSubtype::UrlEncoded => "plain",
@@ -254,14 +254,18 @@ impl AuthConfig {
                 if self.bearer_token.is_empty() {
                     None
                 } else {
-                    Some(("Authorization".to_string(), format!("Bearer {}", self.bearer_token)))
+                    Some((
+                        "Authorization".to_string(),
+                        format!("Bearer {}", self.bearer_token),
+                    ))
                 }
             }
             AuthType::Basic => {
                 if self.basic_username.is_empty() && self.basic_password.is_empty() {
                     None
                 } else {
-                    let encoded = BASE64.encode(format!("{}:{}", self.basic_username, self.basic_password));
+                    let encoded =
+                        BASE64.encode(format!("{}:{}", self.basic_username, self.basic_password));
                     Some(("Authorization".to_string(), format!("Basic {}", encoded)))
                 }
             }
@@ -345,7 +349,13 @@ pub fn is_text_response(headers: &[(String, String)], body: &[u8]) -> bool {
     let content_type = headers
         .iter()
         .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
-        .map(|(_, v)| v.split(';').next().unwrap_or("").trim().to_ascii_lowercase());
+        .map(|(_, v)| {
+            v.split(';')
+                .next()
+                .unwrap_or("")
+                .trim()
+                .to_ascii_lowercase()
+        });
 
     if let Some(ct) = content_type.as_deref() {
         // Clearly text
@@ -379,11 +389,6 @@ pub fn is_text_response(headers: &[(String, String)], body: &[u8]) -> bool {
 }
 
 impl ResponseData {
-    /// Lossy text view of the body (for display when `is_text`).
-    pub fn body_text(&self) -> std::borrow::Cow<'_, str> {
-        String::from_utf8_lossy(&self.body)
-    }
-
     pub fn status_text(&self) -> &'static str {
         match self.status {
             Some(200) => "OK",
@@ -544,7 +549,10 @@ mod tests {
     #[test]
     fn binary_content_types_are_binary() {
         assert!(!is_text_response(&h("image/png"), &[0x89, 0x50]));
-        assert!(!is_text_response(&h("application/octet-stream"), &[0, 1, 2]));
+        assert!(!is_text_response(
+            &h("application/octet-stream"),
+            &[0, 1, 2]
+        ));
         assert!(!is_text_response(&h("application/pdf"), b"%PDF"));
         assert!(!is_text_response(&h("application/zip"), &[0x50, 0x4b]));
     }
@@ -562,20 +570,37 @@ mod tests {
     fn compute_header_none_and_empty_fields_emit_nothing() {
         assert_eq!(AuthConfig::default().compute_header(), None);
         // Bearer with empty token → nothing (don't send a dangling "Bearer ")
-        let a = AuthConfig { auth_type: AuthType::Bearer, ..Default::default() };
+        let a = AuthConfig {
+            auth_type: AuthType::Bearer,
+            ..Default::default()
+        };
         assert_eq!(a.compute_header(), None);
         // Basic with both fields empty → nothing
-        let a = AuthConfig { auth_type: AuthType::Basic, ..Default::default() };
+        let a = AuthConfig {
+            auth_type: AuthType::Basic,
+            ..Default::default()
+        };
         assert_eq!(a.compute_header(), None);
         // ApiKey with empty name → nothing
-        let a = AuthConfig { auth_type: AuthType::ApiKey, api_key_value: "v".into(), ..Default::default() };
+        let a = AuthConfig {
+            auth_type: AuthType::ApiKey,
+            api_key_value: "v".into(),
+            ..Default::default()
+        };
         assert_eq!(a.compute_header(), None);
     }
 
     #[test]
     fn compute_header_bearer() {
-        let a = AuthConfig { auth_type: AuthType::Bearer, bearer_token: "t0ken".into(), ..Default::default() };
-        assert_eq!(a.compute_header(), Some(("Authorization".into(), "Bearer t0ken".into())));
+        let a = AuthConfig {
+            auth_type: AuthType::Bearer,
+            bearer_token: "t0ken".into(),
+            ..Default::default()
+        };
+        assert_eq!(
+            a.compute_header(),
+            Some(("Authorization".into(), "Bearer t0ken".into()))
+        );
     }
 
     #[test]
@@ -587,14 +612,24 @@ mod tests {
             ..Default::default()
         };
         // base64("user:pass") == "dXNlcjpwYXNz"
-        assert_eq!(a.compute_header(), Some(("Authorization".into(), "Basic dXNlcjpwYXNz".into())));
+        assert_eq!(
+            a.compute_header(),
+            Some(("Authorization".into(), "Basic dXNlcjpwYXNz".into()))
+        );
     }
 
     #[test]
     fn compute_header_basic_username_only() {
-        let a = AuthConfig { auth_type: AuthType::Basic, basic_username: "user".into(), ..Default::default() };
+        let a = AuthConfig {
+            auth_type: AuthType::Basic,
+            basic_username: "user".into(),
+            ..Default::default()
+        };
         // base64("user:") == "dXNlcjo="
-        assert_eq!(a.compute_header(), Some(("Authorization".into(), "Basic dXNlcjo=".into())));
+        assert_eq!(
+            a.compute_header(),
+            Some(("Authorization".into(), "Basic dXNlcjo=".into()))
+        );
     }
 
     #[test]
@@ -605,7 +640,10 @@ mod tests {
             api_key_value: "secret".into(),
             ..Default::default()
         };
-        assert_eq!(a.compute_header(), Some(("X-API-Key".into(), "secret".into())));
+        assert_eq!(
+            a.compute_header(),
+            Some(("X-API-Key".into(), "secret".into()))
+        );
     }
 
     #[test]
@@ -618,7 +656,11 @@ mod tests {
     #[test]
     fn effective_headers_appends_auth() {
         let manual = vec![("Accept".to_string(), "*/*".to_string())];
-        let auth = AuthConfig { auth_type: AuthType::Bearer, bearer_token: "t".into(), ..Default::default() };
+        let auth = AuthConfig {
+            auth_type: AuthType::Bearer,
+            bearer_token: "t".into(),
+            ..Default::default()
+        };
         let out = effective_wire_headers(&manual, &auth);
         assert_eq!(
             out,
@@ -636,7 +678,11 @@ mod tests {
             ("Accept".to_string(), "*/*".to_string()),
             ("authorization".to_string(), "Bearer OLD".to_string()),
         ];
-        let auth = AuthConfig { auth_type: AuthType::Bearer, bearer_token: "NEW".into(), ..Default::default() };
+        let auth = AuthConfig {
+            auth_type: AuthType::Bearer,
+            bearer_token: "NEW".into(),
+            ..Default::default()
+        };
         let out = effective_wire_headers(&manual, &auth);
         assert_eq!(
             out,


### PR DESCRIPTION
## Summary

- add an opt-in Tracy feature and optimized profiling build profile
- move startup loading, history persistence, collection refreshes, and environment persistence off the GPUI thread
- guard Database::call against blocking waits from the registered UI thread
- decode, parse, and pretty-print complete response bodies in the background
- keep the shared response InputState on JSON syntax highlighting and display the complete formatted body without truncation or a Load full body flow
- cache prepared response text and discard stale asynchronous UI results

## InputState investigation

The component virtualizes layout and painting to visible lines, but its Rope and tree-sitter highlighter still require the complete text. It has no public scroll-driven data-source API, so this keeps the complete formatted body in InputState as the intended fallback.

## Verification

- cargo.exe test: 190 passed
- cargo.exe build --profile profiling --features profile
- git diff --check
- verified the profiling executable contains response JSON parse/pretty and InputState set_value spans
- verified the executable contains neither Load full body nor Large response preview