### PR TITLE
feat(editor): add native body assistance

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -144,7 +144,9 @@ impl PoopmanApp {
 
         // Push the active environment's variables into the request editor.
         let initial_env_vars = Self::active_env_vars(&environments, active_environment_id);
-        request_editor.update(cx, |editor, _| editor.set_env_vars(initial_env_vars));
+        request_editor.update(cx, |editor, cx| {
+            editor.set_env_vars(initial_env_vars, window, cx)
+        });
 
         // Initialize with one empty tab
         let request_tabs = vec![RequestTab::new_empty(0)];
@@ -302,8 +304,13 @@ impl PoopmanApp {
         let env_changed_sub = cx.subscribe_in(
             &env_manager,
             window,
-            move |this, _, event: &EnvironmentsChanged, _window, cx| {
-                this.apply_environment_state(event.environments.clone(), event.active_id, cx);
+            move |this, _, event: &EnvironmentsChanged, window, cx| {
+                this.apply_environment_state(
+                    event.environments.clone(),
+                    event.active_id,
+                    window,
+                    cx,
+                );
             },
         );
 
@@ -455,13 +462,14 @@ impl PoopmanApp {
         &mut self,
         environments: Vec<crate::types::Environment>,
         active_environment_id: Option<i64>,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         self.environments = environments;
         self.active_environment_id = active_environment_id;
         let vars = Self::active_env_vars(&self.environments, self.active_environment_id);
         self.request_editor
-            .update(cx, |editor, _| editor.set_env_vars(vars));
+            .update(cx, |editor, cx| editor.set_env_vars(vars, window, cx));
         cx.notify();
     }
 

--- a/src/body_editor.rs
+++ b/src/body_editor.rs
@@ -7,6 +7,11 @@ use gpui_component::{
     select::*, v_flex, ActiveTheme as _, IndexPath, Sizable as _,
 };
 
+use std::{collections::{HashMap, HashSet}, rc::Rc, time::Duration};
+
+use crate::body_editor_assistance::{
+    BodyDiagnosticSeverity, VariableCompletionProvider, compute_body_diagnostics,
+};
 use crate::types::{BodyDraft, BodyKind, BodyType, FormDataRow, FormDataValue, RawSubtype};
 
 use gpui::Subscription;
@@ -50,6 +55,8 @@ pub struct BodyEditor {
     // Format/validation state
     validation_message: Option<String>,
     validation_error: bool,
+    env_var_names: HashSet<String>,
+    diagnostics_generation: u64,
 }
 
 impl BodyEditor {
@@ -95,12 +102,15 @@ impl BodyEditor {
         // Create single editor for all raw types (default to JSON)
         let current_raw_subtype = RawSubtype::Json;
         let raw_body_editor = cx.new(|cx| {
-            InputState::new(window, cx)
+            let mut input = InputState::new(window, cx)
                 .code_editor(current_raw_subtype.as_str())
                 .line_number(true)
                 .indent_guides(true)
                 .tab_size(TabSize { tab_size: 4, hard_tabs: false })
-                .placeholder(get_placeholder_for_subtype(current_raw_subtype))
+                .placeholder(get_placeholder_for_subtype(current_raw_subtype));
+            input.lsp.completion_provider =
+                Some(Rc::new(VariableCompletionProvider::new(Vec::new())));
+            input
         });
 
         log::info!("Created single body editor with default language: 'json'");
@@ -119,6 +129,8 @@ impl BodyEditor {
             _formdata_subscriptions: vec![],
             validation_message: None,
             validation_error: false,
+            env_var_names: HashSet::new(),
+            diagnostics_generation: 0,
         };
 
         // Initialize with one empty form-data row for auto-add functionality
@@ -133,8 +145,104 @@ impl BodyEditor {
             },
         );
         editor._subscriptions.push(select_subscription);
+        let raw_input_subscription = cx.subscribe_in(
+            &raw_body_editor,
+            window,
+            |this: &mut BodyEditor, _, event: &InputChangeEvent, window, cx| {
+                if matches!(event, InputChangeEvent::Change) {
+                    this.schedule_raw_diagnostics(true, window, cx);
+                }
+            },
+        );
+        editor._subscriptions.push(raw_input_subscription);
 
         editor
+    }
+
+    /// Replace completion candidates and re-check unknown variables whenever the
+    /// active environment changes.
+    pub fn set_env_vars(
+        &mut self,
+        vars: &HashMap<String, String>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.env_var_names = vars.keys().cloned().collect();
+        let provider = VariableCompletionProvider::new(self.env_var_names.iter().cloned());
+        self.raw_body_editor.update(cx, |input, _| {
+            input.lsp.completion_provider = Some(Rc::new(provider));
+        });
+        self.schedule_raw_diagnostics(false, window, cx);
+    }
+
+    /// Coalesce typing, parse JSON off the UI thread, and discard stale results.
+    fn schedule_raw_diagnostics(
+        &mut self,
+        debounce: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.diagnostics_generation = self.diagnostics_generation.wrapping_add(1);
+        let generation = self.diagnostics_generation;
+
+        cx.spawn_in(window, async move |this, cx| {
+            if debounce {
+                cx.background_executor()
+                    .timer(Duration::from_millis(150))
+                    .await;
+            }
+
+            // Snapshot only after the debounce. This avoids copying a 1 MB body
+            // on every keystroke when a newer generation will supersede it.
+            let snapshot = this.update(cx, |this, cx| {
+                (this.diagnostics_generation == generation).then(|| {
+                    (
+                        this.raw_body_editor.read(cx).value().to_string(),
+                        this.env_var_names.clone(),
+                        this.current_raw_subtype == RawSubtype::Json,
+                    )
+                })
+            })?;
+            let Some((content, variable_names, validate_json)) = snapshot else {
+                return Ok(());
+            };
+
+            let task = cx.background_spawn(async move {
+                compute_body_diagnostics(&content, &variable_names, validate_json)
+            });
+            let diagnostics = task.await;
+
+            this.update(cx, |this, cx| {
+                if this.diagnostics_generation != generation {
+                    return;
+                }
+                this.raw_body_editor.update(cx, |input, cx| {
+                    let Some(target) = input.diagnostics_mut() else {
+                        return;
+                    };
+                    target.clear();
+                    target.extend(diagnostics.into_iter().map(|diagnostic| {
+                        let severity = match diagnostic.severity {
+                            BodyDiagnosticSeverity::Error => {
+                                gpui_component::highlighter::DiagnosticSeverity::Error
+                            }
+                            BodyDiagnosticSeverity::Warning => {
+                                gpui_component::highlighter::DiagnosticSeverity::Warning
+                            }
+                        };
+                        gpui_component::highlighter::Diagnostic::new(
+                            diagnostic.range,
+                            diagnostic.message,
+                        )
+                        .with_severity(severity)
+                        .with_source(diagnostic.source)
+                    }));
+                    cx.notify();
+                });
+            })?;
+            Ok::<_, anyhow::Error>(())
+        })
+        .detach();
     }
 
     /// Handle raw subtype change - switch syntax highlighting and placeholder
@@ -156,6 +264,7 @@ impl BodyEditor {
                 // Update placeholder based on subtype
                 state.set_placeholder(get_placeholder_for_subtype(new_subtype), window, cx);
             });
+            self.schedule_raw_diagnostics(false, window, cx);
 
             // Emit event to notify RequestEditor to update Content-Type header
             cx.emit(BodyTypeChanged {
@@ -240,6 +349,7 @@ impl BodyEditor {
                 cx,
             );
         });
+        self.schedule_raw_diagnostics(false, window, cx);
 
         self.formdata_rows.clear();
         self.formdata_input_states.clear();

--- a/src/body_editor_assistance.rs
+++ b/src/body_editor_assistance.rs
@@ -1,0 +1,411 @@
+//! Native editing assistance for raw request bodies.
+//!
+//! This module deliberately stays small: environment-variable completion is
+//! backed by gpui-component's existing completion provider, while diagnostics
+//! are computed as plain data so JSON parsing can run off the UI thread.
+
+use std::{collections::HashSet, ops::Range};
+
+use anyhow::Result;
+use gpui::{Context, Task, Window};
+use gpui_component::input::{CompletionProvider, InputState, Rope, RopeExt};
+use lsp_types::{
+    CompletionContext, CompletionItem, CompletionItemKind, CompletionResponse, CompletionTextEdit,
+    Position, TextEdit,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum BodyDiagnosticSeverity {
+    Error,
+    Warning,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct BodyDiagnostic {
+    pub range: Range<Position>,
+    pub severity: BodyDiagnosticSeverity,
+    pub message: String,
+    pub source: &'static str,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+struct VariableCompletionContext {
+    prefix: String,
+    replace_range: Range<usize>,
+}
+
+/// Completes variable names inside an unfinished `{{variable}}` expression.
+///
+/// Values are intentionally excluded from completion details because environment
+/// values commonly contain credentials and tokens.
+pub(crate) struct VariableCompletionProvider {
+    variable_names: Vec<String>,
+}
+
+impl VariableCompletionProvider {
+    pub(crate) fn new(variable_names: impl IntoIterator<Item = String>) -> Self {
+        let mut variable_names = variable_names
+            .into_iter()
+            .filter(|name| !name.is_empty())
+            .collect::<Vec<_>>();
+        variable_names.sort();
+        variable_names.dedup();
+        Self { variable_names }
+    }
+}
+
+impl CompletionProvider for VariableCompletionProvider {
+    fn completions(
+        &self,
+        rope: &Rope,
+        offset: usize,
+        _trigger: CompletionContext,
+        _window: &mut Window,
+        _cx: &mut Context<InputState>,
+    ) -> Task<Result<CompletionResponse>> {
+        // Inspect only the cursor's line. In the usual pretty-printed case this
+        // keeps completion work independent of total body size.
+        let cursor_position = rope.offset_to_position(offset);
+        let line = cursor_position.line as usize;
+        let line_start = rope.line_start_offset(line);
+        let line_end = rope.line_end_offset(line);
+        let line_text = rope.slice(line_start..line_end).to_string();
+        let Some(context) = variable_completion_context(&line_text, offset - line_start) else {
+            return Task::ready(Ok(CompletionResponse::Array(Vec::new())));
+        };
+
+        let prefix_lower = context.prefix.to_lowercase();
+        let replace_start = line_start + context.replace_range.start;
+        let replace_end = line_start + context.replace_range.end;
+        let range = lsp_types::Range {
+            start: rope.offset_to_position(replace_start),
+            end: rope.offset_to_position(replace_end),
+        };
+
+        let items = self
+            .variable_names
+            .iter()
+            .filter(|name| name.to_lowercase().starts_with(&prefix_lower))
+            .map(|name| CompletionItem {
+                label: name.clone(),
+                kind: Some(CompletionItemKind::VARIABLE),
+                detail: Some("Environment variable".to_string()),
+                filter_text: Some(context.prefix.clone()),
+                text_edit: Some(CompletionTextEdit::Edit(TextEdit {
+                    range,
+                    new_text: format!("{{{{{name}}}}}"),
+                })),
+                ..Default::default()
+            })
+            .collect();
+
+        Task::ready(Ok(CompletionResponse::Array(items)))
+    }
+
+    fn is_completion_trigger(
+        &self,
+        _offset: usize,
+        _new_text: &str,
+        _cx: &mut Context<InputState>,
+    ) -> bool {
+        // The provider itself cheaply rejects cursors outside `{{...}}`. Always
+        // checking also lets completion follow backspace and edits within an
+        // existing expression.
+        true
+    }
+}
+
+fn variable_completion_context(line: &str, cursor: usize) -> Option<VariableCompletionContext> {
+    if cursor > line.len() || !line.is_char_boundary(cursor) {
+        return None;
+    }
+
+    let before_cursor = &line[..cursor];
+    let open = before_cursor.rfind("{{")?;
+    let typed = &before_cursor[open + 2..];
+    if typed.contains('{') || typed.contains('}') {
+        return None;
+    }
+
+    // If the cursor is inside an already-closed expression, replace its closing
+    // braces too. Otherwise insert them along with the selected name.
+    let after_cursor = &line[cursor..];
+    let replace_end = after_cursor
+        .find("}}")
+        .filter(|close| {
+            let before_close = &after_cursor[..*close];
+            !before_close.contains('{') && !before_close.contains('}')
+        })
+        .map_or(cursor, |close| cursor + close + 2);
+
+    Some(VariableCompletionContext {
+        prefix: typed.trim_start().to_string(),
+        replace_range: open..replace_end,
+    })
+}
+
+#[derive(Debug)]
+struct VariableToken<'a> {
+    range: Range<usize>,
+    name_range: Range<usize>,
+    name: &'a str,
+}
+
+fn variable_tokens(text: &str) -> Vec<VariableToken<'_>> {
+    let mut tokens = Vec::new();
+    let mut cursor = 0;
+
+    while let Some(relative_open) = text[cursor..].find("{{") {
+        let open = cursor + relative_open;
+        let inner_start = open + 2;
+        let Some(relative_close) = text[inner_start..].find("}}") else {
+            break;
+        };
+        let close = inner_start + relative_close;
+        let end = close + 2;
+        let inner = &text[inner_start..close];
+        let trimmed = inner.trim();
+        let leading_whitespace = inner.len() - inner.trim_start().len();
+        let name_start = inner_start + leading_whitespace;
+
+        tokens.push(VariableToken {
+            range: open..end,
+            name_range: name_start..name_start + trimmed.len(),
+            name: trimmed,
+        });
+        cursor = end;
+    }
+
+    tokens
+}
+
+/// Compute variable and JSON diagnostics without touching GPUI state.
+pub(crate) fn compute_body_diagnostics(
+    text: &str,
+    variable_names: &HashSet<String>,
+    validate_json: bool,
+) -> Vec<BodyDiagnostic> {
+    let tokens = variable_tokens(text);
+    let line_starts = line_starts(text);
+    let mut diagnostics = Vec::new();
+
+    for token in &tokens {
+        let (range, message) = if token.name.is_empty() {
+            (
+                token.range.clone(),
+                "Variable name cannot be empty".to_string(),
+            )
+        } else if !variable_names.contains(token.name) {
+            (
+                token.name_range.clone(),
+                format!("Unknown environment variable: {}", token.name),
+            )
+        } else {
+            continue;
+        };
+
+        diagnostics.push(BodyDiagnostic {
+            range: position_at(text, &line_starts, range.start)
+                ..position_at(text, &line_starts, range.end),
+            severity: BodyDiagnosticSeverity::Warning,
+            message,
+            source: "poopman-variables",
+        });
+    }
+
+    if validate_json && !text.trim().is_empty() {
+        let normalized = normalize_variables_for_json(text, &tokens);
+        if let Err(error) = serde_json::from_str::<serde_json::Value>(&normalized) {
+            diagnostics.push(BodyDiagnostic {
+                range: json_error_range(&normalized, &error),
+                severity: BodyDiagnosticSeverity::Error,
+                message: format!("Malformed JSON: {error}"),
+                source: "json",
+            });
+        }
+    }
+
+    diagnostics.sort_by_key(|diagnostic| {
+        (
+            diagnostic.range.start.line,
+            diagnostic.range.start.character,
+            diagnostic.range.end.line,
+            diagnostic.range.end.character,
+        )
+    });
+    diagnostics
+}
+
+/// Replace a single-line variable token with `null` plus padding. The character
+/// count stays stable, so a serde_json error can be mapped back to the editor.
+/// Tokens inside strings remain valid string content; tokens used as raw values
+/// become a valid JSON null placeholder.
+fn normalize_variables_for_json(text: &str, tokens: &[VariableToken<'_>]) -> String {
+    let mut normalized = String::with_capacity(text.len());
+    let mut cursor = 0;
+
+    for token in tokens {
+        let token_text = &text[token.range.clone()];
+        if token_text.contains(['\n', '\r']) {
+            continue;
+        }
+
+        normalized.push_str(&text[cursor..token.range.start]);
+        normalized.push_str("null");
+        normalized.extend(std::iter::repeat_n(
+            ' ',
+            token_text.chars().count().saturating_sub(4),
+        ));
+        cursor = token.range.end;
+    }
+
+    normalized.push_str(&text[cursor..]);
+    normalized
+}
+
+fn line_starts(text: &str) -> Vec<usize> {
+    let mut starts = vec![0];
+    starts.extend(
+        text.bytes()
+            .enumerate()
+            .filter_map(|(index, byte)| (byte == b'\n').then_some(index + 1)),
+    );
+    starts
+}
+
+fn position_at(text: &str, line_starts: &[usize], offset: usize) -> Position {
+    let mut offset = offset.min(text.len());
+    while !text.is_char_boundary(offset) {
+        offset = offset.saturating_sub(1);
+    }
+    let line = line_starts
+        .partition_point(|start| *start <= offset)
+        .saturating_sub(1);
+    let character = text[line_starts[line]..offset].chars().count();
+    Position::new(line as u32, character as u32)
+}
+
+fn json_error_range(text: &str, error: &serde_json::Error) -> Range<Position> {
+    let starts = line_starts(text);
+    let line = error.line().saturating_sub(1).min(starts.len() - 1);
+    let line_start = starts[line];
+    let line_end = text[line_start..]
+        .find('\n')
+        .map_or(text.len(), |relative| line_start + relative);
+    let line_text = &text[line_start..line_end];
+    let mut byte_column = error.column().saturating_sub(1).min(line_text.len());
+    while !line_text.is_char_boundary(byte_column) {
+        byte_column = byte_column.saturating_sub(1);
+    }
+
+    let character_count = line_text.chars().count();
+    let mut start_character = line_text[..byte_column].chars().count();
+    if start_character == character_count && start_character > 0 {
+        start_character -= 1;
+    }
+
+    if character_count > 0 {
+        return Position::new(line as u32, start_character as u32)
+            ..Position::new(line as u32, (start_character + 1) as u32);
+    }
+
+    // EOF immediately after a newline has column 0. Anchor the diagnostic on
+    // the previous line so it still has a visible underline and hover target.
+    if line > 0 {
+        let previous_start = starts[line - 1];
+        let previous_text = text[previous_start..line_start].trim_end_matches(['\r', '\n']);
+        let previous_len = previous_text.chars().count();
+        if previous_len > 0 {
+            return Position::new((line - 1) as u32, (previous_len - 1) as u32)
+                ..Position::new((line - 1) as u32, previous_len as u32);
+        }
+    }
+
+    Position::new(line as u32, 0)..Position::new(line as u32, 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn names(items: &[&str]) -> HashSet<String> {
+        items.iter().map(|item| (*item).to_string()).collect()
+    }
+
+    #[test]
+    fn completion_replaces_unfinished_expression_and_adds_closing_braces() {
+        assert_eq!(
+            variable_completion_context(r#"{"url":"{{ba"}"#, 12),
+            Some(VariableCompletionContext {
+                prefix: "ba".to_string(),
+                replace_range: 8..12,
+            })
+        );
+    }
+
+    #[test]
+    fn completion_replaces_existing_closing_braces() {
+        assert_eq!(
+            variable_completion_context("{{base_ul}}", 9),
+            Some(VariableCompletionContext {
+                prefix: "base_ul".to_string(),
+                replace_range: 0..11,
+            })
+        );
+    }
+
+    #[test]
+    fn completion_ignores_cursor_outside_variable_expression() {
+        assert_eq!(variable_completion_context("{{base_url}} x", 14), None);
+        assert_eq!(variable_completion_context("plain", 5), None);
+    }
+
+    #[test]
+    fn reports_only_unknown_variables() {
+        let diagnostics = compute_body_diagnostics(
+            r#"{"known":"{{ token }}","missing":"{{other}}"}"#,
+            &names(&["token"]),
+            true,
+        );
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].severity, BodyDiagnosticSeverity::Warning);
+        assert_eq!(
+            diagnostics[0].message,
+            "Unknown environment variable: other"
+        );
+    }
+
+    #[test]
+    fn variable_placeholders_are_valid_in_json_string_or_value_positions() {
+        let diagnostics = compute_body_diagnostics(
+            r#"{"name":"{{name}}","count":{{count}}}"#,
+            &names(&["name", "count"]),
+            true,
+        );
+
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn malformed_json_gets_an_error_diagnostic() {
+        let diagnostics = compute_body_diagnostics(r#"{"name": }"#, &names(&[]), true);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].severity, BodyDiagnosticSeverity::Error);
+        assert!(diagnostics[0].message.starts_with("Malformed JSON:"));
+    }
+
+    #[test]
+    fn empty_json_body_has_no_diagnostic() {
+        assert!(compute_body_diagnostics("  \n", &names(&[]), true).is_empty());
+    }
+
+    #[test]
+    fn non_json_body_only_gets_variable_diagnostics() {
+        let diagnostics = compute_body_diagnostics("not json {{missing}}", &names(&[]), false);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].severity, BodyDiagnosticSeverity::Warning);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@
 mod app;
 mod auth_editor;
 mod body_editor;
+mod body_editor_assistance;
 mod code_formatter;
 mod code_gen;
 mod code_snippet_panel;

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -415,7 +415,14 @@ impl RequestEditor {
     }
 
     /// Replace the active environment variable map (called by PoopmanApp).
-    pub fn set_env_vars(&mut self, vars: std::collections::HashMap<String, String>) {
+    pub fn set_env_vars(
+        &mut self,
+        vars: std::collections::HashMap<String, String>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.body_editor
+            .update(cx, |editor, cx| editor.set_env_vars(&vars, window, cx));
         self.env_vars = vars;
     }
 

--- a/src/response_viewer.rs
+++ b/src/response_viewer.rs
@@ -618,8 +618,6 @@ impl Render for ResponseViewer {
                         .when(self.active_tab == 0, |this| {
                             let resp_is_text = self.response.as_ref().is_none_or(|r| r.is_text);
                             if resp_is_text {
-                                let is_error =
-                                    self.response.as_ref().is_some_and(|r| r.is_network_error());
                                 let body_display = self.body_display.clone();
                                 let has_body_display = self.body_ready;
                                 let body_loading = self.body_loading;
@@ -638,7 +636,15 @@ impl Render for ResponseViewer {
                                             this.child(
                                                 div().flex_1().min_h_0().w_full().child(
                                                     Input::new(&body_display)
-                                                        .disabled(is_error)
+                                                        // Disabled InputState still supports
+                                                        // selection, copy, navigation, and search,
+                                                        // but rejects every text mutation path.
+                                                        .disabled(true)
+                                                        // `disabled` normally paints a muted input
+                                                        // background and focus border. The parent
+                                                        // supplies the viewer chrome, so keep the
+                                                        // editor surface visually neutral.
+                                                        .appearance(false)
                                                         .rounded(theme.radius_lg)
                                                         .w_full()
                                                         .h_full(),


### PR DESCRIPTION
## Summary

- keep the editor stack native to Rust/GPUI; no WebView, Tauri migration, or dependency upgrade
- add active-environment `{{variable}}` completion without exposing variable values
- add debounced unknown-variable and malformed-JSON diagnostics for raw request bodies
- make response bodies read-only while preserving selection, copy, navigation, and search
- keep the read-only response viewer visually neutral instead of using disabled-control styling

## Verification

- `cargo clippy --all-targets -- -D warnings`
- Windows `cargo test`: 235 passed, 0 failed
- Windows release build completed
- response viewer appearance verified manually on Windows

Closes #63