### PR TITLE
fix(url): make Params synchronization lossless and scheme-safe

### DIFF
--- a/src/postman.rs
+++ b/src/postman.rs
@@ -136,7 +136,7 @@ fn parse_url(
             })
             .collect::<Vec<_>>();
         return (
-            crate::url_params::build_url_with_params(base, &query_params),
+            crate::url_params::build_url_with_params(&base, &query_params),
             params,
         );
     }
@@ -848,7 +848,7 @@ mod tests {
                 "request": {
                     "method": "GET",
                     "url": {
-                        "raw": "https://example.test/items?page=1&debug=true",
+                        "raw": "https://example.test/items?page=1&debug=true#results",
                         "query": [
                             {"key":"page", "value":"1"},
                             {"key":"debug", "value":"true", "disabled":true}
@@ -859,14 +859,17 @@ mod tests {
         });
         let result = import_collection(&input.to_string()).unwrap();
         let request = &result.collection.requests[0];
-        assert_eq!(request.request.url, "https://example.test/items?page=1");
+        assert_eq!(
+            request.request.url,
+            "https://example.test/items?page=1#results"
+        );
         assert_eq!(request.params_state.len(), 2);
         assert!(!request.params_state[1].enabled);
         let output: Value =
             serde_json::from_str(&export_collection(&result.collection).unwrap()).unwrap();
         assert_eq!(
             output["item"][0]["request"]["url"]["raw"],
-            "https://example.test/items?page=1"
+            "https://example.test/items?page=1#results"
         );
         assert_eq!(
             output["item"][0]["request"]["url"]["query"][1]["disabled"],

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -1009,9 +1009,6 @@ impl RequestEditor {
         // their values out of logs even before a request is sent.
         log::debug!("Rebuilding URL from parameter state");
 
-        // Extract base URL using pure function
-        let base = url_params::extract_base_url(url_str);
-
         // Collect params as QueryParam structs
         let params: Vec<QueryParam> = self
             .params
@@ -1026,7 +1023,7 @@ impl RequestEditor {
             .collect();
 
         // Build URL using pure function
-        let result = url_params::build_url_with_params(base, &params);
+        let result = url_params::build_url_with_params(url_str, &params);
 
         log::debug!("Rebuilt URL from parameter state");
         result
@@ -1236,19 +1233,15 @@ impl RequestEditor {
 
         // Substitute {{env vars}} BEFORE scheme normalization/validation, so a
         // value like "https://host" doesn't get an extra "http://" prefix.
-        url = crate::variables::substitute(&url, &self.env_vars);
+        url = crate::variables::substitute_url(&url, &self.env_vars);
 
-        // Auto-add scheme if missing (like Postman does) - default to http://
-        if !url.starts_with("http://") && !url.starts_with("https://") {
-            url = format!("http://{}", url);
-            log::debug!("Auto-added http:// scheme to request URL");
-        }
-
-        // Validate URL format after normalization
-        if url::Url::parse(&url).is_err() {
+        // Scheme detection and normalization are delegated to structured URL
+        // parsing, which correctly accepts case-insensitive HTTP(S) schemes.
+        let Some(parsed_url) = url_params::normalize_http_url(&url) else {
             log::error!("Invalid URL format after normalization");
             return;
-        }
+        };
+        url = parsed_url.into();
 
         log::debug!("Sending request");
 

--- a/src/url_params.rs
+++ b/src/url_params.rs
@@ -3,6 +3,8 @@
 //! This module contains stateless, side-effect-free functions for parsing and building URLs
 //! with query parameters. These functions are designed to be easily testable.
 
+use std::borrow::Cow;
+
 use url::Url;
 
 /// Represents a query parameter with its enabled state.
@@ -23,19 +25,45 @@ impl QueryParam {
     }
 }
 
-/// Extract the base URL (without query string) from a URL string.
+/// Syntactic URL pieces used while the user may still be typing an incomplete
+/// URL. Splitting does not require the input to be a valid absolute URL.
+struct UrlParts<'a> {
+    base: &'a str,
+    query: Option<&'a str>,
+    fragment: Option<&'a str>,
+}
+
+fn split_url(url: &str) -> UrlParts<'_> {
+    let (before_fragment, fragment) = match url.split_once('#') {
+        Some((before, fragment)) => (before, Some(fragment)),
+        None => (url, None),
+    };
+    let (base, query) = match before_fragment.split_once('?') {
+        Some((base, query)) => (base, Some(query)),
+        None => (before_fragment, None),
+    };
+
+    UrlParts {
+        base,
+        query,
+        fragment,
+    }
+}
+
+/// Extract the URL without its query string while preserving any fragment.
 ///
 /// # Examples
 /// ```
 /// assert_eq!(extract_base_url("https://example.com/api?foo=bar"), "https://example.com/api");
+/// assert_eq!(extract_base_url("https://example.com/api?foo=bar#result"), "https://example.com/api#result");
 /// assert_eq!(extract_base_url("https://example.com/api"), "https://example.com/api");
 /// assert_eq!(extract_base_url(""), "");
 /// ```
-pub fn extract_base_url(url: &str) -> &str {
-    if let Some(pos) = url.find('?') {
-        &url[..pos]
-    } else {
-        url
+pub fn extract_base_url(url: &str) -> String {
+    let parts = split_url(url);
+    match parts.fragment {
+        Some(fragment) => format!("{}#{fragment}", parts.base),
+        None => parts.base.to_string(),
     }
 }
 
@@ -45,7 +73,9 @@ pub fn extract_base_url(url: &str) -> &str {
 /// Returns an empty Vec if:
 /// - URL is empty
 /// - URL has no query string
-/// - URL parsing fails and no manual query string found
+///
+/// Parsing is deliberately syntactic so partial/template URLs behave exactly
+/// like complete absolute URLs while they are edited.
 ///
 /// # Examples
 /// ```
@@ -53,62 +83,28 @@ pub fn extract_base_url(url: &str) -> &str {
 /// assert_eq!(params, vec![("foo".to_string(), "bar".to_string()), ("baz".to_string(), "qux".to_string())]);
 /// ```
 pub fn parse_query_params(url: &str) -> Vec<(String, String)> {
-    if url.is_empty() {
-        return Vec::new();
-    }
-
-    // Try to parse as a valid URL first
-    if let Ok(parsed_url) = Url::parse(url) {
-        return parsed_url
-            .query_pairs()
-            .map(|(k, v)| (k.to_string(), v.to_string()))
-            .collect();
-    }
-
-    // URL parsing failed, try to extract query string manually
-    if let Some(query_start) = url.find('?') {
-        let query = &url[query_start + 1..];
-        let mut params = Vec::new();
-
-        for pair in query.split('&') {
-            if pair.is_empty() {
-                continue;
-            }
-            if let Some(eq_pos) = pair.find('=') {
-                let key = urlencoding::decode(&pair[..eq_pos])
-                    .map(|s| s.to_string())
-                    .unwrap_or_default();
-                let value = urlencoding::decode(&pair[eq_pos + 1..])
-                    .map(|s| s.to_string())
-                    .unwrap_or_default();
-                if !key.is_empty() {
-                    params.push((key, value));
-                }
-            } else {
-                // Key without value (e.g., "?foo&bar=baz")
-                let key = urlencoding::decode(pair)
-                    .map(|s| s.to_string())
-                    .unwrap_or_default();
-                if !key.is_empty() {
-                    params.push((key, String::new()));
-                }
-            }
-        }
-
-        return params;
-    }
-
-    // No query string found
-    Vec::new()
+    split_url(url)
+        .query
+        .map(parse_query_string)
+        .unwrap_or_default()
 }
 
-/// Build a URL by combining a base URL with query parameters.
+fn parse_query_string(query: &str) -> Vec<(String, String)> {
+    url::form_urlencoded::parse(query.as_bytes())
+        .filter(|(key, _)| !key.is_empty())
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect()
+}
+
+/// Build a URL by replacing its query parameters while preserving its
+/// fragment. Template tokens stay literal so send-time substitution can still
+/// recognize them; every other key/value byte is percent-encoded.
 ///
 /// Only enabled params with non-empty keys are included in the query string.
 /// Keys and values are URL-encoded.
 ///
 /// # Arguments
-/// * `base_url` - The base URL (without query string)
+/// * `url` - A complete or partial URL; its existing query is replaced
 /// * `params` - List of query parameters with enabled state
 ///
 /// # Examples
@@ -121,33 +117,110 @@ pub fn parse_query_params(url: &str) -> Vec<(String, String)> {
 /// let url = build_url_with_params("https://example.com/api", &params);
 /// assert_eq!(url, "https://example.com/api?foo=bar&baz=qux");
 /// ```
-pub fn build_url_with_params(base_url: &str, params: &[QueryParam]) -> String {
+pub fn build_url_with_params(url: &str, params: &[QueryParam]) -> String {
+    let parts = split_url(url);
+    build_url_parts(parts.base, parts.fragment, params, true)
+}
+
+fn build_url_parts(
+    base: &str,
+    fragment: Option<&str>,
+    params: &[QueryParam],
+    preserve_templates: bool,
+) -> String {
     let param_parts: Vec<String> = params
         .iter()
         .filter(|p| p.enabled && !p.key.is_empty())
         .map(|p| {
             format!(
                 "{}={}",
-                urlencoding::encode(&p.key),
-                urlencoding::encode(&p.value)
+                encode_query_component(&p.key, preserve_templates),
+                encode_query_component(&p.value, preserve_templates)
             )
         })
         .collect();
 
-    if param_parts.is_empty() {
-        base_url.to_string()
-    } else {
-        format!("{}?{}", base_url, param_parts.join("&"))
+    let mut result = base.to_string();
+    if !param_parts.is_empty() {
+        result.push('?');
+        result.push_str(&param_parts.join("&"));
     }
+    if let Some(fragment) = fragment {
+        result.push('#');
+        result.push_str(fragment);
+    }
+    result
+}
+
+fn encode_query_component(value: &str, preserve_templates: bool) -> String {
+    if !preserve_templates {
+        return urlencoding::encode(value).into_owned();
+    }
+
+    let mut encoded = String::with_capacity(value.len());
+    let mut rest = value;
+    while let Some(open) = rest.find("{{") {
+        encoded.push_str(urlencoding::encode(&rest[..open]).as_ref());
+        let after_open = &rest[open + 2..];
+        let Some(close) = after_open.find("}}") else {
+            encoded.push_str(urlencoding::encode(&rest[open..]).as_ref());
+            return encoded;
+        };
+        let token_end = open + 2 + close + 2;
+        encoded.push_str(&rest[open..token_end]);
+        rest = &rest[token_end..];
+    }
+    encoded.push_str(urlencoding::encode(rest).as_ref());
+    encoded
+}
+
+/// Resolve all URL template-bearing pieces and encode the resulting query
+/// keys/values exactly once. An input without a literal query is resolved as a
+/// whole so a `{{base_url}}` variable may itself supply a complete URL.
+pub fn resolve_url_for_send(url: &str, mut resolve: impl FnMut(&str) -> String) -> String {
+    let parts = split_url(url);
+    let Some(query) = parts.query else {
+        return resolve(url);
+    };
+
+    let base = resolve(parts.base);
+    let fragment = parts.fragment.map(&mut resolve);
+    let params = parse_query_string(query)
+        .into_iter()
+        .map(|(key, value)| QueryParam::new(resolve(&key), resolve(&value), true))
+        .collect::<Vec<_>>();
+
+    build_url_parts(&base, fragment.as_deref(), &params, false)
+}
+
+/// Add the default HTTP scheme when absent, then parse and normalize with the
+/// URL library. Only HTTP(S) URLs with a host are accepted.
+pub fn normalize_http_url(url: &str) -> Option<Url> {
+    let candidate = if has_explicit_scheme(url) {
+        Cow::Borrowed(url)
+    } else {
+        Cow::Owned(format!("http://{url}"))
+    };
+    let parsed = Url::parse(&candidate).ok()?;
+    (matches!(parsed.scheme(), "http" | "https") && parsed.has_host()).then_some(parsed)
+}
+
+fn has_explicit_scheme(url: &str) -> bool {
+    let Some(separator) = url.find("://") else {
+        return false;
+    };
+    let scheme = &url[..separator];
+    let mut chars = scheme.chars();
+    chars
+        .next()
+        .is_some_and(|first| first.is_ascii_alphabetic())
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '+' | '-' | '.'))
 }
 
 /// Compare two lists of query parameters (ignoring empty trailing entries).
 ///
 /// Returns true if the params are equivalent (same keys and values in order).
-pub fn params_equal(
-    params1: &[(String, String)],
-    params2: &[(String, String)],
-) -> bool {
+pub fn params_equal(params1: &[(String, String)], params2: &[(String, String)]) -> bool {
     // Filter out empty entries for comparison
     let filtered1: Vec<_> = params1
         .iter()
@@ -191,6 +264,18 @@ mod tests {
     #[test]
     fn test_extract_base_url_only_query() {
         assert_eq!(extract_base_url("?foo=bar"), "");
+    }
+
+    #[test]
+    fn test_extract_base_url_preserves_fragment_after_query() {
+        assert_eq!(
+            extract_base_url("https://example.com/api?foo=bar#result"),
+            "https://example.com/api#result"
+        );
+        assert_eq!(
+            extract_base_url("https://example.com/api#result"),
+            "https://example.com/api#result"
+        );
     }
 
     // ============ parse_query_params tests ============
@@ -265,6 +350,30 @@ mod tests {
             vec![
                 ("foo".to_string(), "bar".to_string()),
                 ("baz".to_string(), "qux".to_string())
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_query_stops_before_fragment() {
+        assert_eq!(
+            parse_query_params("https://example.com/path?q=value#fragment?not=a-query"),
+            vec![("q".to_string(), "value".to_string())]
+        );
+    }
+
+    #[test]
+    fn test_parse_preserves_templates_duplicates_empty_values_and_unicode() {
+        assert_eq!(
+            parse_query_params(
+                "partial/{{path}}?tag=one&token={{token}}&tag=two&empty=&name=%E4%BD%A0%E5%A5%BD#result"
+            ),
+            vec![
+                ("tag".to_string(), "one".to_string()),
+                ("token".to_string(), "{{token}}".to_string()),
+                ("tag".to_string(), "two".to_string()),
+                ("empty".to_string(), "".to_string()),
+                ("name".to_string(), "你好".to_string()),
             ]
         );
     }
@@ -345,6 +454,76 @@ mod tests {
     fn test_build_url_empty_base() {
         let params = vec![QueryParam::new("foo", "bar", true)];
         assert_eq!(build_url_with_params("", &params), "?foo=bar");
+    }
+
+    #[test]
+    fn test_build_keeps_templates_substitutable_and_query_before_fragment() {
+        let params = vec![
+            QueryParam::new("q", "prefix-{{ token }}-suffix", true),
+            QueryParam::new("tag", "one", true),
+            QueryParam::new("tag", "two", true),
+            QueryParam::new("empty", "", true),
+        ];
+        assert_eq!(
+            build_url_with_params("{{base_url}}/search?old=value#results", &params),
+            "{{base_url}}/search?q=prefix-{{ token }}-suffix&tag=one&tag=two&empty=#results"
+        );
+    }
+
+    #[test]
+    fn test_build_encodes_unicode_without_losing_order_or_duplicates() {
+        let params = vec![
+            QueryParam::new("名称", "你好 世界", true),
+            QueryParam::new("名称", "再见", true),
+        ];
+        assert_eq!(
+            build_url_with_params("https://example.test/#片段", &params),
+            "https://example.test/?%E5%90%8D%E7%A7%B0=%E4%BD%A0%E5%A5%BD%20%E4%B8%96%E7%95%8C&%E5%90%8D%E7%A7%B0=%E5%86%8D%E8%A7%81#片段"
+        );
+    }
+
+    #[test]
+    fn test_resolve_url_encodes_substituted_query_exactly_once() {
+        let result = resolve_url_for_send(
+            "https://example.test/search?q={{term}}&existing=hello%20world#results",
+            |part| part.replace("{{term}}", "a b&c/你好"),
+        );
+        assert_eq!(
+            result,
+            "https://example.test/search?q=a%20b%26c%2F%E4%BD%A0%E5%A5%BD&existing=hello%20world#results"
+        );
+    }
+
+    #[test]
+    fn test_resolve_partial_url_uses_deterministic_syntactic_split() {
+        let result = resolve_url_for_send("{{base_url}}/search?q={{term}}#{{section}}", |part| {
+            part.replace("{{base_url}}", "HTTPS://example.test")
+                .replace("{{term}}", "hello world")
+                .replace("{{section}}", "results")
+        });
+        assert_eq!(
+            result,
+            "HTTPS://example.test/search?q=hello%20world#results"
+        );
+    }
+
+    #[test]
+    fn test_normalize_http_url_accepts_uppercase_and_defaults_missing_scheme() {
+        let uppercase = normalize_http_url("HTTPS://Example.Test/path").unwrap();
+        assert_eq!(uppercase.as_str(), "https://example.test/path");
+
+        let defaulted = normalize_http_url("example.test/path").unwrap();
+        assert_eq!(defaulted.as_str(), "http://example.test/path");
+
+        let scheme_in_query =
+            normalize_http_url("example.test/callback?next=https://other.test").unwrap();
+        assert_eq!(
+            scheme_in_query.as_str(),
+            "http://example.test/callback?next=https://other.test"
+        );
+
+        assert!(normalize_http_url("ftp://example.test/file").is_none());
+        assert!(normalize_http_url("HTTPS://").is_none());
     }
 
     // ============ params_equal tests ============

--- a/src/variables.rs
+++ b/src/variables.rs
@@ -38,6 +38,12 @@ pub fn substitute(input: &str, vars: &HashMap<String, String>) -> String {
     out
 }
 
+/// Resolve URL templates without allowing resolved query delimiters to change
+/// parameter boundaries. Query keys and values are encoded after substitution.
+pub fn substitute_url(input: &str, vars: &HashMap<String, String>) -> String {
+    crate::url_params::resolve_url_for_send(input, |part| substitute(part, vars))
+}
+
 /// Substitute `{{vars}}` in every auth field. `auth_type` is preserved as-is.
 pub fn substitute_auth(auth: &AuthConfig, vars: &HashMap<String, String>) -> AuthConfig {
     AuthConfig {
@@ -82,7 +88,7 @@ pub fn substitute_request(req: &RequestData, vars: &HashMap<String, String>) -> 
 
     RequestData {
         method: req.method,
-        url: substitute(&req.url, vars),
+        url: substitute_url(&req.url, vars),
         headers,
         body,
         auth: substitute_auth(&req.auth, vars),
@@ -160,6 +166,21 @@ mod tests {
             BodyType::Raw { content, .. } => assert_eq!(content, "{\"env\": \"prod\"}"),
             _ => panic!("expected raw body"),
         }
+    }
+
+    #[test]
+    fn substitute_url_encodes_resolved_query_without_moving_fragment() {
+        let out = substitute_url(
+            "{{base_url}}/search?q={{term}}&q=already%20encoded#results",
+            &vars(&[
+                ("base_url", "HTTPS://api.test"),
+                ("term", "a b&c/你好"),
+            ]),
+        );
+        assert_eq!(
+            out,
+            "HTTPS://api.test/search?q=a%20b%26c%2F%E4%BD%A0%E5%A5%BD&q=already%20encoded#results"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- split URL base, query, and fragment deterministically without requiring a complete absolute URL
- preserve `{{variable}}` placeholders while editing Params, then substitute and percent-encode resolved query keys and values exactly once
- keep fragments after the query string and retain duplicate parameters, ordering, empty values, and Unicode
- normalize HTTP and HTTPS schemes through structured URL parsing, including uppercase schemes
- preserve fragments when filtering disabled Postman query parameters

## Testing

- `cargo test -- --test-threads=1` on Windows PowerShell: 255 passed
- `cargo check --tests`
- `cargo clippy --tests` (passes with 4 pre-existing warnings)
- `cargo build --release`

Fixes #43