### PR TITLE
fix: bind in-flight requests to originating tabs

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -22,7 +22,7 @@ use crate::environment_manager::{
 };
 use crate::history_panel::{HistoryItemClicked, HistoryPanel};
 use crate::request_editor::{
-    OpenCodeSnippet, RequestCancelled, RequestCompleted, RequestEditor,
+    OpenCodeSnippet, RequestCancelled, RequestCompleted, RequestEditor, RequestStarted,
     ToggleRequestBookmarkRequested,
 };
 use crate::request_tab::RequestTab;
@@ -152,10 +152,35 @@ impl PoopmanApp {
         let next_tab_id = 1;
         let sidebar_view = SidebarView::Collections;
 
+        // Capture stable ownership and the immutable editor snapshot before the
+        // asynchronous request can complete.
+        let request_started_sub = cx.subscribe_in(
+            &request_editor,
+            window,
+            move |this, _, event: &RequestStarted, window, cx| {
+                let Some(tab_index) = this
+                    .request_tabs
+                    .iter()
+                    .position(|tab| tab.id == event.tab_id)
+                else {
+                    return;
+                };
+                this.request_tabs[tab_index]
+                    .begin_request(event.request_id, event.request.clone());
+                if tab_index == this.active_tab_index
+                    && this.response_viewer.read(cx).is_canceled()
+                {
+                    this.response_viewer.update(cx, |viewer, cx| {
+                        viewer.clear_response(window, cx);
+                    });
+                }
+                this.update_tab_bar(cx);
+            },
+        );
+
         // Subscribe to request completion events
         let db_clone = db.clone();
         let history_panel_clone = history_panel.clone();
-        let response_viewer_clone = response_viewer.clone();
         let request_sub = cx.subscribe_in(
             &request_editor,
             window,
@@ -163,22 +188,27 @@ impl PoopmanApp {
                 #[cfg(feature = "profile")]
                 profiling::scope!("handle request completed");
 
-                // Paint the response first. Persistence is intentionally not on
-                // this callback's critical path: Telegram-style UI work submits
-                // storage work and receives completion back on the main loop.
-                response_viewer_clone.update(cx, |viewer, cx| {
-                    viewer.set_response(event.response.clone(), window, cx);
-                });
-
-                // Keep the editor's unresolved request in the tab. The event
-                // request is the wire form (environment variables substituted),
-                // which must not overwrite a saved `{{variable}}` expression.
-                if let Some(tab) = this.request_tabs.get_mut(this.active_tab_index) {
-                    tab.request = this.request_editor.read(cx).get_current_request_data(cx);
-                    tab.response = Some(event.response.clone());
-                    tab.update_title_from_saved_name();
-                    this.update_tab_bar(cx);
+                let Some(tab_index) = this
+                    .request_tabs
+                    .iter()
+                    .position(|tab| tab.id == event.tab_id)
+                else {
+                    return;
+                };
+                if !this.request_tabs[tab_index]
+                    .complete_request(event.request_id, event.response.clone())
+                {
+                    return;
                 }
+
+                // The response is stored on its originating tab. Paint the
+                // shared viewer only if that tab is still active.
+                if tab_index == this.active_tab_index {
+                    this.response_viewer.update(cx, |viewer, cx| {
+                        viewer.set_response(event.response.clone(), window, cx);
+                    });
+                }
+                this.update_tab_bar(cx);
 
                 // Postman behavior: every send is logged to History, including a
                 // re-send of a request opened from history. Database::call is
@@ -306,14 +336,25 @@ impl PoopmanApp {
 
         // Show the canceled notice when the user aborts an in-flight request.
         // Canceled requests are never written to history (same as Postman).
-        let response_viewer_for_cancel = response_viewer.clone();
         let cancel_sub = cx.subscribe_in(
             &request_editor,
             window,
-            move |_this, _, _e: &RequestCancelled, window, cx| {
-                response_viewer_for_cancel.update(cx, |viewer, cx| {
-                    viewer.show_canceled(window, cx);
-                });
+            move |this, _, event: &RequestCancelled, window, cx| {
+                let Some(tab_index) = this
+                    .request_tabs
+                    .iter()
+                    .position(|tab| tab.id == event.tab_id)
+                else {
+                    return;
+                };
+                if !this.request_tabs[tab_index].cancel_request(event.request_id) {
+                    return;
+                }
+                if tab_index == this.active_tab_index {
+                    this.response_viewer.update(cx, |viewer, cx| {
+                        viewer.show_canceled(window, cx);
+                    });
+                }
             },
         );
 
@@ -356,6 +397,7 @@ impl PoopmanApp {
             code_panel,
             collections_reconcile_generation: 0,
             _subscriptions: vec![
+                request_started_sub,
                 request_sub,
                 history_sub,
                 collections_sub,
@@ -480,9 +522,11 @@ impl PoopmanApp {
             let params_state = self.request_editor.read(cx).get_params_state(cx);
             let headers_state = self.request_editor.read(cx).get_headers_state(cx);
             let response = self.response_viewer.read(cx).get_response();
+            let response_canceled = self.response_viewer.read(cx).is_canceled();
 
             tab.request = request_data;
             tab.response = response;
+            tab.response_canceled = response_canceled;
             tab.params_state = Some(params_state);
             tab.headers_state = Some(headers_state);
             tab.update_title_from_saved_name();
@@ -506,14 +550,7 @@ impl PoopmanApp {
         if let Some(tab) = self.request_tabs.get(index).cloned() {
             self.load_tab_into_editor(&tab, window, cx);
 
-            // Load response data
-            self.response_viewer.update(cx, |viewer, cx| {
-                if let Some(response) = &tab.response {
-                    viewer.set_response(response.clone(), window, cx);
-                } else {
-                    viewer.clear_response(window, cx);
-                }
-            });
+            self.load_tab_response(&tab, window, cx);
         }
 
         self.update_tab_bar(cx);
@@ -545,6 +582,15 @@ impl PoopmanApp {
 
     /// Close a tab
     fn close_tab(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(closing_tab_id) = self.request_tabs.get(index).map(|tab| tab.id) else {
+            return;
+        };
+        // Explicit policy: closing a tab aborts its in-flight request. The
+        // editor removes ownership first, so its eventual task result is ignored.
+        self.request_editor.update(cx, |editor, cx| {
+            editor.close_request_tab(closing_tab_id, cx);
+        });
+
         if self.request_tabs.len() <= 1 {
             // Don't close the last tab, just reset it to empty
             self.request_tabs[0] = RequestTab::new_empty(self.next_tab_id);
@@ -580,14 +626,7 @@ impl PoopmanApp {
             if let Some(tab) = self.request_tabs.get(self.active_tab_index).cloned() {
                 self.load_tab_into_editor(&tab, window, cx);
 
-                // Load response for the new active tab
-                self.response_viewer.update(cx, |viewer, cx| {
-                    if let Some(response) = &tab.response {
-                        viewer.set_response(response.clone(), window, cx);
-                    } else {
-                        viewer.clear_response(window, cx);
-                    }
-                });
+                self.load_tab_response(&tab, window, cx);
             }
         }
 
@@ -703,6 +742,7 @@ impl PoopmanApp {
         cx: &mut Context<Self>,
     ) {
         self.request_editor.update(cx, |editor, cx| {
+            editor.set_active_request_tab(tab.id, cx);
             editor.load_request(&tab.request, window, cx);
             editor.set_is_saved_request(tab.saved_request_id.is_some(), cx);
             if let Some(params_state) = &tab.params_state
@@ -714,6 +754,23 @@ impl PoopmanApp {
                 && !headers_state.is_empty()
             {
                 editor.load_headers_state(headers_state, window, cx);
+            }
+        });
+    }
+
+    fn load_tab_response(
+        &mut self,
+        tab: &RequestTab,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.response_viewer.update(cx, |viewer, cx| {
+            if tab.response_canceled {
+                viewer.show_canceled(window, cx);
+            } else if let Some(response) = &tab.response {
+                viewer.set_response(response.clone(), window, cx);
+            } else {
+                viewer.clear_response(window, cx);
             }
         });
     }
@@ -1084,6 +1141,7 @@ impl PoopmanApp {
     fn update_tab_bar(&mut self, cx: &mut Context<Self>) {
         self.tab_bar.update(cx, |tab_bar, cx| {
             tab_bar.update_tabs(self.request_tabs.clone(), self.active_tab_index, cx);
+            cx.notify();
         });
     }
 }

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -14,10 +14,22 @@ use crate::theme::METHOD_SELECT_WIDTH;
 use crate::types::{HeaderType, HttpMethod, PredefinedHeader, RequestData, ResponseData};
 use crate::url_params::{self, QueryParam};
 
+/// Event emitted synchronously when a tab starts a request.
+#[derive(Clone)]
+pub struct RequestStarted {
+    pub tab_id: usize,
+    pub request_id: u64,
+    /// Immutable, unresolved editor snapshot captured at send time.
+    pub request: RequestData,
+}
+
 /// Event emitted when a request is sent and response is received.
 /// The response is `Arc`-shared so subscribers can store it without copying the body.
 #[derive(Clone)]
 pub struct RequestCompleted {
+    pub tab_id: usize,
+    pub request_id: u64,
+    /// Immutable resolved snapshot of the request that went over the wire.
     pub request: RequestData,
     pub response: std::sync::Arc<ResponseData>,
 }
@@ -28,7 +40,15 @@ pub struct OpenCodeSnippet;
 
 /// Event emitted when the user cancels an in-flight request.
 #[derive(Clone)]
-pub struct RequestCancelled;
+pub struct RequestCancelled {
+    pub tab_id: usize,
+    pub request_id: u64,
+}
+
+struct InFlightRequest {
+    request_id: u64,
+    abort_handle: tokio::task::AbortHandle,
+}
 
 /// Emitted when the user toggles the current request's collection bookmark.
 /// The app saves an unbookmarked request or removes an existing bookmark.
@@ -89,13 +109,12 @@ pub struct RequestEditor {
     params: Vec<ParamRow>,
     params_scroll_handle: ScrollHandle,
     active_tab: usize,
-    loading: bool,
-    /// Abort handle for the in-flight request (Some only while loading).
-    abort_handle: Option<tokio::task::AbortHandle>,
-    /// Incremented on every send *and* cancel; spawned tasks capture their
-    /// generation and bail out if it no longer matches, so a stale task can
-    /// never clobber state owned by a newer send.
-    send_generation: u64,
+    /// Stable id of the request tab currently displayed by this shared editor.
+    active_request_tab_id: usize,
+    /// Runtime request ownership is keyed by tab, allowing different tabs to
+    /// run concurrently without sharing loading or cancellation state.
+    in_flight: std::collections::HashMap<usize, InFlightRequest>,
+    next_request_id: u64,
     _subscriptions: Vec<Subscription>, // Permanent: URL input + body editor subscriptions
     _row_subscriptions: Vec<Subscription>, // Header/param row subscriptions; rebuilt on load
     /// Active environment variables, pushed by PoopmanApp; used at send time.
@@ -141,9 +160,9 @@ impl RequestEditor {
             params: vec![],
             params_scroll_handle: ScrollHandle::new(),
             active_tab: 0,
-            loading: false,
-            abort_handle: None,
-            send_generation: 0,
+            active_request_tab_id: 0,
+            in_flight: std::collections::HashMap::new(),
+            next_request_id: 1,
             _subscriptions: vec![],
             _row_subscriptions: vec![],
             env_vars: std::collections::HashMap::new(),
@@ -192,6 +211,27 @@ impl RequestEditor {
             self.is_saved_request = is_saved;
             cx.notify();
         }
+    }
+
+    /// Point the shared editor at a stable request-tab identity.
+    pub fn set_active_request_tab(&mut self, tab_id: usize, cx: &mut Context<Self>) {
+        if self.active_request_tab_id != tab_id {
+            self.active_request_tab_id = tab_id;
+            cx.notify();
+        }
+    }
+
+    /// Closing a tab explicitly aborts its request and drops ownership. No
+    /// cancellation event is emitted because the destination no longer exists.
+    pub fn close_request_tab(&mut self, tab_id: usize, cx: &mut Context<Self>) {
+        if let Some(in_flight) = self.in_flight.remove(&tab_id) {
+            in_flight.abort_handle.abort();
+            cx.notify();
+        }
+    }
+
+    fn active_tab_is_loading(&self) -> bool {
+        self.in_flight.contains_key(&self.active_request_tab_id)
     }
 
     /// Initialize all predefined headers
@@ -1035,13 +1075,15 @@ impl RequestEditor {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if let Some(handle) = self.abort_handle.take() {
-            handle.abort();
-        }
-        // Invalidate the spawned task so its completion can't touch state.
-        self.send_generation = self.send_generation.wrapping_add(1);
-        self.loading = false;
-        cx.emit(RequestCancelled);
+        let tab_id = self.active_request_tab_id;
+        let Some(in_flight) = self.in_flight.remove(&tab_id) else {
+            return;
+        };
+        in_flight.abort_handle.abort();
+        cx.emit(RequestCancelled {
+            tab_id,
+            request_id: in_flight.request_id,
+        });
         cx.notify();
     }
 
@@ -1070,7 +1112,7 @@ impl RequestEditor {
     /// it from PoopmanApp; no-op while a request is already in flight (the
     /// button is swapped to Cancel then, but the keyboard path isn't).
     pub fn send(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if self.loading {
+        if self.active_tab_is_loading() {
             return;
         }
         let mut url = self
@@ -1105,6 +1147,7 @@ impl RequestEditor {
 
         // Update Content-Length before sending
         self.update_content_length(window, cx);
+        let editor_request_snapshot = self.get_current_request_data(cx);
 
         // Get selected method
         let method_index = self
@@ -1193,9 +1236,12 @@ impl RequestEditor {
             auth: resolved_auth.clone(),
         };
 
-        self.send_generation = self.send_generation.wrapping_add(1);
-        let generation = self.send_generation;
-        self.loading = true;
+        let tab_id = self.active_request_tab_id;
+        let request_id = self.next_request_id;
+        self.next_request_id = self
+            .next_request_id
+            .checked_add(1)
+            .expect("request id space exhausted");
 
         log::debug!("Starting {} request to: {}", method.as_str(), url);
 
@@ -1205,7 +1251,18 @@ impl RequestEditor {
         let client = crate::http_client::HttpClient::new();
         let wire_headers = crate::types::effective_wire_headers(&headers, &resolved_auth);
         let inflight = client.start_send(method, url, wire_headers, body);
-        self.abort_handle = Some(inflight.abort_handle());
+        self.in_flight.insert(
+            tab_id,
+            InFlightRequest {
+                request_id,
+                abort_handle: inflight.abort_handle(),
+            },
+        );
+        cx.emit(RequestStarted {
+            tab_id,
+            request_id,
+            request: editor_request_snapshot,
+        });
         cx.notify();
 
         cx.spawn_in(window, async move |this, cx| {
@@ -1215,8 +1272,7 @@ impl RequestEditor {
                     if e.downcast_ref::<crate::http_client::RequestCanceled>()
                         .is_some()
                     {
-                        // cancel_request() already reset the UI and bumped the
-                        // generation; nothing left to do.
+                        // Cancellation or tab closure already removed ownership.
                         return Ok(());
                     }
                     // Handle request error (network error, file read error, etc.)
@@ -1233,12 +1289,17 @@ impl RequestEditor {
                     };
 
                     this.update(cx, |this, cx| {
-                        if this.send_generation != generation {
-                            return; // superseded by a newer send/cancel
+                        let is_current = this
+                            .in_flight
+                            .get(&tab_id)
+                            .is_some_and(|state| state.request_id == request_id);
+                        if !is_current {
+                            return;
                         }
-                        this.loading = false;
-                        this.abort_handle = None;
+                        this.in_flight.remove(&tab_id);
                         cx.emit(RequestCompleted {
+                            tab_id,
+                            request_id,
                             request,
                             response: std::sync::Arc::new(error_response),
                         });
@@ -1273,12 +1334,17 @@ impl RequestEditor {
             };
 
             this.update(cx, |this, cx| {
-                if this.send_generation != generation {
-                    return; // superseded by a newer send/cancel
+                let is_current = this
+                    .in_flight
+                    .get(&tab_id)
+                    .is_some_and(|state| state.request_id == request_id);
+                if !is_current {
+                    return;
                 }
-                this.loading = false;
-                this.abort_handle = None;
+                this.in_flight.remove(&tab_id);
                 cx.emit(RequestCompleted {
+                    tab_id,
+                    request_id,
                     request,
                     response: std::sync::Arc::new(response_data),
                 });
@@ -1291,6 +1357,7 @@ impl RequestEditor {
     }
 }
 
+impl EventEmitter<RequestStarted> for RequestEditor {}
 impl EventEmitter<RequestCompleted> for RequestEditor {}
 impl EventEmitter<OpenCodeSnippet> for RequestEditor {}
 impl EventEmitter<RequestCancelled> for RequestEditor {}
@@ -1300,6 +1367,7 @@ impl Render for RequestEditor {
     #[cfg_attr(feature = "profile", profiling::function)]
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
+        let active_tab_is_loading = self.active_tab_is_loading();
 
         div().id("request-editor-root").flex().flex_col().w_full().h_full().on_click(cx.listener(|_, _, _, cx| cx.stop_propagation())).child(
             // Request section with header
@@ -1369,7 +1437,7 @@ impl Render for RequestEditor {
                         .child(
                             // Send button - prevent it from shrinking.
                             // While loading it becomes a Cancel button.
-                            div().flex_shrink_0().child(if self.loading {
+                            div().flex_shrink_0().child(if active_tab_is_loading {
                                 Button::new("cancel-btn")
                                     .danger()
                                     .label("Cancel")

--- a/src/request_tab.rs
+++ b/src/request_tab.rs
@@ -10,6 +10,11 @@ pub struct RequestTab {
     pub request: RequestData,
     /// Response data for this tab (shared, so tab switches never copy the body)
     pub response: Option<Arc<ResponseData>>,
+    /// The request currently owned by this tab. Completion/cancellation events
+    /// must match this id before they may mutate the tab.
+    pub active_request_id: Option<u64>,
+    /// Persisted response-panel state for a canceled request.
+    pub response_canceled: bool,
     // UI state (not persisted to database)
     pub params_state: Option<Vec<ParamState>>,
     pub headers_state: Option<Vec<HeaderState>>,
@@ -38,6 +43,8 @@ impl RequestTab {
                 auth: crate::types::AuthConfig::default(),
             },
             response: None,
+            active_request_id: None,
+            response_canceled: false,
             params_state: None,
             headers_state: None,
             history_id: None,
@@ -55,6 +62,8 @@ impl RequestTab {
             title: Self::generate_title(&item.request),
             request: item.request.clone(),
             response: item.response.clone(),
+            active_request_id: None,
+            response_canceled: false,
             params_state: None,
             headers_state: None,
             history_id: Some(item.id),
@@ -72,6 +81,8 @@ impl RequestTab {
             title: saved.name.clone(),
             request: saved.request.clone(),
             response: None,
+            active_request_id: None,
+            response_canceled: false,
             params_state: Some(saved.params_state.clone()),
             headers_state: Some(saved.headers_state.clone()),
             history_id: None,
@@ -118,6 +129,40 @@ impl RequestTab {
         } else {
             self.update_title();
         }
+    }
+
+    /// Record the immutable editor snapshot associated with a new send.
+    pub fn begin_request(&mut self, request_id: u64, request: RequestData) {
+        self.request = request;
+        self.active_request_id = Some(request_id);
+        self.response_canceled = false;
+        self.update_title_from_saved_name();
+    }
+
+    /// Apply a response only when it belongs to this tab's current request.
+    pub fn complete_request(
+        &mut self,
+        request_id: u64,
+        response: Arc<ResponseData>,
+    ) -> bool {
+        if self.active_request_id != Some(request_id) {
+            return false;
+        }
+        self.active_request_id = None;
+        self.response = Some(response);
+        self.response_canceled = false;
+        true
+    }
+
+    /// Apply cancellation only to the matching request in this tab.
+    pub fn cancel_request(&mut self, request_id: u64) -> bool {
+        if self.active_request_id != Some(request_id) {
+            return false;
+        }
+        self.active_request_id = None;
+        self.response = None;
+        self.response_canceled = true;
+        true
     }
 
     /// A pristine scratch tab — the default tab at startup, or an untouched
@@ -199,6 +244,16 @@ mod tests {
         assert!(!tab.is_blank());
     }
 
+    fn response(status: u16) -> Arc<ResponseData> {
+        Arc::new(ResponseData {
+            status: Some(status),
+            duration_ms: 1,
+            headers: vec![],
+            body: status.to_string().into_bytes(),
+            is_text: true,
+        })
+    }
+
     #[test]
     fn generated_tab_title_leaves_method_to_tab_bar() {
         let mut request = empty_request();
@@ -220,5 +275,82 @@ mod tests {
             ("Cache-Control".to_string(), "no-cache".to_string()),
         ];
         assert!(tab.is_blank());
+    }
+
+    #[test]
+    fn completion_after_switch_updates_only_its_originating_tab() {
+        let mut tabs = [RequestTab::new_empty(10), RequestTab::new_empty(20)];
+        tabs[0].begin_request(101, RequestData::new(HttpMethod::GET, "https://a.test".into()));
+
+        // The user switched to tab B before A completed. Routing uses tab id,
+        // never the active index.
+        let active_index = 1;
+        let origin = tabs.iter_mut().find(|tab| tab.id == 10).unwrap();
+        assert!(origin.complete_request(101, response(201)));
+
+        assert_eq!(tabs[0].response.as_ref().unwrap().status, Some(201));
+        assert!(tabs[active_index].response.is_none());
+    }
+
+    #[test]
+    fn send_keeps_an_immutable_request_snapshot() {
+        let mut editor_request = RequestData::new(HttpMethod::GET, "https://a.test".into());
+        let mut tab = RequestTab::new_empty(10);
+        tab.begin_request(101, editor_request.clone());
+
+        editor_request.url = "https://edited-later.test".into();
+
+        assert_eq!(tab.request.url, "https://a.test");
+    }
+
+    #[test]
+    fn concurrent_out_of_order_completions_stay_with_their_tabs() {
+        let mut a = RequestTab::new_empty(10);
+        let mut b = RequestTab::new_empty(20);
+        a.begin_request(101, RequestData::new(HttpMethod::GET, "https://a.test".into()));
+        b.begin_request(102, RequestData::new(HttpMethod::GET, "https://b.test".into()));
+
+        assert!(b.complete_request(102, response(202)));
+        assert!(a.complete_request(101, response(201)));
+        assert_eq!(a.response.unwrap().status, Some(201));
+        assert_eq!(b.response.unwrap().status, Some(202));
+    }
+
+    #[test]
+    fn cancel_affects_only_the_matching_tab_and_request() {
+        let mut a = RequestTab::new_empty(10);
+        let mut b = RequestTab::new_empty(20);
+        a.begin_request(101, RequestData::new(HttpMethod::GET, "https://a.test".into()));
+        b.begin_request(102, RequestData::new(HttpMethod::GET, "https://b.test".into()));
+
+        assert!(b.cancel_request(102));
+        assert!(b.response_canceled);
+        assert_eq!(a.active_request_id, Some(101));
+        assert!(!a.response_canceled);
+        assert!(!a.cancel_request(999));
+    }
+
+    #[test]
+    fn stale_same_tab_completion_cannot_overwrite_a_newer_request() {
+        let mut tab = RequestTab::new_empty(10);
+        tab.begin_request(101, RequestData::new(HttpMethod::GET, "https://old.test".into()));
+        tab.begin_request(102, RequestData::new(HttpMethod::GET, "https://new.test".into()));
+
+        assert!(!tab.complete_request(101, response(201)));
+        assert!(tab.response.is_none());
+        assert!(tab.complete_request(102, response(202)));
+        assert_eq!(tab.response.unwrap().status, Some(202));
+    }
+
+    #[test]
+    fn closing_a_running_tab_leaves_no_completion_destination() {
+        let mut tabs = vec![RequestTab::new_empty(10), RequestTab::new_empty(20)];
+        tabs[0].begin_request(101, RequestData::new(HttpMethod::GET, "https://a.test".into()));
+
+        tabs.remove(0);
+
+        assert!(tabs.iter_mut().find(|tab| tab.id == 10).is_none());
+        assert_eq!(tabs[0].id, 20);
+        assert!(tabs[0].response.is_none());
     }
 }

--- a/src/response_viewer.rs
+++ b/src/response_viewer.rs
@@ -359,6 +359,10 @@ impl ResponseViewer {
         self.response.clone()
     }
 
+    pub fn is_canceled(&self) -> bool {
+        self.canceled
+    }
+
     /// Clear response data
     pub fn clear_response(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
         self.canceled = false;


### PR DESCRIPTION
## Summary

- assign every send a stable tab ID, unique request ID, and immutable request snapshot
- scope loading, cancellation, and response state to the originating tab
- route concurrent and out-of-order completions by identity instead of the active tab
- abort in-flight work when its tab is closed and ignore stale results
- preserve canceled response state across tab switches

## Testing

- `cargo check --tests`
- `cargo clippy --tests -- -D warnings`
- `cargo test` on Windows: 210 passed, 0 failed
- manual verification with delayed HTTP requests across multiple tabs

Fixes #36