### PR TITLE
feat(http): add timeouts, response limits, and streamed downloads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4493,6 +4493,7 @@ dependencies = [
  "chrono",
  "dirs 6.0.0",
  "env_logger",
+ "flate2",
  "futures",
  "gpui",
  "gpui-component",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,9 +36,12 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 quick-xml = "0.40"
 mime_guess = "2"
-tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "fs", "io-util"] }
 url = "2.5"
 urlencoding = "2.1"
+
+[dev-dependencies]
+flate2 = "1"
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winresource = "0.1"

--- a/docs/superpowers/specs/settings-general-preview.svg
+++ b/docs/superpowers/specs/settings-general-preview.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1120" height="760" viewBox="0 0 1120 760" fill="none">
+  <style>
+    .title { font: 700 15px Arial, sans-serif; letter-spacing: .06em; fill: #1A1915; }
+    .nav { font: 600 14px Arial, sans-serif; fill: #73706A; }
+    .navActive { font: 700 14px Arial, sans-serif; fill: #C15F3C; }
+    .heading { font: 700 24px Arial, sans-serif; fill: #1A1915; }
+    .section { font: 700 13px Arial, sans-serif; letter-spacing: .08em; fill: #73706A; }
+    .label { font: 700 15px Arial, sans-serif; fill: #1A1915; }
+    .body { font: 400 13px Arial, sans-serif; fill: #73706A; }
+    .field { font: 400 14px Arial, sans-serif; fill: #1A1915; }
+    .unit { font: 400 13px Arial, sans-serif; fill: #73706A; }
+    .hint { font: 600 12px Arial, sans-serif; fill: #4F8A5B; }
+  </style>
+  <rect width="1120" height="760" rx="18" fill="#FAF9F5"/>
+  <rect x="0" y="0" width="1120" height="64" rx="18" fill="#F0EEE6"/>
+  <rect x="0" y="48" width="1120" height="16" fill="#F0EEE6"/>
+  <text x="34" y="39" class="title">SETTINGS</text>
+  <path d="M1080 25L1093 38M1093 25L1080 38" stroke="#73706A" stroke-width="1.6" stroke-linecap="round"/>
+
+  <rect x="0" y="64" width="1120" height="48" fill="#FFF"/>
+  <text x="34" y="94" class="navActive">General</text>
+  <text x="126" y="94" class="nav">Themes</text>
+  <text x="214" y="94" class="nav">Shortcuts</text>
+  <text x="321" y="94" class="nav">Data</text>
+  <text x="386" y="94" class="nav">Certificates</text>
+  <text x="500" y="94" class="nav">Proxy</text>
+  <text x="571" y="94" class="nav">Update</text>
+  <text x="651" y="94" class="nav">About</text>
+  <rect x="23" y="109" width="72" height="3" rx="1.5" fill="#C15F3C"/>
+
+  <text x="58" y="164" class="heading">General</text>
+  <text x="58" y="190" class="body">Request defaults and safeguards apply to every new request.</text>
+
+  <rect x="58" y="218" width="1004" height="462" rx="12" fill="#FFF" stroke="#E7E4DA"/>
+  <text x="86" y="258" class="section">REQUEST</text>
+
+  <text x="86" y="300" class="label">HTTP version</text>
+  <text x="86" y="323" class="body">Choose the protocol preference used for outgoing requests.</text>
+  <rect x="814" y="278" width="172" height="42" rx="8" fill="#FFF" stroke="#E7E4DA"/>
+  <text x="832" y="304" class="field">Automatic</text>
+  <path d="M959 295l5 5 5-5" stroke="#73706A" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M86 350H1034" stroke="#E7E4DA"/>
+
+  <text x="86" y="388" class="section">TIMEOUTS</text>
+  <text x="86" y="430" class="label">Connect timeout</text>
+  <text x="86" y="453" class="body">Stop if a connection cannot be established in time.</text>
+  <rect x="814" y="407" width="126" height="42" rx="8" fill="#FFF" stroke="#E7E4DA"/>
+  <text x="832" y="433" class="field">10,000</text>
+  <text x="955" y="433" class="unit">ms</text>
+  <path d="M86 480H1034" stroke="#E7E4DA"/>
+
+  <text x="86" y="520" class="label">Read idle timeout</text>
+  <text x="86" y="543" class="body">Stop when a connected server stops sending response data.</text>
+  <rect x="814" y="497" width="126" height="42" rx="8" fill="#FFF" stroke="#E7E4DA"/>
+  <text x="832" y="523" class="field">30,000</text>
+  <text x="955" y="523" class="unit">ms</text>
+  <path d="M86 570H1034" stroke="#E7E4DA"/>
+
+  <text x="86" y="610" class="label">Total request timeout</text>
+  <text x="86" y="633" class="body">A final limit for the complete request, including download time.</text>
+  <rect x="814" y="587" width="126" height="42" rx="8" fill="#FFF" stroke="#E7E4DA"/>
+  <text x="832" y="613" class="field">60,000</text>
+  <text x="955" y="613" class="unit">ms</text>
+
+  <rect x="58" y="702" width="1004" height="1" fill="#E7E4DA"/>
+  <circle cx="88" cy="727" r="4" fill="#4F8A5B"/>
+  <text x="101" y="731" class="hint">Changes are saved automatically</text>
+  <text x="829" y="731" class="body">Response limits &amp; downloads · next section</text>
+</svg>

--- a/src/app.rs
+++ b/src/app.rs
@@ -9,7 +9,7 @@ use gpui_component::{
     select::{Select, SelectState},
     v_flex,
 };
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use crate::code_snippet_panel::CodeSnippetPanel;
 use crate::collections_panel::{
@@ -60,6 +60,7 @@ pub(crate) struct AppInitialState {
     active_environment_id: Option<i64>,
     history: Vec<crate::types::HistoryItem>,
     collections: Vec<crate::types::Collection>,
+    settings: crate::types::AppSettings,
 }
 
 impl AppInitialState {
@@ -69,12 +70,14 @@ impl AppInitialState {
         let active_environment_id = db.get_active_environment_id()?;
         let history = db.load_recent_history(crate::history_panel::HISTORY_LIMIT)?;
         let collections = db.load_collections()?;
+        let settings = db.load_app_settings()?;
         Ok(Self {
             db,
             environments,
             active_environment_id,
             history,
             collections,
+            settings,
         })
     }
 }
@@ -95,6 +98,9 @@ pub struct PoopmanApp {
     /// `track_focus` call in `render`. Moving it back up kills the window controls.
     focus_handle: FocusHandle,
     db: Arc<Database>,
+    /// Shared with the settings panel and request editor. A setting change
+    /// affects the next request immediately, before its async disk write ends.
+    settings: Arc<RwLock<crate::types::AppSettings>>,
     history_panel: Entity<HistoryPanel>,
     collections_panel: Entity<CollectionsPanel>,
     sidebar_view: SidebarView,
@@ -120,11 +126,15 @@ impl PoopmanApp {
             active_environment_id,
             history,
             collections,
+            settings,
         } = initial;
         db.register_ui_thread();
 
+        let settings = Arc::new(RwLock::new(settings));
+
         // Create components
-        let request_editor = cx.new(|cx| RequestEditor::new(window, cx));
+        let request_editor =
+            cx.new(|cx| RequestEditor::new(settings.clone(), window, cx));
         let response_viewer = cx.new(|cx| ResponseViewer::new(window, cx));
         let history_panel = cx.new(|cx| HistoryPanel::new(db.clone(), history, window, cx));
         let collections_panel =
@@ -389,6 +399,7 @@ impl PoopmanApp {
         Self {
             focus_handle,
             db,
+            settings,
             history_panel,
             collections_panel,
             sidebar_view,
@@ -507,6 +518,39 @@ impl PoopmanApp {
                 .bg(theme.popover)
                 .rounded(px(16.))
                 .child(manager.clone())
+        });
+    }
+
+    /// Open the app-wide HTTP General settings. The panel is fresh on each
+    /// open, but edits share an `Arc<RwLock<_>>` with the request editor.
+    pub(crate) fn open_settings(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let db = self.db.clone();
+        let settings = self.settings.clone();
+        let panel = cx.new(|cx| crate::settings::SettingsPanel::new(db, settings, window, cx));
+        window.open_dialog(cx, move |dialog, _window, cx| {
+            let theme = cx.theme();
+            dialog
+                .title(
+                    v_flex()
+                        .gap_0p5()
+                        .child(
+                            div()
+                                .text_lg()
+                                .font_weight(gpui::FontWeight::BOLD)
+                                .text_color(theme.foreground)
+                                .child("Settings"),
+                        )
+                        .child(
+                            div()
+                                .text_xs()
+                                .text_color(theme.muted_foreground)
+                                .child("Configure request behavior and response safeguards."),
+                        ),
+                )
+                .w(px(880.))
+                .bg(theme.popover)
+                .rounded(px(16.))
+                .child(panel.clone())
         });
     }
 
@@ -1211,7 +1255,16 @@ impl Render for PoopmanApp {
                             cx.entity(),
                             self.environments.clone(),
                             self.active_environment_id,
-                        )),
+                        ))
+                        .child(
+                            Button::new("open-settings")
+                                .ghost()
+                                .icon(gpui_component::Icon::empty().path("icons/settings.svg"))
+                                .tooltip("Settings")
+                                .on_click(cx.listener(|this, _, window, cx| {
+                                    this.open_settings(window, cx);
+                                })),
+                        ),
                 ),
             )
             .child(

--- a/src/db.rs
+++ b/src/db.rs
@@ -19,8 +19,8 @@ use std::sync::{
 use std::thread;
 
 use crate::types::{
-    AuthConfig, BodyType, Collection, CollectionFolder, EnvVar, Environment, HeaderState,
-    HistoryItem, HttpMethod, ParamState, RequestData, SavedRequest,
+    AppSettings, AuthConfig, BodyType, Collection, CollectionFolder, EnvVar, Environment,
+    HeaderState, HistoryItem, HttpMethod, ParamState, RequestData, SavedRequest,
 };
 
 /// A unit of work executed on the database's owning thread.
@@ -1138,16 +1138,64 @@ impl Database {
             Ok(())
         })
     }
+
+    /// Load the app-wide HTTP safeguards. Missing or malformed values are
+    /// intentionally non-fatal: an upgrade should always start with safe
+    /// defaults rather than leave the application unusable.
+    pub fn load_app_settings(&self) -> Result<AppSettings> {
+        self.call(|conn| {
+            let value: Option<String> = conn
+                .query_row(
+                    "SELECT value FROM app_meta WHERE key = 'app_settings'",
+                    [],
+                    |row| row.get(0),
+                )
+                .optional()?;
+            Ok(value
+                .as_deref()
+                .and_then(|json| serde_json::from_str::<AppSettings>(json).ok())
+                .unwrap_or_default()
+                .normalized())
+        })
+    }
+
+    /// Persist all General settings atomically in the existing app metadata
+    /// table. Keeping them in one JSON value makes future settings additions
+    /// backwards-compatible and avoids a schema migration for every field.
+    pub fn save_app_settings(&self, settings: &AppSettings) -> Result<()> {
+        let json = serde_json::to_string(&settings.clone().normalized())?;
+        self.call(move |conn| {
+            conn.execute(
+                "INSERT INTO app_meta (key, value) VALUES ('app_settings', ?1)
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+                params![json],
+            )?;
+            Ok(())
+        })
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use crate::types::{AuthConfig, AuthType};
+    use crate::types::{AppSettings, AuthConfig, AuthType};
 
     fn mem_db() -> Database {
         Database::new_in_memory()
+    }
+
+    #[test]
+    fn app_settings_round_trip_through_metadata() {
+        let db = mem_db();
+        let settings = AppSettings {
+            connect_timeout_ms: 1_500,
+            read_timeout_ms: 2_500,
+            total_timeout_ms: 3_500,
+            max_response_size_bytes: 12 * 1024 * 1024,
+        };
+        db.save_app_settings(&settings).unwrap();
+        assert_eq!(db.load_app_settings().unwrap(), settings);
     }
 
     #[test]

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -1,22 +1,33 @@
-use std::sync::OnceLock;
+use std::{
+    path::{Path, PathBuf},
+    sync::{
+        OnceLock,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
 use anyhow::Result;
+use futures::StreamExt as _;
+use tokio::io::AsyncWriteExt as _;
 use tokio::runtime::Runtime;
 
-use crate::types::{BodyType, FormDataValue, HttpMethod};
+use crate::types::{AppSettings, BodyType, FormDataValue, HttpMethod};
 
 static RUNTIME: OnceLock<Runtime> = OnceLock::new();
-/// Shared reqwest client. A `Client` owns the connection pool and is internally
-/// reference-counted, so one instance is reused across all requests (keep-alive
-/// / pooling / TLS setup are amortized) and cloning is cheap.
-static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+static NEXT_DOWNLOAD_ID: AtomicU64 = AtomicU64::new(1);
 
-/// A fully-read HTTP response. The body is collected on the tokio runtime
-/// (reqwest's body stream requires its reactor), so callers can use it freely.
+/// A completed HTTP response. Normal sends collect a bounded body on the Tokio
+/// runtime; download sends retain only metadata because their body is streamed
+/// to a destination file.
 #[derive(Debug)]
 pub struct HttpResponse {
     pub status: u16,
     pub headers: Vec<(String, String)>,
     pub body: Vec<u8>,
+    /// A download uses the exact same request path, but streams decoded chunks
+    /// to this destination instead of retaining a second complete copy in RAM.
+    pub downloaded_to: Option<PathBuf>,
+    pub downloaded_bytes: Option<u64>,
 }
 
 /// Marker error: the in-flight request was aborted by the user.
@@ -31,6 +42,55 @@ impl std::fmt::Display for RequestCanceled {
 }
 
 impl std::error::Error for RequestCanceled {}
+
+/// A reqwest timeout expressed in language that is safe and useful to show in
+/// the response pane. Raw transport errors can include a URL with credentials.
+#[derive(Debug)]
+pub struct RequestTimedOut;
+
+impl std::fmt::Display for RequestTimedOut {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Request timed out. Adjust the connection, read idle, or total timeout in Settings → General."
+        )
+    }
+}
+
+impl std::error::Error for RequestTimedOut {}
+
+/// Raised only after counting chunks yielded from reqwest's decoded response
+/// stream. `Content-Length` is deliberately not trusted for this safeguard.
+#[derive(Debug)]
+pub struct ResponseLimitExceeded {
+    pub limit_bytes: u64,
+}
+
+impl std::fmt::Display for ResponseLimitExceeded {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Response exceeds the {} viewer limit. Increase it in Settings → General, or use Download to stream the response directly to a file.",
+            format_byte_limit(self.limit_bytes),
+        )
+    }
+}
+
+impl std::error::Error for ResponseLimitExceeded {}
+
+/// Return a user-facing error only for errors that we explicitly made safe to
+/// expose. Other transport failures intentionally remain the generic
+/// "Request failed" so resolved URLs and their secrets never leak into UI.
+pub fn actionable_error_message(error: &anyhow::Error) -> Option<String> {
+    error
+        .downcast_ref::<RequestTimedOut>()
+        .map(ToString::to_string)
+        .or_else(|| {
+            error
+                .downcast_ref::<ResponseLimitExceeded>()
+                .map(ToString::to_string)
+        })
+}
 
 /// A request already running on the tokio runtime. `abort_handle()` lets the
 /// UI abort the underlying task — the transfer really stops, the result isn't
@@ -57,19 +117,23 @@ impl InFlightRequest {
 /// tokio runtime.
 pub struct HttpClient {
     client: reqwest::Client,
+    settings: AppSettings,
 }
 
 impl HttpClient {
-    pub fn new() -> Self {
-        let client = CLIENT
-            .get_or_init(|| {
-                reqwest::Client::builder()
-                    .build()
-                    .expect("Failed to initialize HTTP client")
-            })
-            .clone();
+    /// Build a client for one request. Reqwest's timeout configuration belongs
+    /// to a `Client`, so creating it at this boundary means a General-settings
+    /// edit affects the next request immediately rather than only after restart.
+    pub fn new(settings: AppSettings) -> Self {
+        let settings = settings.normalized();
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_millis(settings.connect_timeout_ms))
+            .read_timeout(Duration::from_millis(settings.read_timeout_ms))
+            .timeout(Duration::from_millis(settings.total_timeout_ms))
+            .build()
+            .expect("Failed to initialize HTTP client");
 
-        Self { client }
+        Self { client, settings }
     }
 
     /// Spawn a request built from our own model onto the shared tokio runtime
@@ -88,93 +152,245 @@ impl HttpClient {
         body: BodyType,
     ) -> InFlightRequest {
         let client = self.client.clone();
+        let max_response_size_bytes = self.settings.max_response_size_bytes;
 
-        let runtime = RUNTIME.get_or_init(|| {
-            tokio::runtime::Builder::new_multi_thread()
-                .worker_threads(2)
-                .enable_all()
-                .build()
-                .expect("Failed to initialize tokio runtime")
+        let handle = runtime().spawn(async move {
+            let response = send_request(client, method, url, headers, body).await?;
+            collect_response(response, max_response_size_bytes).await
         });
 
-        let handle = runtime
-            .spawn(async move {
-                let reqwest_method = reqwest::Method::from_bytes(method.as_str().as_bytes())?;
-                let mut req = client.request(reqwest_method, &url);
-
-                let is_form = matches!(body, BodyType::FormData(_));
-                for (key, value) in &headers {
-                    // Never send a manual Content-Length — reqwest computes the correct
-                    // one from the actual body. A stale value (e.g. the predefined "0")
-                    // truncates the request body server-side (multipart boundary then
-                    // can't be found -> 400). reqwest's .header() appends, so we must
-                    // skip it here rather than rely on override.
-                    if key.eq_ignore_ascii_case("content-length") {
-                        continue;
-                    }
-                    // For multipart, let reqwest set Content-Type — it includes the
-                    // boundary. A manually-set one would lack the boundary.
-                    if is_form && key.eq_ignore_ascii_case("content-type") {
-                        continue;
-                    }
-                    req = req.header(key.as_str(), value.as_str());
-                }
-
-                match body {
-                    BodyType::None => {}
-                    BodyType::Raw { content, .. } => {
-                        req = req.body(content.into_bytes());
-                    }
-                    BodyType::FormData(rows) => {
-                        let mut form = reqwest::multipart::Form::new();
-                        for row in rows {
-                            if !row.enabled || row.key.is_empty() {
-                                continue;
-                            }
-                            match row.value {
-                                FormDataValue::Text(text) => {
-                                    form = form.text(row.key, text);
-                                }
-                                FormDataValue::File { path } => {
-                                    if path.is_empty() {
-                                        continue;
-                                    }
-                                    // Reads the file and guesses MIME from its extension.
-                                    form = form.file(row.key, &path).await.map_err(|e| {
-                                        anyhow::anyhow!("Failed to read file '{}': {}", path, e)
-                                    })?;
-                                }
-                            }
-                        }
-                        req = req.multipart(form);
-                    }
-                }
-
-                let response = req.send().await?;
-                let status = response.status().as_u16();
-                let headers = response
-                    .headers()
-                    .iter()
-                    .filter_map(|(k, v)| v.to_str().ok().map(|s| (k.to_string(), s.to_string())))
-                    .collect::<Vec<_>>();
-                let body = response.bytes().await?.to_vec();
-
-                Ok::<HttpResponse, anyhow::Error>(HttpResponse {
-                    status,
-                    headers,
-                    body,
-                })
-            });
-
         InFlightRequest { handle }
+    }
+
+    /// Start a request whose decoded body is streamed to `destination`. The
+    /// response status and headers still reach the UI, while the body stays out
+    /// of the response viewer and never needs a complete in-memory allocation.
+    pub fn start_download(
+        &self,
+        method: HttpMethod,
+        url: String,
+        headers: Vec<(String, String)>,
+        body: BodyType,
+        destination: PathBuf,
+    ) -> InFlightRequest {
+        let client = self.client.clone();
+        let handle = runtime().spawn(async move {
+            let response = send_request(client, method, url, headers, body).await?;
+            download_response(response, destination).await
+        });
+        InFlightRequest { handle }
+    }
+}
+
+fn runtime() -> &'static Runtime {
+    RUNTIME.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()
+            .expect("Failed to initialize tokio runtime")
+    })
+}
+
+async fn send_request(
+    client: reqwest::Client,
+    method: HttpMethod,
+    url: String,
+    headers: Vec<(String, String)>,
+    body: BodyType,
+) -> Result<reqwest::Response> {
+    let reqwest_method = reqwest::Method::from_bytes(method.as_str().as_bytes())?;
+    let mut req = client.request(reqwest_method, &url);
+
+    let is_form = matches!(body, BodyType::FormData(_));
+    for (key, value) in &headers {
+        // Never send a manual Content-Length — reqwest computes the correct one
+        // from the actual body. A stale predefined value would truncate it.
+        if key.eq_ignore_ascii_case("content-length") {
+            continue;
+        }
+        // For multipart, reqwest owns Content-Type so it includes its boundary.
+        if is_form && key.eq_ignore_ascii_case("content-type") {
+            continue;
+        }
+        req = req.header(key.as_str(), value.as_str());
+    }
+
+    match body {
+        BodyType::None => {}
+        BodyType::Raw { content, .. } => {
+            req = req.body(content.into_bytes());
+        }
+        BodyType::FormData(rows) => {
+            let mut form = reqwest::multipart::Form::new();
+            for row in rows {
+                if !row.enabled || row.key.is_empty() {
+                    continue;
+                }
+                match row.value {
+                    FormDataValue::Text(text) => {
+                        form = form.text(row.key, text);
+                    }
+                    FormDataValue::File { path } => {
+                        if path.is_empty() {
+                            continue;
+                        }
+                        form = form.file(row.key, &path).await.map_err(|e| {
+                            anyhow::anyhow!("Failed to read file '{}': {}", path, e)
+                        })?;
+                    }
+                }
+            }
+            req = req.multipart(form);
+        }
+    }
+
+    req.send().await.map_err(classify_reqwest_error)
+}
+
+fn response_metadata(response: &reqwest::Response) -> (u16, Vec<(String, String)>) {
+    let status = response.status().as_u16();
+    let headers = response
+        .headers()
+        .iter()
+        .filter_map(|(k, v)| v.to_str().ok().map(|s| (k.to_string(), s.to_string())))
+        .collect();
+    (status, headers)
+}
+
+async fn collect_response(response: reqwest::Response, limit_bytes: u64) -> Result<HttpResponse> {
+    let (status, headers) = response_metadata(&response);
+    let mut body = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(classify_reqwest_error)?;
+        let next_len = body.len().saturating_add(chunk.len()) as u64;
+        if next_len > limit_bytes {
+            return Err(anyhow::Error::new(ResponseLimitExceeded { limit_bytes }));
+        }
+        body.extend_from_slice(&chunk);
+    }
+
+    Ok(HttpResponse {
+        status,
+        headers,
+        body,
+        downloaded_to: None,
+        downloaded_bytes: None,
+    })
+}
+
+/// Drop-cleaned partial file. Aborting the tokio task drops this guard, so a
+/// canceled/erroring transfer never leaves a misleading completed destination.
+struct PartialDownload {
+    path: PathBuf,
+    keep: bool,
+}
+
+impl PartialDownload {
+    fn new(path: PathBuf) -> Self {
+        Self { path, keep: false }
+    }
+
+    fn keep(&mut self) {
+        self.keep = true;
+    }
+}
+
+impl Drop for PartialDownload {
+    fn drop(&mut self) {
+        if !self.keep {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+fn partial_download_path(destination: &Path) -> PathBuf {
+    let name = destination
+        .file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("response.bin");
+    let id = NEXT_DOWNLOAD_ID.fetch_add(1, Ordering::Relaxed);
+    destination.with_file_name(format!(
+        ".{name}.poopman-download-{}-{id}.part",
+        std::process::id()
+    ))
+}
+
+async fn download_response(response: reqwest::Response, destination: PathBuf) -> Result<HttpResponse> {
+    if destination.exists() {
+        return Err(anyhow::anyhow!(
+            "The selected download destination already exists. Choose a new filename."
+        ));
+    }
+
+    let (status, headers) = response_metadata(&response);
+    let partial_path = partial_download_path(&destination);
+    let mut partial = PartialDownload::new(partial_path.clone());
+    let mut file = tokio::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&partial_path)
+        .await
+        .map_err(|e| anyhow::anyhow!("Could not create the selected download file: {e}"))?;
+
+    let mut downloaded_bytes = 0u64;
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(classify_reqwest_error)?;
+        file.write_all(&chunk)
+            .await
+            .map_err(|e| anyhow::anyhow!("Could not write the download file: {e}"))?;
+        downloaded_bytes = downloaded_bytes.saturating_add(chunk.len() as u64);
+    }
+    file.flush()
+        .await
+        .map_err(|e| anyhow::anyhow!("Could not finish writing the download file: {e}"))?;
+    drop(file);
+    tokio::fs::rename(&partial_path, &destination)
+        .await
+        .map_err(|e| anyhow::anyhow!("Could not finalize the download file: {e}"))?;
+    partial.keep();
+
+    Ok(HttpResponse {
+        status,
+        headers,
+        body: vec![],
+        downloaded_to: Some(destination),
+        downloaded_bytes: Some(downloaded_bytes),
+    })
+}
+
+fn classify_reqwest_error(error: reqwest::Error) -> anyhow::Error {
+    if error.is_timeout() {
+        anyhow::Error::new(RequestTimedOut)
+    } else {
+        error.into()
+    }
+}
+
+fn format_byte_limit(bytes: u64) -> String {
+    if bytes % (1024 * 1024) == 0 {
+        format!("{} MiB", bytes / (1024 * 1024))
+    } else if bytes % 1024 == 0 {
+        format!("{} KiB", bytes / 1024)
+    } else {
+        format!("{bytes} bytes")
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{BodyType, HttpMethod};
+    use crate::types::{AppSettings, BodyType, HttpMethod};
+    use flate2::{Compression, write::GzEncoder};
     use std::io::{Read as _, Write as _};
+    use std::time::Duration;
+
+    fn test_settings() -> AppSettings {
+        AppSettings::default()
+    }
 
     /// Block on a future using the same runtime `start_send` spawned onto.
     /// (Awaiting a JoinHandle from outside the runtime is exactly what the
@@ -193,7 +409,7 @@ mod tests {
         let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
         let url = format!("http://{}/", listener.local_addr().unwrap());
 
-        let client = HttpClient::new();
+        let client = HttpClient::new(test_settings());
         let inflight = client.start_send(HttpMethod::GET, url, vec![], BodyType::None);
         inflight.abort_handle().abort();
 
@@ -221,11 +437,148 @@ mod tests {
                 .unwrap();
         });
 
-        let client = HttpClient::new();
+        let client = HttpClient::new(test_settings());
         let inflight = client.start_send(HttpMethod::GET, url, vec![], BodyType::None);
 
         let response = block_on(inflight.wait()).expect("request should succeed");
         assert_eq!(response.status, 200);
         assert_eq!(response.body, b"hi");
+    }
+
+    #[test]
+    fn total_timeout_stops_a_server_that_never_responds() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}/", listener.local_addr().unwrap());
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            std::thread::sleep(Duration::from_millis(180));
+        });
+
+        let mut settings = test_settings();
+        settings.total_timeout_ms = 40;
+        settings.read_timeout_ms = 500;
+        let inflight = HttpClient::new(settings).start_send(HttpMethod::GET, url, vec![], BodyType::None);
+        let error = block_on(inflight.wait()).expect_err("stalled request should time out");
+        assert!(error.downcast_ref::<RequestTimedOut>().is_some(), "{error:#}");
+    }
+
+    #[test]
+    fn read_idle_timeout_stops_a_stalled_response_body() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}/", listener.local_addr().unwrap());
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 4\r\nConnection: close\r\n\r\n")
+                .unwrap();
+            stream.flush().unwrap();
+            std::thread::sleep(Duration::from_millis(180));
+        });
+
+        let mut settings = test_settings();
+        settings.read_timeout_ms = 40;
+        settings.total_timeout_ms = 500;
+        let inflight = HttpClient::new(settings).start_send(HttpMethod::GET, url, vec![], BodyType::None);
+        let error = block_on(inflight.wait()).expect_err("idle body should time out");
+        assert!(error.downcast_ref::<RequestTimedOut>().is_some(), "{error:#}");
+    }
+
+    #[test]
+    fn chunked_response_limit_does_not_trust_content_length() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}/", listener.local_addr().unwrap());
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nConnection: close\r\n\r\n400\r\n",
+                )
+                .unwrap();
+            stream.write_all(&vec![b'x'; 1024]).unwrap();
+            stream.write_all(b"\r\n400\r\n").unwrap();
+            stream.write_all(&vec![b'y'; 1024]).unwrap();
+            stream.write_all(b"\r\n0\r\n\r\n").unwrap();
+        });
+
+        let mut settings = test_settings();
+        settings.max_response_size_bytes = 1_024;
+        let inflight = HttpClient::new(settings).start_send(HttpMethod::GET, url, vec![], BodyType::None);
+        let error = block_on(inflight.wait()).expect_err("chunked body should exceed limit");
+        let limit = error
+            .downcast_ref::<ResponseLimitExceeded>()
+            .expect("expected response limit error");
+        assert_eq!(limit.limit_bytes, 1_024);
+    }
+
+    #[test]
+    fn compressed_response_limit_counts_decoded_bytes() {
+        let plain = vec![b'x'; 4 * 1024];
+        let mut gzip = GzEncoder::new(Vec::new(), Compression::default());
+        gzip.write_all(&plain).unwrap();
+        let compressed = gzip.finish().unwrap();
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}/", listener.local_addr().unwrap());
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            stream
+                .write_all(
+                    format!(
+                        "HTTP/1.1 200 OK\r\nContent-Encoding: gzip\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                        compressed.len()
+                    )
+                    .as_bytes(),
+                )
+                .unwrap();
+            stream.write_all(&compressed).unwrap();
+        });
+
+        let mut settings = test_settings();
+        settings.max_response_size_bytes = 1_024;
+        let inflight = HttpClient::new(settings).start_send(HttpMethod::GET, url, vec![], BodyType::None);
+        let error = block_on(inflight.wait()).expect_err("decoded gzip body should exceed limit");
+        assert!(error.downcast_ref::<ResponseLimitExceeded>().is_some(), "{error:#}");
+    }
+
+    #[test]
+    fn download_streams_to_disk_without_retaining_body() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}/", listener.local_addr().unwrap());
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 4096];
+            let _ = stream.read(&mut buf);
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 11\r\nConnection: close\r\n\r\nhello world",
+                )
+                .unwrap();
+        });
+        let destination = std::env::temp_dir().join(format!(
+            "poopman-http-client-test-{}-{}.bin",
+            std::process::id(),
+            NEXT_DOWNLOAD_ID.fetch_add(1, Ordering::Relaxed)
+        ));
+
+        let inflight = HttpClient::new(test_settings()).start_download(
+            HttpMethod::GET,
+            url,
+            vec![],
+            BodyType::None,
+            destination.clone(),
+        );
+        let response = block_on(inflight.wait()).expect("download should succeed");
+        assert!(response.body.is_empty());
+        assert_eq!(response.downloaded_bytes, Some(11));
+        assert_eq!(std::fs::read(&destination).unwrap(), b"hello world");
+        std::fs::remove_file(destination).unwrap();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod postman;
 mod request_editor;
 mod request_tab;
 mod response_viewer;
+mod settings;
 mod tab_bar;
 mod theme;
 mod types;

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -4,7 +4,12 @@ use gpui::*;
 use gpui_component::input::InputEvent;
 use gpui_component::{
     ActiveTheme as _, Disableable as _, Icon, IndexPath, Sizable as _, WindowExt, button::*,
-    checkbox::Checkbox, input::*, scroll::ScrollableElement as _, select::*, v_flex,
+    checkbox::Checkbox, input::*, menu::PopupMenuItem, scroll::ScrollableElement as _,
+    select::*, v_flex,
+};
+use std::{
+    path::PathBuf,
+    sync::{Arc, RwLock},
 };
 
 use crate::auth_editor::AuthEditor;
@@ -122,6 +127,8 @@ pub struct RequestEditor {
     /// Whether the active tab is associated with a request in a collection.
     /// Saved requests use a filled bookmark in the request bar.
     is_saved_request: bool,
+    /// App-wide transfer settings shared with the Settings dialog.
+    settings: Arc<RwLock<crate::types::AppSettings>>,
 }
 
 impl RequestEditor {
@@ -150,7 +157,11 @@ impl RequestEditor {
         });
     }
 
-    pub fn new(window: &mut Window, cx: &mut Context<Self>) -> Self {
+    pub fn new(
+        settings: Arc<RwLock<crate::types::AppSettings>>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
         let url_input =
             cx.new(|cx| InputState::new(window, cx).placeholder("https://api.github.com/zen"));
 
@@ -192,6 +203,7 @@ impl RequestEditor {
             _row_subscriptions: vec![],
             env_vars: std::collections::HashMap::new(),
             is_saved_request: false,
+            settings,
         };
 
         // Subscribe to URL input changes: a pasted `curl …` command imports the
@@ -1157,6 +1169,28 @@ impl RequestEditor {
         self.send(window, cx);
     }
 
+    /// Ask for a destination before starting the request. The file picker runs
+    /// before networking begins so `start_download` can stream every decoded
+    /// chunk directly there instead of first filling the response viewer.
+    fn prompt_download_destination(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.active_tab_is_loading() {
+            return;
+        }
+        let dir = dirs::download_dir()
+            .or_else(dirs::home_dir)
+            .unwrap_or_else(|| PathBuf::from("."));
+        let picker = cx.prompt_for_new_path(&dir, Some("response.bin"));
+        cx.spawn_in(window, async move |this, cx| {
+            if let Ok(Ok(Some(path))) = picker.await {
+                this.update_in(cx, |this, window, cx| {
+                    this.send_with_destination(Some(path), window, cx);
+                })?;
+            }
+            Ok::<_, anyhow::Error>(())
+        })
+        .detach();
+    }
+
     /// Focus the URL input and select all of its text. Public so the ctrl-l
     /// action can trigger it from PoopmanApp.
     ///
@@ -1173,6 +1207,18 @@ impl RequestEditor {
     /// it from PoopmanApp; no-op while a request is already in flight (the
     /// button is swapped to Cancel then, but the keyboard path isn't).
     pub fn send(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.send_with_destination(None, window, cx);
+    }
+
+    /// Send normally, or stream the decoded response into a user-selected
+    /// destination. The latter follows the same request/auth/history path but
+    /// never allocates a full response body for the viewer.
+    fn send_with_destination(
+        &mut self,
+        destination: Option<PathBuf>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         if self.active_tab_is_loading() {
             return;
         }
@@ -1302,9 +1348,17 @@ impl RequestEditor {
         // Spawn the HTTP work onto the tokio runtime *now* so we can hold an
         // abort handle; the gpui task below only awaits the outcome.
         let start = std::time::Instant::now();
-        let client = crate::http_client::HttpClient::new();
+        let settings = self
+            .settings
+            .read()
+            .expect("settings lock poisoned")
+            .clone();
+        let client = crate::http_client::HttpClient::new(settings);
         let wire_headers = crate::types::effective_wire_headers(&headers, &resolved_auth);
-        let inflight = client.start_send(method, url, wire_headers, body);
+        let inflight = match destination {
+            Some(destination) => client.start_download(method, url, wire_headers, body, destination),
+            None => client.start_send(method, url, wire_headers, body),
+        };
         self.in_flight.insert(
             tab_id,
             InFlightRequest {
@@ -1334,7 +1388,8 @@ impl RequestEditor {
                     // Transport errors can embed the fully-resolved URL. Never
                     // copy them into logs or the response viewer because that
                     // URL may contain environment-backed credentials.
-                    let error_message = "Request failed".to_string();
+                    let error_message = crate::http_client::actionable_error_message(&e)
+                        .unwrap_or_else(|| "Request failed".to_string());
                     log::error!("{}", error_message);
 
                     let error_response = ResponseData {
@@ -1343,6 +1398,8 @@ impl RequestEditor {
                         headers: vec![],
                         body: error_message.into_bytes(),
                         is_text: true,
+                        downloaded_to: None,
+                        downloaded_bytes: None,
                     };
 
                     this.update(cx, |this, cx| {
@@ -1375,7 +1432,13 @@ impl RequestEditor {
                 duration.as_millis()
             );
 
-            let is_text = crate::types::is_text_response(&response.headers, &response.body);
+            let downloaded_to = response
+                .downloaded_to
+                .as_ref()
+                .map(|path| path.to_string_lossy().into_owned());
+            let downloaded_bytes = response.downloaded_bytes;
+            let is_text = downloaded_to.is_none()
+                && crate::types::is_text_response(&response.headers, &response.body);
             log::debug!(
                 "Response body size: {} bytes (text={})",
                 response.body.len(),
@@ -1388,6 +1451,8 @@ impl RequestEditor {
                 headers: response.headers,
                 body: response.body,
                 is_text,
+                downloaded_to,
+                downloaded_bytes,
             };
 
             this.update(cx, |this, cx| {
@@ -1499,11 +1564,30 @@ impl Render for RequestEditor {
                                     .danger()
                                     .label("Cancel")
                                     .on_click(cx.listener(Self::cancel_request))
+                                    .into_any_element()
                             } else {
-                                Button::new("send-btn")
-                                    .primary()
-                                    .label("Send")
-                                    .on_click(cx.listener(Self::send_request))
+                                {
+                                    let editor = cx.entity();
+                                    DropdownButton::new("send-split-btn")
+                                        .primary()
+                                        .button(
+                                            Button::new("send-btn")
+                                                .label("Send")
+                                                .on_click(cx.listener(Self::send_request)),
+                                        )
+                                        .dropdown_menu(move |menu, _window, _cx| {
+                                            let editor = editor.clone();
+                                            menu.item(
+                                                PopupMenuItem::new("Download response…")
+                                                    .on_click(move |_, window, cx| {
+                                                        editor.update(cx, |editor, cx| {
+                                                            editor.prompt_download_destination(window, cx);
+                                                        });
+                                                    }),
+                                            )
+                                        })
+                                        .into_any_element()
+                                }
                             }),
                         ),
                 )

--- a/src/request_tab.rs
+++ b/src/request_tab.rs
@@ -236,6 +236,8 @@ mod tests {
             headers: vec![],
             body: vec![],
             is_text: true,
+            downloaded_to: None,
+            downloaded_bytes: None,
         }));
         assert!(!tab.is_blank());
     }
@@ -257,6 +259,8 @@ mod tests {
             headers: vec![],
             body: status.to_string().into_bytes(),
             is_text: true,
+            downloaded_to: None,
+            downloaded_bytes: None,
         })
     }
 

--- a/src/response_viewer.rs
+++ b/src/response_viewer.rs
@@ -207,7 +207,7 @@ impl ResponseViewer {
     ) {
         self.canceled = false;
         // Pre-build an inline preview for image responses (binary only).
-        self.preview_image = if response.is_text {
+        self.preview_image = if response.is_text || response.downloaded_to.is_some() {
             None
         } else {
             response
@@ -226,7 +226,10 @@ impl ResponseViewer {
         // Binary responses use their dedicated preview. Text response metadata
         // is visible immediately; its expensive display representation arrives
         // asynchronously or is restored from the prepared-state cache.
-        if response.is_text {
+        if response.downloaded_to.is_some() {
+            // The body deliberately remains empty: Download has already
+            // streamed it to disk without a viewer-sized allocation.
+        } else if response.is_text {
             if let Some(cached) = self.take_cached_body(&response) {
                 #[cfg(feature = "profile")]
                 profiling::scope!("response body cache hit");
@@ -468,7 +471,13 @@ impl ResponseViewer {
                     "Time: {}",
                     crate::format::format_duration_ms(response.duration_ms)
                 )))
-                .when(!response.is_network_error(), |this| {
+                .when_some(response.downloaded_bytes, |this, downloaded_bytes| {
+                    this.child(div().text_sm().child(format!(
+                        "Downloaded: {}",
+                        crate::format::format_size(downloaded_bytes as usize)
+                    )))
+                })
+                .when(response.downloaded_bytes.is_none() && !response.is_network_error(), |this| {
                     this.child(div().text_sm().child(format!(
                         "Size: {}",
                         crate::format::format_size(response.body.len())
@@ -616,6 +625,42 @@ impl Render for ResponseViewer {
                                 ),
                         )
                         .when(self.active_tab == 0, |this| {
+                            if let Some(path) = self
+                                .response
+                                .as_ref()
+                                .and_then(|response| response.downloaded_to.clone())
+                            {
+                                let downloaded_bytes = self
+                                    .response
+                                    .as_ref()
+                                    .and_then(|response| response.downloaded_bytes)
+                                    .unwrap_or(0);
+                                return this.child(
+                                    v_flex()
+                                        .flex_1()
+                                        .w_full()
+                                        .items_center()
+                                        .justify_center()
+                                        .gap_2()
+                                        .child(
+                                            div()
+                                                .text_sm()
+                                                .font_weight(FontWeight::SEMIBOLD)
+                                                .text_color(theme.success)
+                                                .child("Download complete"),
+                                        )
+                                        .child(
+                                            div()
+                                                .text_xs()
+                                                .text_color(theme.muted_foreground)
+                                                .child(format!(
+                                                    "{} saved to {}",
+                                                    crate::format::format_size(downloaded_bytes as usize),
+                                                    path
+                                                )),
+                                        ),
+                                );
+                            }
                             let resp_is_text = self.response.as_ref().is_none_or(|r| r.is_text);
                             if resp_is_text {
                                 let body_display = self.body_display.clone();

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,475 @@
+//! App-wide HTTP safety settings. The panel owns only the editable controls;
+//! the live value is shared with the request editor, so a successful edit takes
+//! effect for the very next request without restarting the app.
+
+use std::{
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+
+use gpui::prelude::FluentBuilder as _;
+use gpui::*;
+use gpui_component::{
+    ActiveTheme as _, IndexPath, Sizable as _, h_flex,
+    input::{Input, InputEvent as InputChangeEvent, InputState},
+    select::{Select, SelectState},
+    v_flex,
+};
+
+use crate::{db::Database, types::AppSettings};
+
+const MAX_TIMEOUT_MS: u64 = 3_600_000;
+const MIN_RESPONSE_LIMIT_MIB: u64 = 1;
+const MAX_RESPONSE_LIMIT_MIB: u64 = 2_048;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SaveStatus {
+    Saved,
+    Saving,
+    Invalid,
+    Failed,
+}
+
+impl SaveStatus {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Saved => "Changes are saved automatically",
+            Self::Saving => "Saving changes…",
+            Self::Invalid => "Use a positive whole number within the supported range",
+            Self::Failed => "Changes could not be saved",
+        }
+    }
+}
+
+/// The General page rendered inside Poopman's Settings dialog.
+pub struct SettingsPanel {
+    db: Arc<Database>,
+    settings: Arc<RwLock<AppSettings>>,
+    http_version: Entity<SelectState<Vec<&'static str>>>,
+    connect_timeout: Entity<InputState>,
+    read_timeout: Entity<InputState>,
+    total_timeout: Entity<InputState>,
+    response_limit: Entity<InputState>,
+    status: SaveStatus,
+    save_generation: u64,
+    _subscriptions: Vec<Subscription>,
+}
+
+impl SettingsPanel {
+    pub fn new(
+        db: Arc<Database>,
+        settings: Arc<RwLock<AppSettings>>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let current = settings
+            .read()
+            .expect("settings lock poisoned")
+            .clone()
+            .normalized();
+        let http_version = cx
+            .new(|cx| SelectState::new(vec!["Automatic"], Some(IndexPath::default()), window, cx));
+        let connect_timeout = number_input(
+            &current.connect_timeout_ms.to_string(),
+            "10,000",
+            window,
+            cx,
+        );
+        let read_timeout = number_input(&current.read_timeout_ms.to_string(), "30,000", window, cx);
+        let total_timeout =
+            number_input(&current.total_timeout_ms.to_string(), "60,000", window, cx);
+        let response_limit = number_input(
+            &current.response_limit_mebibytes().to_string(),
+            "50",
+            window,
+            cx,
+        );
+
+        let mut panel = Self {
+            db,
+            settings,
+            http_version,
+            connect_timeout,
+            read_timeout,
+            total_timeout,
+            response_limit,
+            status: SaveStatus::Saved,
+            save_generation: 0,
+            _subscriptions: vec![],
+        };
+        panel.wire_inputs(window, cx);
+        panel
+    }
+
+    fn wire_inputs(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let inputs = [
+            self.connect_timeout.clone(),
+            self.read_timeout.clone(),
+            self.total_timeout.clone(),
+            self.response_limit.clone(),
+        ];
+        self._subscriptions = inputs
+            .iter()
+            .map(|input| {
+                cx.subscribe_in(
+                    input,
+                    window,
+                    |this, _, event: &InputChangeEvent, window, cx| {
+                        if matches!(event, InputChangeEvent::Change) {
+                            this.commit(window, cx);
+                        }
+                    },
+                )
+            })
+            .collect();
+    }
+
+    fn value(input: &Entity<InputState>, cx: &App) -> Option<u64> {
+        input
+            .read(cx)
+            .value()
+            .trim()
+            .replace(',', "")
+            .parse::<u64>()
+            .ok()
+    }
+
+    fn form_settings(&self, cx: &App) -> Option<AppSettings> {
+        let connect_timeout_ms = Self::value(&self.connect_timeout, cx)?;
+        let read_timeout_ms = Self::value(&self.read_timeout, cx)?;
+        let total_timeout_ms = Self::value(&self.total_timeout, cx)?;
+        let response_limit_mib = Self::value(&self.response_limit, cx)?;
+        if !(1..=MAX_TIMEOUT_MS).contains(&connect_timeout_ms)
+            || !(1..=MAX_TIMEOUT_MS).contains(&read_timeout_ms)
+            || !(1..=MAX_TIMEOUT_MS).contains(&total_timeout_ms)
+            || !(MIN_RESPONSE_LIMIT_MIB..=MAX_RESPONSE_LIMIT_MIB).contains(&response_limit_mib)
+        {
+            return None;
+        }
+        Some(AppSettings {
+            connect_timeout_ms,
+            read_timeout_ms,
+            total_timeout_ms,
+            max_response_size_bytes: response_limit_mib * 1024 * 1024,
+        })
+    }
+
+    /// Apply a valid value immediately to the shared runtime settings, then
+    /// coalesce rapid typing into one SQLite write. A generation check prevents
+    /// an older debounce from overwriting a newer value.
+    fn commit(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        let Some(settings) = self.form_settings(cx) else {
+            self.status = SaveStatus::Invalid;
+            cx.notify();
+            return;
+        };
+        *self.settings.write().expect("settings lock poisoned") = settings.clone();
+        self.save_generation = self.save_generation.wrapping_add(1);
+        let generation = self.save_generation;
+        self.status = SaveStatus::Saving;
+        cx.notify();
+
+        let db = self.db.clone();
+        cx.spawn_in(window, async move |this, cx| {
+            cx.background_executor()
+                .timer(Duration::from_millis(180))
+                .await;
+            let is_current = this
+                .update(cx, |this, _| this.save_generation == generation)
+                .unwrap_or(false);
+            if !is_current {
+                return Ok(());
+            }
+            let save = cx.background_spawn(async move { db.save_app_settings(&settings) });
+            let result = save.await;
+            this.update(cx, |this, cx| {
+                if this.save_generation != generation {
+                    return;
+                }
+                this.status = if result.is_ok() {
+                    SaveStatus::Saved
+                } else {
+                    log::error!("Failed to save settings: {}", result.unwrap_err());
+                    SaveStatus::Failed
+                };
+                cx.notify();
+            })?;
+            Ok::<_, anyhow::Error>(())
+        })
+        .detach();
+    }
+
+    fn timeout_row(
+        theme: &gpui_component::Theme,
+        label: &'static str,
+        description: &'static str,
+        input: Entity<InputState>,
+        top_border: bool,
+    ) -> Div {
+        h_flex()
+            .w_full()
+            .items_center()
+            .justify_between()
+            .gap_6()
+            .px_5()
+            .py_4()
+            .when(top_border, |row| {
+                row.border_t_1().border_color(theme.border)
+            })
+            .child(
+                v_flex()
+                    .flex_1()
+                    .min_w_0()
+                    .gap_1()
+                    .child(
+                        div()
+                            .text_sm()
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .text_color(theme.foreground)
+                            .child(label),
+                    )
+                    .child(
+                        div()
+                            .text_xs()
+                            .text_color(theme.muted_foreground)
+                            .child(description),
+                    ),
+            )
+            .child(
+                h_flex()
+                    .items_center()
+                    .gap_2()
+                    .flex_shrink_0()
+                    .child(div().w(px(126.)).child(Input::new(&input).small()))
+                    .child(
+                        div()
+                            .w(px(28.))
+                            .text_xs()
+                            .text_color(theme.muted_foreground)
+                            .child("ms"),
+                    ),
+            )
+    }
+}
+
+fn number_input(
+    value: &str,
+    placeholder: &'static str,
+    window: &mut Window,
+    cx: &mut Context<SettingsPanel>,
+) -> Entity<InputState> {
+    let value = value.to_string();
+    cx.new(move |cx| {
+        let mut input = InputState::new(window, cx).placeholder(placeholder);
+        input.set_value(&value, window, cx);
+        input
+    })
+}
+
+impl Render for SettingsPanel {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let theme = cx.theme();
+        let (status_color, status_text_color) = match self.status {
+            SaveStatus::Saved => (theme.success, theme.muted_foreground),
+            SaveStatus::Saving => (theme.warning, theme.muted_foreground),
+            SaveStatus::Invalid | SaveStatus::Failed => (theme.danger, theme.danger),
+        };
+
+        v_flex()
+            .w_full()
+            .h(px(550.))
+            .gap_3()
+            .child(
+                h_flex()
+                    .w_full()
+                    .items_center()
+                    .gap_3()
+                    .px_1()
+                    .child(
+                        div()
+                            .px_3()
+                            .py_1p5()
+                            .rounded(theme.radius)
+                            .bg(theme.primary.opacity(0.12))
+                            .text_sm()
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .text_color(theme.primary)
+                            .child("General"),
+                    )
+                    .child(
+                        div()
+                            .text_sm()
+                            .text_color(theme.muted_foreground)
+                            .child("Request defaults and safeguards"),
+                    ),
+            )
+            .child(
+                crate::ui::inset_panel(theme)
+                    .flex()
+                    .flex_col()
+                    .w_full()
+                    .child(
+                        div()
+                            .px_5()
+                            .pt_4()
+                            .text_xs()
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .text_color(theme.muted_foreground)
+                            .child("REQUEST"),
+                    )
+                    .child(
+                        h_flex()
+                            .w_full()
+                            .items_center()
+                            .justify_between()
+                            .gap_6()
+                            .px_5()
+                            .py_4()
+                            .child(
+                                v_flex()
+                                    .flex_1()
+                                    .min_w_0()
+                                    .gap_1()
+                                    .child(
+                                        div()
+                                            .text_sm()
+                                            .font_weight(FontWeight::SEMIBOLD)
+                                            .text_color(theme.foreground)
+                                            .child("HTTP version"),
+                                    )
+                                    .child(
+                                        div()
+                                            .text_xs()
+                                            .text_color(theme.muted_foreground)
+                                            .child("Choose the protocol preference used for outgoing requests."),
+                                    ),
+                            )
+                            .child(
+                                div()
+                                    .w(px(172.))
+                                    .flex_shrink_0()
+                                    .child(Select::new(&self.http_version)),
+                            ),
+                    )
+                    .child(
+                        div()
+                            .px_5()
+                            .pt_3()
+                            .text_xs()
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .text_color(theme.muted_foreground)
+                            .child("TIMEOUTS"),
+                    )
+                    .child(Self::timeout_row(
+                        theme,
+                        "Connect timeout",
+                        "Stop if a connection cannot be established in time.",
+                        self.connect_timeout.clone(),
+                        false,
+                    ))
+                    .child(Self::timeout_row(
+                        theme,
+                        "Read idle timeout",
+                        "Stop when a connected server stops sending response data.",
+                        self.read_timeout.clone(),
+                        true,
+                    ))
+                    .child(Self::timeout_row(
+                        theme,
+                        "Total request timeout",
+                        "A final limit for the complete request, including download time.",
+                        self.total_timeout.clone(),
+                        true,
+                    ))
+                    .child(
+                        div()
+                            .px_5()
+                            .pt_3()
+                            .text_xs()
+                            .font_weight(FontWeight::SEMIBOLD)
+                            .text_color(theme.muted_foreground)
+                            .border_t_1()
+                            .border_color(theme.border)
+                            .child("RESPONSE LIMITS & DOWNLOADS"),
+                    )
+                    .child(
+                        h_flex()
+                            .w_full()
+                            .items_center()
+                            .justify_between()
+                            .gap_6()
+                            .px_5()
+                            .py_4()
+                            .child(
+                                v_flex()
+                                    .flex_1()
+                                    .min_w_0()
+                                    .gap_1()
+                                    .child(
+                                        div()
+                                            .text_sm()
+                                            .font_weight(FontWeight::SEMIBOLD)
+                                            .text_color(theme.foreground)
+                                            .child("Viewer response limit"),
+                                    )
+                                    .child(
+                                        div()
+                                            .text_xs()
+                                            .text_color(theme.muted_foreground)
+                                            .child("Decoded responses above this limit stop safely. Download streams directly to disk."),
+                                    ),
+                            )
+                            .child(
+                                h_flex()
+                                    .items_center()
+                                    .gap_2()
+                                    .flex_shrink_0()
+                                    .child(
+                                        div()
+                                            .w(px(126.))
+                                            .child(Input::new(&self.response_limit).small()),
+                                    )
+                                    .child(
+                                        div()
+                                            .w(px(28.))
+                                            .text_xs()
+                                            .text_color(theme.muted_foreground)
+                                            .child("MiB"),
+                                    ),
+                            ),
+                    ),
+            )
+            .child(
+                h_flex()
+                    .w_full()
+                    .items_center()
+                    .gap_2()
+                    .px_1()
+                    .child(div().size(px(7.)).rounded_full().bg(status_color))
+                    .child(
+                        div()
+                            .text_xs()
+                            .text_color(status_text_color)
+                            .child(self.status.label()),
+                    )
+                    .child(div().flex_1())
+                    .child(
+                        div()
+                            .text_xs()
+                            .text_color(theme.muted_foreground)
+                            .child("Use Download beside Send for large files"),
+                    ),
+            )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MAX_RESPONSE_LIMIT_MIB, MIN_RESPONSE_LIMIT_MIB};
+
+    #[test]
+    fn response_limit_bounds_cover_a_useful_range() {
+        assert_eq!(MIN_RESPONSE_LIMIT_MIB, 1);
+        assert!(MAX_RESPONSE_LIMIT_MIB >= 1_024);
+    }
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,75 @@ use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
+/// Limits and transfer behavior applied to every newly started HTTP request.
+///
+/// These values deliberately live outside individual requests: they are client
+/// safeguards, not data that should be saved into a collection or history item.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AppSettings {
+    /// Maximum time allowed to establish a TCP/TLS connection.
+    pub connect_timeout_ms: u64,
+    /// Maximum period with no response-body bytes arriving.
+    pub read_timeout_ms: u64,
+    /// Wall-clock limit for the complete request, including the response body.
+    pub total_timeout_ms: u64,
+    /// Maximum decoded bytes retained for display in the response viewer.
+    pub max_response_size_bytes: u64,
+}
+
+impl AppSettings {
+    pub const DEFAULT_CONNECT_TIMEOUT_MS: u64 = 10_000;
+    pub const DEFAULT_READ_TIMEOUT_MS: u64 = 30_000;
+    pub const DEFAULT_TOTAL_TIMEOUT_MS: u64 = 60_000;
+    pub const DEFAULT_MAX_RESPONSE_SIZE_BYTES: u64 = 50 * 1024 * 1024;
+
+    const MAX_TIMEOUT_MS: u64 = 3_600_000;
+    const MIN_RESPONSE_SIZE_BYTES: u64 = 1_024;
+    const MAX_RESPONSE_SIZE_BYTES: u64 = 2 * 1024 * 1024 * 1024;
+
+    /// Protect startup from a malformed or hand-edited persisted value. The UI
+    /// performs the same validation before allowing a change to take effect.
+    pub fn normalized(mut self) -> Self {
+        self.connect_timeout_ms = Self::valid_timeout(
+            self.connect_timeout_ms,
+            Self::DEFAULT_CONNECT_TIMEOUT_MS,
+        );
+        self.read_timeout_ms =
+            Self::valid_timeout(self.read_timeout_ms, Self::DEFAULT_READ_TIMEOUT_MS);
+        self.total_timeout_ms =
+            Self::valid_timeout(self.total_timeout_ms, Self::DEFAULT_TOTAL_TIMEOUT_MS);
+        if !(Self::MIN_RESPONSE_SIZE_BYTES..=Self::MAX_RESPONSE_SIZE_BYTES)
+            .contains(&self.max_response_size_bytes)
+        {
+            self.max_response_size_bytes = Self::DEFAULT_MAX_RESPONSE_SIZE_BYTES;
+        }
+        self
+    }
+
+    fn valid_timeout(value: u64, fallback: u64) -> u64 {
+        if (1..=Self::MAX_TIMEOUT_MS).contains(&value) {
+            value
+        } else {
+            fallback
+        }
+    }
+
+    pub fn response_limit_mebibytes(&self) -> u64 {
+        self.max_response_size_bytes.div_ceil(1024 * 1024)
+    }
+}
+
+impl Default for AppSettings {
+    fn default() -> Self {
+        Self {
+            connect_timeout_ms: Self::DEFAULT_CONNECT_TIMEOUT_MS,
+            read_timeout_ms: Self::DEFAULT_READ_TIMEOUT_MS,
+            total_timeout_ms: Self::DEFAULT_TOTAL_TIMEOUT_MS,
+            max_response_size_bytes: Self::DEFAULT_MAX_RESPONSE_SIZE_BYTES,
+        }
+    }
+}
+
 /// Header type for distinguishing predefined vs custom headers
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum HeaderType {
@@ -456,6 +525,13 @@ pub struct ResponseData {
     pub body: Vec<u8>,
     /// Whether the body should be shown as text (vs treated as binary).
     pub is_text: bool,
+    /// Destination selected for a streamed download. Such responses never keep
+    /// their full body in memory.
+    #[serde(default)]
+    pub downloaded_to: Option<String>,
+    /// Number of decoded bytes written by a streamed download.
+    #[serde(default)]
+    pub downloaded_bytes: Option<u64>,
 }
 
 /// Decide whether a response body should be shown as text.


### PR DESCRIPTION
## Summary
- add persisted General settings for connect, read-idle, total-request, and response-viewer limits
- enforce the decoded response limit while streaming, with actionable timeout and limit errors
- add a Send dropdown action that streams downloads directly to disk
- add coverage for stalled, chunked oversized, compressed oversized, download, and settings persistence paths

## Verification
- `cargo check`
- `cargo check --tests`
- Windows `cargo build --release`

`cargo test` could not link in this Linux environment because system libraries `xkbcommon` and `xkbcommon-x11` are unavailable.

Closes #41