### PR TITLE
fix: keep authentication secrets out of history

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -215,7 +215,7 @@ impl PoopmanApp {
                 // synchronous by design, so run it only on GPUI's background
                 // executor and refresh the panel after the write has completed.
                 let db = db_clone.clone();
-                let request = event.request.clone();
+                let request = event.history_request.clone();
                 let history_panel = history_panel_clone.clone();
                 let persist = cx.background_spawn(async move { Self::persist_send(&db, &request) });
                 cx.spawn_in(window, async move |_this, cx| {

--- a/src/db.rs
+++ b/src/db.rs
@@ -550,7 +550,9 @@ impl Database {
         let request_headers = request_headers.to_string();
         // Serialize body type + auth to JSON before crossing the channel.
         let body_json = serde_json::to_string(request_body).unwrap_or_default();
-        let auth_json = serde_json::to_string(auth).unwrap_or_default();
+        // Defense in depth: callers should pass a history snapshot, but the DB
+        // boundary also refuses to serialize drafts from inactive auth modes.
+        let auth_json = serde_json::to_string(&auth.active_only()).unwrap_or_default();
 
         self.call(move |conn| {
             let timestamp = chrono::Utc::now().to_rfc3339();
@@ -1278,6 +1280,36 @@ mod tests {
         let items = db.load_recent_history(10).unwrap();
         assert_eq!(items[0].request.auth.auth_type, AuthType::Bearer);
         assert_eq!(items[0].request.auth.bearer_token, "abc");
+    }
+
+    #[test]
+    fn history_storage_drops_inactive_auth_fields() {
+        let db = mem_db();
+        let auth = AuthConfig {
+            auth_type: AuthType::None,
+            bearer_token: "must-not-persist".into(),
+            basic_username: "must-not-persist".into(),
+            basic_password: "must-not-persist".into(),
+            api_key_name: "must-not-persist".into(),
+            api_key_value: "must-not-persist".into(),
+        };
+
+        db.insert_history(
+            "GET",
+            "{{base_url}}/private",
+            r#"[["Authorization","Bearer {{token}}"]]"#,
+            &BodyType::None,
+            &auth,
+        )
+        .unwrap();
+
+        let item = db.load_recent_history(1).unwrap().remove(0);
+        assert_eq!(item.request.url, "{{base_url}}/private");
+        assert_eq!(
+            item.request.headers,
+            vec![("Authorization".into(), "Bearer {{token}}".into())]
+        );
+        assert_eq!(item.request.auth, AuthConfig::default());
     }
 
     #[test]

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -29,8 +29,8 @@ pub struct RequestStarted {
 pub struct RequestCompleted {
     pub tab_id: usize,
     pub request_id: u64,
-    /// Immutable resolved snapshot of the request that went over the wire.
-    pub request: RequestData,
+    /// Immutable, unresolved and auth-sanitized snapshot for History.
+    pub history_request: RequestData,
     pub response: std::sync::Arc<ResponseData>,
 }
 
@@ -954,7 +954,9 @@ impl RequestEditor {
     ///
     /// Uses pure functions from url_params module for URL building.
     fn rebuild_url_with_params(&self, url_str: &str, cx: &App) -> String {
-        log::debug!("Rebuilding URL from: {}", url_str);
+        // URLs can contain literal or environment-backed credentials. Keep
+        // their values out of logs even before a request is sent.
+        log::debug!("Rebuilding URL from parameter state");
 
         // Extract base URL using pure function
         let base = url_params::extract_base_url(url_str);
@@ -975,7 +977,7 @@ impl RequestEditor {
         // Build URL using pure function
         let result = url_params::build_url_with_params(base, &params);
 
-        log::debug!("Rebuilt URL to: {}", result);
+        log::debug!("Rebuilt URL from parameter state");
         result
     }
 
@@ -1154,20 +1156,21 @@ impl RequestEditor {
         // Auto-add scheme if missing (like Postman does) - default to http://
         if !url.starts_with("http://") && !url.starts_with("https://") {
             url = format!("http://{}", url);
-            log::debug!("Auto-added http:// scheme to URL: {}", url);
+            log::debug!("Auto-added http:// scheme to request URL");
         }
 
         // Validate URL format after normalization
         if url::Url::parse(&url).is_err() {
-            log::error!("Invalid URL format even after normalization: '{}'", url);
+            log::error!("Invalid URL format after normalization");
             return;
         }
 
-        log::debug!("Sending request to: {}", url);
+        log::debug!("Sending request");
 
         // Update Content-Length before sending
         self.update_content_length(window, cx);
         let editor_request_snapshot = self.get_current_request_data(cx);
+        let history_request_snapshot = editor_request_snapshot.history_snapshot();
 
         // Get selected method
         let method_index = self
@@ -1245,16 +1248,8 @@ impl RequestEditor {
         // Resolve auth {{vars}} and compute the wire header. The saved request
         // keeps manual headers + the auth config; only the wire gets the merged
         // header set (auth wins over a manual same-name header).
-        let resolved_auth =
-            crate::variables::substitute_auth(&self.auth_editor.read(cx).get_auth(cx), env);
-
-        let request = RequestData {
-            method,
-            url: url.clone(),
-            headers: headers.clone(),
-            body: body.clone(),
-            auth: resolved_auth.clone(),
-        };
+        let unresolved_active_auth = self.auth_editor.read(cx).get_auth(cx).active_only();
+        let resolved_auth = crate::variables::substitute_auth(&unresolved_active_auth, env);
 
         let tab_id = self.active_request_tab_id;
         let request_id = self.next_request_id;
@@ -1263,7 +1258,7 @@ impl RequestEditor {
             .checked_add(1)
             .expect("request id space exhausted");
 
-        log::debug!("Starting {} request to: {}", method.as_str(), url);
+        log::debug!("Starting {} request", method.as_str());
 
         // Spawn the HTTP work onto the tokio runtime *now* so we can hold an
         // abort handle; the gpui task below only awaits the outcome.
@@ -1297,7 +1292,10 @@ impl RequestEditor {
                     }
                     // Handle request error (network error, file read error, etc.)
                     let duration = start.elapsed();
-                    let error_message = format!("Request failed: {}", e);
+                    // Transport errors can embed the fully-resolved URL. Never
+                    // copy them into logs or the response viewer because that
+                    // URL may contain environment-backed credentials.
+                    let error_message = "Request failed".to_string();
                     log::error!("{}", error_message);
 
                     let error_response = ResponseData {
@@ -1320,7 +1318,7 @@ impl RequestEditor {
                         cx.emit(RequestCompleted {
                             tab_id,
                             request_id,
-                            request,
+                            history_request: history_request_snapshot,
                             response: std::sync::Arc::new(error_response),
                         });
                         cx.notify();
@@ -1365,7 +1363,7 @@ impl RequestEditor {
                 cx.emit(RequestCompleted {
                     tab_id,
                     request_id,
-                    request,
+                    history_request: history_request_snapshot,
                     response: std::sync::Arc::new(response_data),
                 });
                 cx.notify();

--- a/src/types.rs
+++ b/src/types.rs
@@ -315,6 +315,35 @@ pub struct AuthConfig {
 }
 
 impl AuthConfig {
+    /// Return the portion of this configuration that belongs to the selected
+    /// auth mode.
+    ///
+    /// The editor deliberately keeps every mode's inputs alive so users can
+    /// switch between drafts. Those inactive drafts must not cross persistence
+    /// or wire boundaries, where they would become unrelated credentials.
+    pub fn active_only(&self) -> Self {
+        match self.auth_type {
+            AuthType::None => Self::default(),
+            AuthType::Bearer => Self {
+                auth_type: AuthType::Bearer,
+                bearer_token: self.bearer_token.clone(),
+                ..Self::default()
+            },
+            AuthType::Basic => Self {
+                auth_type: AuthType::Basic,
+                basic_username: self.basic_username.clone(),
+                basic_password: self.basic_password.clone(),
+                ..Self::default()
+            },
+            AuthType::ApiKey => Self {
+                auth_type: AuthType::ApiKey,
+                api_key_name: self.api_key_name.clone(),
+                api_key_value: self.api_key_value.clone(),
+                ..Self::default()
+            },
+        }
+    }
+
     /// The header this auth would put on the wire, or `None`.
     ///
     /// Emitted only when the relevant field(s) are non-empty, so an in-progress
@@ -343,7 +372,7 @@ impl AuthConfig {
                 }
             }
             AuthType::ApiKey => {
-                if self.api_key_name.is_empty() {
+                if self.api_key_name.is_empty() || self.api_key_value.is_empty() {
                     None
                 } else {
                     Some((self.api_key_name.clone(), self.api_key_value.clone()))
@@ -355,25 +384,32 @@ impl AuthConfig {
 
 /// Manual headers with the computed auth header merged in.
 ///
-/// Any manual header whose name case-insensitively matches the auth header's
-/// name is removed first (auth wins), then the auth header is appended. When the
-/// auth produces no header, the manual headers are returned unchanged.
+/// Selecting an auth mode claims its header even while its fields are empty:
+/// a stale manual credential must not become a fallback. If the selected auth
+/// is complete, its computed header is appended after the conflict is removed.
 pub fn effective_wire_headers(
     headers: &[(String, String)],
     auth: &AuthConfig,
 ) -> Vec<(String, String)> {
-    match auth.compute_header() {
-        None => headers.to_vec(),
-        Some((name, value)) => {
-            let mut out: Vec<(String, String)> = headers
-                .iter()
-                .filter(|(k, _)| !k.eq_ignore_ascii_case(&name))
-                .cloned()
-                .collect();
-            out.push((name, value));
-            out
-        }
+    let claimed_header = match auth.auth_type {
+        AuthType::None => None,
+        AuthType::Bearer | AuthType::Basic => Some("Authorization"),
+        AuthType::ApiKey if !auth.api_key_name.is_empty() => Some(auth.api_key_name.as_str()),
+        AuthType::ApiKey => None,
+    };
+
+    let mut out: Vec<(String, String)> = headers
+        .iter()
+        .filter(|(name, _)| {
+            claimed_header.is_none_or(|claimed| !name.eq_ignore_ascii_case(claimed))
+        })
+        .cloned()
+        .collect();
+
+    if let Some((name, value)) = auth.compute_header() {
+        out.push((name, value));
     }
+    out
 }
 
 /// Request data structure
@@ -399,6 +435,14 @@ impl RequestData {
             body: BodyType::default(),
             auth: AuthConfig::default(),
         }
+    }
+
+    /// Build the unresolved snapshot that is safe to write to request history.
+    /// Environment substitution happens only on the separate wire request.
+    pub fn history_snapshot(&self) -> Self {
+        let mut snapshot = self.clone();
+        snapshot.auth = snapshot.auth.active_only();
+        snapshot
     }
 }
 
@@ -661,6 +705,13 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(a.compute_header(), None);
+        // ApiKey with empty value → nothing
+        let a = AuthConfig {
+            auth_type: AuthType::ApiKey,
+            api_key_name: "X-API-Key".into(),
+            ..Default::default()
+        };
+        assert_eq!(a.compute_header(), None);
     }
 
     #[test]
@@ -767,6 +818,52 @@ mod tests {
     }
 
     #[test]
+    fn incomplete_bearer_suppresses_stale_manual_authorization() {
+        let manual = vec![
+            ("Accept".to_string(), "*/*".to_string()),
+            ("authorization".to_string(), "Bearer OLD".to_string()),
+        ];
+        let auth = AuthConfig {
+            auth_type: AuthType::Bearer,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            effective_wire_headers(&manual, &auth),
+            vec![("Accept".to_string(), "*/*".to_string())]
+        );
+    }
+
+    #[test]
+    fn incomplete_basic_suppresses_stale_manual_authorization() {
+        let manual = vec![(
+            "Authorization".to_string(),
+            "Basic c3RhbGU6c2VjcmV0".to_string(),
+        )];
+        let auth = AuthConfig {
+            auth_type: AuthType::Basic,
+            ..Default::default()
+        };
+
+        assert!(effective_wire_headers(&manual, &auth).is_empty());
+    }
+
+    #[test]
+    fn incomplete_api_key_suppresses_its_stale_manual_header() {
+        let manual = vec![("X-API-Key".to_string(), "OLD".to_string())];
+        let auth = AuthConfig {
+            auth_type: AuthType::ApiKey,
+            api_key_name: "X-API-Key".into(),
+            api_key_value: String::new(),
+            ..Default::default()
+        };
+
+        // The selected mode still claims the name, so neither the stale value
+        // nor an empty replacement goes onto the wire.
+        assert!(effective_wire_headers(&manual, &auth).is_empty());
+    }
+
+    #[test]
     fn effective_headers_api_key_custom_name_dedupes() {
         let manual = vec![("X-API-Key".to_string(), "old".to_string())];
         let auth = AuthConfig {
@@ -777,6 +874,89 @@ mod tests {
         };
         let out = effective_wire_headers(&manual, &auth);
         assert_eq!(out, vec![("X-API-Key".to_string(), "new".to_string())]);
+    }
+
+    #[test]
+    fn history_snapshot_preserves_templates_and_drops_inactive_auth() {
+        let request = RequestData {
+            method: HttpMethod::POST,
+            url: "{{base_url}}/users?token={{query_token}}".into(),
+            headers: vec![("X-Token".into(), "{{header_token}}".into())],
+            body: BodyType::Raw {
+                content: "{\"token\":\"{{body_token}}\"}".into(),
+                subtype: RawSubtype::Json,
+            },
+            auth: AuthConfig {
+                auth_type: AuthType::Bearer,
+                bearer_token: "{{bearer_token}}".into(),
+                basic_username: "inactive-user".into(),
+                basic_password: "inactive-password".into(),
+                api_key_name: "X-Inactive-Key".into(),
+                api_key_value: "inactive-api-key".into(),
+            },
+        };
+
+        let snapshot = request.history_snapshot();
+        assert_eq!(snapshot.url, request.url);
+        assert_eq!(snapshot.headers, request.headers);
+        assert_eq!(snapshot.body, request.body);
+        assert_eq!(snapshot.auth.auth_type, AuthType::Bearer);
+        assert_eq!(snapshot.auth.bearer_token, "{{bearer_token}}");
+        assert!(snapshot.auth.basic_username.is_empty());
+        assert!(snapshot.auth.basic_password.is_empty());
+        assert!(snapshot.auth.api_key_name.is_empty());
+        assert!(snapshot.auth.api_key_value.is_empty());
+    }
+
+    #[test]
+    fn history_snapshot_with_none_drops_every_auth_draft() {
+        let mut request = RequestData::new(HttpMethod::GET, "{{base_url}}".into());
+        request.auth = AuthConfig {
+            auth_type: AuthType::None,
+            bearer_token: "inactive-bearer".into(),
+            basic_username: "inactive-user".into(),
+            basic_password: "inactive-password".into(),
+            api_key_name: "X-Inactive-Key".into(),
+            api_key_value: "inactive-api-key".into(),
+        };
+
+        assert_eq!(request.history_snapshot().auth, AuthConfig::default());
+    }
+
+    #[test]
+    fn active_only_keeps_basic_and_api_key_fields_separate() {
+        let all = AuthConfig {
+            auth_type: AuthType::Basic,
+            bearer_token: "bearer".into(),
+            basic_username: "user".into(),
+            basic_password: "pass".into(),
+            api_key_name: "X-Key".into(),
+            api_key_value: "key-value".into(),
+        };
+
+        assert_eq!(
+            all.active_only(),
+            AuthConfig {
+                auth_type: AuthType::Basic,
+                basic_username: "user".into(),
+                basic_password: "pass".into(),
+                ..Default::default()
+            }
+        );
+
+        let api_key = AuthConfig {
+            auth_type: AuthType::ApiKey,
+            ..all
+        };
+        assert_eq!(
+            api_key.active_only(),
+            AuthConfig {
+                auth_type: AuthType::ApiKey,
+                api_key_name: "X-Key".into(),
+                api_key_value: "key-value".into(),
+                ..Default::default()
+            }
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- persist an unresolved, auth-sanitized snapshot to request history
- prevent incomplete selected auth from falling back to stale manual credentials
- keep resolved URLs and transport errors out of logs and error responses
- add regression coverage for auth-mode switching, incomplete auth, and environment-backed templates

## Verification

- cargo check --all-targets
- cargo test --release on Windows: 221 passed
- cargo build --release on Windows

Fixes #38