### PR TITLE
fix(headers): make Content-Length transport-owned

### DIFF
--- a/src/body_editor.rs
+++ b/src/body_editor.rs
@@ -370,19 +370,6 @@ impl BodyEditor {
         cx.emit(BodyTypeChanged { content_type });
     }
 
-    /// Calculate body content length
-    pub fn calculate_length(&self, cx: &App) -> usize {
-        match self.body_type_index {
-            0 => 0, // None
-            1 => {
-                // Raw - read from single editor
-                self.raw_body_editor.read(cx).value().len()
-            }
-            2 | 3 => 0, // Form-data and UrlEncoded - approximate
-            _ => 0,
-        }
-    }
-
     // Form-data table methods
     fn add_formdata_row(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.add_formdata_row_with_value(FormDataRow {

--- a/src/code_gen.rs
+++ b/src/code_gen.rs
@@ -88,14 +88,15 @@ fn form_rows(req: &RequestData) -> Vec<&FormDataRow> {
     }
 }
 
-/// Headers to export: non-blank keys, minus Content-Type for form-data
-/// bodies — the UI pins `multipart/form-data; boundary=<auto>` on such
-/// requests, and each target's library must generate its own boundary.
+/// Headers to export: non-blank user-managed keys, minus Content-Type for
+/// form-data bodies. Each target's library owns multipart boundaries and all
+/// targets calculate Content-Length from their final encoded body.
 fn export_headers(req: &RequestData) -> Vec<(&str, &str)> {
     let skip_content_type = matches!(&req.body, BodyType::FormData(_));
     req.headers
         .iter()
         .filter(|(k, _)| !k.trim().is_empty())
+        .filter(|(k, _)| !crate::types::is_transport_owned_header(k))
         .filter(|(k, _)| !(skip_content_type && k.eq_ignore_ascii_case("content-type")))
         .map(|(k, v)| (k.as_str(), v.as_str()))
         .collect()
@@ -641,6 +642,17 @@ mod tests {
         let out = generate(CodeTarget::Curl, &req);
         assert!(out.contains("Bearer NEW"));
         assert!(!out.contains("Bearer OLD"));
+    }
+
+    #[test]
+    fn every_target_omits_stale_content_length() {
+        let mut req = post_json_req();
+        req.headers.push(("Content-Length".into(), "1".into()));
+
+        for target in CodeTarget::all() {
+            let out = generate(target, &req);
+            assert!(!out.contains("Content-Length"), "generated {target:?}: {out}");
+        }
     }
 
     #[test]

--- a/src/curl_import.rs
+++ b/src/curl_import.rs
@@ -9,7 +9,10 @@
 
 use std::fmt;
 
-use crate::types::{AuthConfig, AuthType, BodyType, FormDataRow, FormDataValue, HttpMethod, RawSubtype, RequestData};
+use crate::types::{
+    AuthConfig, AuthType, BodyType, FormDataRow, FormDataValue, HttpMethod, RawSubtype,
+    RequestData, is_transport_owned_header,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CurlImportError {
@@ -233,7 +236,9 @@ pub fn parse_curl(input: &str) -> Result<Option<RequestData>, CurlImportError> {
                     expected: "a `Name: value` header",
                 });
             }
-            headers.push((k.trim().to_string(), val.trim().to_string()));
+            if !is_transport_owned_header(k.trim()) {
+                headers.push((k.trim().to_string(), val.trim().to_string()));
+            }
         } else if matches_flag(&tok, "", "--data-raw")
             || matches_flag(&tok, "", "--data-binary")
             || matches_flag(&tok, "", "--data-urlencode")
@@ -406,6 +411,17 @@ mod tests {
         assert_eq!(
             r.headers,
             vec![("A".to_string(), "1".to_string()), ("B".to_string(), "2".to_string())]
+        );
+    }
+
+    #[test]
+    fn content_length_is_not_imported() {
+        let r = parse(
+            "curl -H 'Content-Length: 1' -H 'X-Trace: kept' -d '你好' https://example.com",
+        );
+        assert_eq!(
+            r.headers,
+            vec![("X-Trace".to_string(), "kept".to_string())]
         );
     }
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -39,7 +39,9 @@ fn row_to_history_item(row: &rusqlite::Row) -> rusqlite::Result<HistoryItem> {
     let request_body: String = row.get(5)?;
     let request_auth: Option<String> = row.get(6)?;
 
-    let headers: Vec<(String, String)> = serde_json::from_str(&request_headers).unwrap_or_default();
+    let mut headers: Vec<(String, String)> =
+        serde_json::from_str(&request_headers).unwrap_or_default();
+    headers.retain(|(name, _)| !crate::types::is_transport_owned_header(name));
     let body: BodyType = serde_json::from_str(&request_body).unwrap_or_default();
     let auth: crate::types::AuthConfig = request_auth
         .as_deref()
@@ -89,14 +91,19 @@ struct SavedRequestRow {
 }
 
 fn decode_saved_request(row: SavedRequestRow) -> Result<SavedRequest> {
+    let mut request: RequestData = serde_json::from_str(&row.request_json)?;
+    request.strip_transport_owned_headers();
+    let mut headers_state = serde_json::from_str::<Vec<HeaderState>>(&row.headers_json)?;
+    headers_state.retain(|header| !header.is_transport_owned());
+
     Ok(SavedRequest {
         id: row.id,
         collection_id: row.collection_id,
         folder_id: row.folder_id,
         name: row.name,
-        request: serde_json::from_str(&row.request_json)?,
+        request,
         params_state: serde_json::from_str::<Vec<ParamState>>(&row.params_json)?,
-        headers_state: serde_json::from_str::<Vec<HeaderState>>(&row.headers_json)?,
+        headers_state,
         position: row.position,
         created_at: row.created_at,
         updated_at: row.updated_at,
@@ -226,10 +233,16 @@ fn encode_saved_request(
     params_state: &[ParamState],
     headers_state: &[HeaderState],
 ) -> Result<(String, String, String)> {
+    let mut request = request.clone();
+    request.strip_transport_owned_headers();
+    let headers_state: Vec<&HeaderState> = headers_state
+        .iter()
+        .filter(|header| !header.is_transport_owned())
+        .collect();
     Ok((
-        serde_json::to_string(request)?,
+        serde_json::to_string(&request)?,
         serde_json::to_string(params_state)?,
-        serde_json::to_string(headers_state)?,
+        serde_json::to_string(&headers_state)?,
     ))
 }
 
@@ -547,7 +560,10 @@ impl Database {
     ) -> Result<i64> {
         let method = method.to_string();
         let url = url.to_string();
-        let request_headers = request_headers.to_string();
+        let mut request_headers: Vec<(String, String)> =
+            serde_json::from_str(request_headers).unwrap_or_default();
+        request_headers.retain(|(name, _)| !crate::types::is_transport_owned_header(name));
+        let request_headers = serde_json::to_string(&request_headers).unwrap_or_default();
         // Serialize body type + auth to JSON before crossing the channel.
         let body_json = serde_json::to_string(request_body).unwrap_or_default();
         // Defense in depth: callers should pass a history snapshot, but the DB
@@ -1331,6 +1347,28 @@ mod tests {
     }
 
     #[test]
+    fn history_storage_and_loading_strip_content_length() {
+        let db = mem_db();
+        db.insert_history(
+            "POST",
+            "https://x",
+            r#"[["Content-Length","1"],["X-Trace","kept"]]"#,
+            &BodyType::Raw {
+                content: "你好".into(),
+                subtype: crate::types::RawSubtype::Text,
+            },
+            &AuthConfig::default(),
+        )
+        .unwrap();
+
+        let items = db.load_recent_history(10).unwrap();
+        assert_eq!(
+            items[0].request.headers,
+            vec![("X-Trace".into(), "kept".into())]
+        );
+    }
+
+    #[test]
     fn history_storage_drops_inactive_auth_fields() {
         let db = mem_db();
         let auth = AuthConfig {
@@ -1609,6 +1647,72 @@ mod tests {
         assert_eq!(saved.request, request);
         assert_eq!(saved.params_state, params);
         assert_eq!(saved.headers_state, headers);
+    }
+
+    #[test]
+    fn saved_request_persistence_strips_legacy_content_length() {
+        let db = mem_db();
+        let collection_id = db.create_collection("Demo").unwrap();
+        let (mut request, params, mut headers) =
+            saved_request_fixture("Request", "https://api.test/a");
+        request.headers.push(("content-length".into(), "1".into()));
+        headers.push(HeaderState {
+            enabled: true,
+            key: "Content-Length".into(),
+            value: "1".into(),
+            header_type: crate::types::HeaderType::Predefined,
+            predefined: Some(crate::types::PredefinedHeader::ContentLength),
+        });
+
+        let id = db
+            .insert_saved_request(collection_id, None, "Request", &request, &params, &headers)
+            .unwrap();
+        let saved = db.load_saved_request(id).unwrap().unwrap();
+
+        assert_eq!(
+            saved.request.headers,
+            vec![("X-Enabled".into(), "yes".into())]
+        );
+        assert!(
+            saved
+                .headers_state
+                .iter()
+                .all(|header| !header.is_transport_owned())
+        );
+    }
+
+    #[test]
+    fn decoding_old_saved_rows_strips_synthetic_content_length() {
+        let request = RequestData {
+            method: HttpMethod::POST,
+            url: "https://api.test/a".into(),
+            headers: vec![("Content-Length".into(), "0".into())],
+            body: BodyType::None,
+            auth: AuthConfig::default(),
+        };
+        let headers = vec![HeaderState {
+            enabled: true,
+            key: "Content-Length".into(),
+            value: "0".into(),
+            header_type: crate::types::HeaderType::Mandatory,
+            predefined: Some(crate::types::PredefinedHeader::ContentLength),
+        }];
+        let decoded = decode_saved_request(SavedRequestRow {
+            id: 1,
+            collection_id: 1,
+            folder_id: None,
+            name: "Legacy".into(),
+            request_json: serde_json::to_string(&request).unwrap(),
+            params_json: "[]".into(),
+            headers_json: serde_json::to_string(&headers).unwrap(),
+            position: 0,
+            created_at: String::new(),
+            updated_at: String::new(),
+        })
+        .unwrap();
+
+        assert!(decoded.request.headers.is_empty());
+        assert!(decoded.headers_state.is_empty());
     }
 
     #[test]

--- a/src/header_names.rs
+++ b/src/header_names.rs
@@ -8,11 +8,10 @@
 /// Common HTTP request header names offered as completions.
 ///
 /// Byte-sorted and deduplicated — `suggest` returns candidates in table order, so
-/// the table's order *is* the menu's order. The six headers that already own
+/// the table's order *is* the menu's order. The five headers that already own
 /// dedicated rows in the editor (`Cache-Control`, `Content-Type`, `Accept`,
-/// `User-Agent`, `Connection`, `Content-Length`) are deliberately absent: they
-/// cannot be typed into a custom row without sending a duplicate header on the
-/// wire. See `PredefinedHeader` in `types.rs`.
+/// `User-Agent`, `Connection`) are deliberately absent to prevent duplicates.
+/// `Content-Length` is absent because it is owned by the HTTP transport.
 pub const HEADER_NAMES: &[&str] = &[
     "Accept-Charset",
     "Accept-Encoding",
@@ -99,8 +98,8 @@ fn starts_with_ignore_ascii_case(name: &str, prefix: &str) -> bool {
 mod tests {
     use super::*;
 
-    /// The names that own dedicated rows in the editor and must never be suggested.
-    const PREDEFINED: &[&str] = &[
+    /// Editor-owned and transport-owned names must never be suggested.
+    const RESERVED: &[&str] = &[
         "Cache-Control",
         "Content-Type",
         "Accept",
@@ -155,7 +154,7 @@ mod tests {
 
     #[test]
     fn predefined_headers_are_never_suggested() {
-        for predefined in PREDEFINED {
+        for predefined in RESERVED {
             assert!(
                 !HEADER_NAMES.contains(predefined),
                 "{predefined} is in the table but owns a dedicated row"

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -179,15 +179,18 @@ impl HttpClient {
     /// edit affects the next request immediately rather than only after restart.
     pub fn new(settings: AppSettings) -> Self {
         let settings = settings.normalized();
-        let client = reqwest::Client::builder()
+        let builder = reqwest::Client::builder()
             .connect_timeout(Duration::from_millis(settings.connect_timeout_ms))
             .read_timeout(Duration::from_millis(settings.read_timeout_ms))
             .timeout(Duration::from_millis(settings.total_timeout_ms))
             // Redirects are followed explicitly in `send_request` so an auth
             // header with an arbitrary name can be removed at an origin boundary.
-            .redirect(reqwest::redirect::Policy::none())
-            .build()
-            .expect("Failed to initialize HTTP client");
+            .redirect(reqwest::redirect::Policy::none());
+        // Wire tests must reach their loopback listener directly even when the
+        // developer machine has a system proxy configured.
+        #[cfg(test)]
+        let builder = builder.no_proxy();
+        let client = builder.build().expect("Failed to initialize HTTP client");
 
         Self { client, settings }
     }
@@ -328,7 +331,7 @@ async fn send_single_request(
     for (key, value) in headers {
         // Never send a manual Content-Length — reqwest computes the correct one
         // from the actual body. A stale predefined value would truncate it.
-        if key.eq_ignore_ascii_case("content-length") {
+        if crate::types::is_transport_owned_header(key) {
             continue;
         }
         // For multipart, reqwest owns Content-Type so it includes its boundary.
@@ -580,7 +583,7 @@ fn format_byte_limit(bytes: u64) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::{AppSettings, BodyType, HttpMethod};
+    use crate::types::{AppSettings, BodyType, FormDataRow, HttpMethod, RequestData};
     use flate2::{Compression, write::GzEncoder};
     use std::io::{Read as _, Write as _};
     use std::sync::mpsc;
@@ -614,6 +617,170 @@ mod tests {
             request.extend_from_slice(&chunk[..read]);
         }
         String::from_utf8(request).unwrap()
+    }
+
+    #[derive(Debug)]
+    struct CapturedRequest {
+        head: String,
+        body: Vec<u8>,
+    }
+
+    impl CapturedRequest {
+        fn header(&self, expected_name: &str) -> Option<&str> {
+            self.head.lines().skip(1).find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case(expected_name)
+                    .then_some(value.trim())
+            })
+        }
+    }
+
+    fn read_complete_request(stream: &mut std::net::TcpStream) -> CapturedRequest {
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        let mut request = Vec::new();
+        let mut chunk = [0u8; 4096];
+        let header_end = loop {
+            if let Some(offset) = request.windows(4).position(|window| window == b"\r\n\r\n") {
+                break offset + 4;
+            }
+            let read = stream.read(&mut chunk).unwrap();
+            assert!(read > 0, "connection closed before request headers arrived");
+            request.extend_from_slice(&chunk[..read]);
+        };
+
+        let head = String::from_utf8(request[..header_end].to_vec()).unwrap();
+        let content_length = head
+            .lines()
+            .filter_map(|line| line.split_once(':'))
+            .find(|(name, _)| name.eq_ignore_ascii_case("content-length"))
+            .and_then(|(_, value)| value.trim().parse::<usize>().ok())
+            .unwrap_or(0);
+        while request.len() < header_end + content_length {
+            let read = stream.read(&mut chunk).unwrap();
+            assert!(read > 0, "connection closed before request body arrived");
+            request.extend_from_slice(&chunk[..read]);
+        }
+
+        CapturedRequest {
+            head,
+            body: request[header_end..header_end + content_length].to_vec(),
+        }
+    }
+
+    fn capture_request(
+        method: HttpMethod,
+        headers: Vec<(String, String)>,
+        body: BodyType,
+    ) -> CapturedRequest {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let url = format!("http://{}/", listener.local_addr().unwrap());
+        let (request_tx, request_rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            request_tx.send(read_complete_request(&mut stream)).unwrap();
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok")
+                .unwrap();
+        });
+
+        let inflight =
+            HttpClient::new(test_settings()).start_send(method, url, headers, None, body);
+        block_on(inflight.wait()).expect("captured request should succeed");
+        request_rx.recv_timeout(Duration::from_secs(2)).unwrap()
+    }
+
+    #[test]
+    fn variable_backed_unicode_body_gets_its_real_byte_length() {
+        let unresolved = RequestData {
+            method: HttpMethod::POST,
+            url: "https://unused.test".into(),
+            headers: vec![("Content-Length".into(), "1".into())],
+            body: BodyType::Raw {
+                content: "{{message}}".into(),
+                subtype: crate::types::RawSubtype::Text,
+            },
+            auth: crate::types::AuthConfig::default(),
+        };
+        let env =
+            std::collections::HashMap::from([("message".to_string(), "你好，Poopman".to_string())]);
+        let resolved = crate::variables::substitute_request(&unresolved, &env);
+        let expected_body = match &resolved.body {
+            BodyType::Raw { content, .. } => content.as_bytes(),
+            _ => unreachable!(),
+        };
+        let captured = capture_request(
+            resolved.method,
+            crate::types::effective_wire_headers(&resolved.headers, &resolved.auth),
+            resolved.body.clone(),
+        );
+
+        assert_eq!(captured.body, expected_body);
+        assert_eq!(
+            captured
+                .header("Content-Length")
+                .and_then(|value| value.parse::<usize>().ok()),
+            Some(expected_body.len())
+        );
+    }
+
+    #[test]
+    fn empty_body_has_no_injected_editor_headers() {
+        let captured = capture_request(
+            HttpMethod::POST,
+            vec![("Content-Length".into(), "999".into())],
+            BodyType::None,
+        );
+
+        assert!(captured.body.is_empty());
+        if let Some(length) = captured.header("Content-Length") {
+            assert_eq!(length, "0");
+        }
+        // reqwest 0.13 owns its own `Accept: */*` transport default. The
+        // application-level defaults that used to come from editor rows must
+        // not leak onto an otherwise headerless request.
+        for name in ["Cache-Control", "Content-Type", "User-Agent", "Connection"] {
+            assert_eq!(captured.header(name), None, "unexpected {name} header");
+        }
+    }
+
+    #[test]
+    fn multipart_boundary_and_length_are_generated_from_encoded_body() {
+        let captured = capture_request(
+            HttpMethod::POST,
+            vec![
+                ("Content-Length".into(), "0".into()),
+                (
+                    "Content-Type".into(),
+                    "multipart/form-data; boundary=<auto>".into(),
+                ),
+            ],
+            BodyType::FormData(vec![
+                FormDataRow {
+                    enabled: true,
+                    key: "message".into(),
+                    value: FormDataValue::Text("你好".into()),
+                },
+                FormDataRow {
+                    enabled: false,
+                    key: "ignored".into(),
+                    value: FormDataValue::Text("not-on-wire".into()),
+                },
+            ]),
+        );
+
+        let content_type = captured.header("Content-Type").unwrap();
+        assert!(content_type.starts_with("multipart/form-data; boundary="));
+        assert!(!content_type.contains("<auto>"));
+        assert_eq!(
+            captured.header("Content-Length").unwrap(),
+            captured.body.len().to_string()
+        );
+        let body = String::from_utf8(captured.body).unwrap();
+        assert!(body.contains("name=\"message\""));
+        assert!(body.contains("你好"));
+        assert!(!body.contains("not-on-wire"));
     }
 
     #[test]

--- a/src/postman.rs
+++ b/src/postman.rs
@@ -224,6 +224,9 @@ fn parse_headers(
             warning(warnings, item_path, "header without a key was ignored");
             continue;
         }
+        if crate::types::is_transport_owned_header(&key) {
+            continue;
+        }
         let enabled = !bool_entry(item, "disabled");
         let state = HeaderState {
             enabled,
@@ -587,7 +590,7 @@ fn export_headers(saved: &SavedRequest) -> Vec<Value> {
         return saved
             .headers_state
             .iter()
-            .filter(|header| !header.key.trim().is_empty())
+            .filter(|header| !header.key.trim().is_empty() && !header.is_transport_owned())
             .map(|header| {
                 json!({
                     "key": header.key,
@@ -601,7 +604,7 @@ fn export_headers(saved: &SavedRequest) -> Vec<Value> {
         .request
         .headers
         .iter()
-        .filter(|(key, _)| !key.trim().is_empty())
+        .filter(|(key, _)| !key.trim().is_empty() && !crate::types::is_transport_owned_header(key))
         .map(|(key, value)| json!({ "key": key, "value": value }))
         .collect()
 }
@@ -790,6 +793,38 @@ mod tests {
         assert!(!request.headers_state[1].enabled);
         assert!(!request.params_state[1].enabled);
         assert!(!result.warnings.is_empty());
+    }
+
+    #[test]
+    fn import_and_export_strip_content_length() {
+        let input = json!({
+            "info": {"name":"Headers", "schema": V21_SCHEMA},
+            "item": [{
+                "name": "request",
+                "request": {
+                    "method": "POST",
+                    "url": "https://example.test",
+                    "header": [
+                        {"key":"Content-Length", "value":"1"},
+                        {"key":"X-Trace", "value":"kept", "disabled":true}
+                    ],
+                    "body": {"mode":"raw", "raw":"你好"}
+                }
+            }]
+        });
+
+        let imported = import_collection(&input.to_string()).unwrap();
+        let saved = &imported.collection.requests[0];
+        assert!(saved.request.headers.is_empty());
+        assert_eq!(saved.headers_state.len(), 1);
+        assert_eq!(saved.headers_state[0].key, "X-Trace");
+        assert!(!saved.headers_state[0].enabled);
+
+        let exported: Value =
+            serde_json::from_str(&export_collection(&imported.collection).unwrap()).unwrap();
+        let headers = exported["item"][0]["request"]["header"].as_array().unwrap();
+        assert_eq!(headers.len(), 1);
+        assert_eq!(headers[0]["key"], "X-Trace");
     }
 
     #[test]

--- a/src/request_editor.rs
+++ b/src/request_editor.rs
@@ -237,7 +237,7 @@ impl RequestEditor {
         editor._subscriptions.push(url_sub);
         editor._subscriptions.push(body_sub);
 
-        // Initialize with predefined headers
+        // Match Postman's new-request behavior: predefined rows start enabled.
         editor.init_predefined_headers(window, cx);
 
         // Add initial empty custom header row with subscription
@@ -278,9 +278,9 @@ impl RequestEditor {
         self.in_flight.contains_key(&self.active_request_tab_id)
     }
 
-    /// Initialize all predefined headers
+    /// Initialize user-editable predefined headers in Postman-style enabled state.
     fn init_predefined_headers(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        for predefined in PredefinedHeader::all() {
+        for predefined in PredefinedHeader::editable() {
             let header_type = predefined.header_type();
 
             let key_input = cx.new(|cx| {
@@ -296,7 +296,7 @@ impl RequestEditor {
             });
 
             self.headers.push(HeaderRow {
-                enabled: true, // All predefined headers are enabled by default
+                enabled: true,
                 key_input,
                 value_input,
                 header_type,
@@ -362,14 +362,18 @@ impl RequestEditor {
         // Clear params to force rebuild with fresh subscriptions.
         self.params.clear();
 
-        // First, add all predefined headers
+        // First, add every user-editable predefined header.
         self.init_predefined_headers(window, cx);
 
-        // Then, update predefined headers or add custom headers from the loaded request
+        // Then, overlay values explicitly present in the loaded request.
+        let editable_predefined = PredefinedHeader::editable();
         for (key, value) in &request.headers {
+            if crate::types::is_transport_owned_header(key) {
+                continue;
+            }
+
             // Check if this matches a predefined header
-            let all_predefined = PredefinedHeader::all();
-            let predefined_match = all_predefined
+            let predefined_match = editable_predefined
                 .iter()
                 .find(|p| p.name().eq_ignore_ascii_case(key));
 
@@ -462,6 +466,10 @@ impl RequestEditor {
                 let key = header_row.key_input.read(cx).value().to_string();
                 let value = header_row.value_input.read(cx).value().to_string();
 
+                if crate::types::is_transport_owned_header(&key) {
+                    continue;
+                }
+
                 // Skip empty custom headers (the placeholder row)
                 if !key.is_empty() || !matches!(header_row.header_type, HeaderType::Custom) {
                     headers.push((key, value));
@@ -512,16 +520,21 @@ impl RequestEditor {
     pub fn get_headers_state(&self, cx: &App) -> Vec<crate::types::HeaderState> {
         self.headers
             .iter()
-            .map(|header_row| {
+            .filter_map(|header_row| {
                 let key = header_row.key_input.read(cx).value().to_string();
+                if header_row.predefined == Some(PredefinedHeader::ContentLength)
+                    || crate::types::is_transport_owned_header(&key)
+                {
+                    return None;
+                }
                 let value = header_row.value_input.read(cx).value().to_string();
-                crate::types::HeaderState {
+                Some(crate::types::HeaderState {
                     enabled: header_row.enabled,
                     key,
                     value,
                     header_type: header_row.header_type,
                     predefined: header_row.predefined,
-                }
+                })
             })
             .collect()
     }
@@ -586,60 +599,77 @@ impl RequestEditor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        // Clear existing headers and subscriptions
+        // Begin from the complete Postman-style predefined set. Older saved/imported
+        // states may contain only the rows that appeared in the source request.
         self.headers.clear();
+        self.init_predefined_headers(window, cx);
 
-        // Rebuild headers from saved state
+        // Apply saved state on top, normalizing predefined rows and dropping
+        // legacy Content-Length values.
+        let editable_predefined = PredefinedHeader::editable();
         for header_state in state {
-            // Predefined rows render their key field disabled, so only custom rows
-            // get the typeahead.
-            let key_input = if matches!(header_state.header_type, HeaderType::Custom) {
-                custom_header_key_input(&header_state.key, window, cx)
-            } else {
-                cx.new(|cx| {
-                    let mut input = InputState::new(window, cx);
-                    input.set_value(&header_state.key, window, cx);
-                    input
-                })
-            };
+            if header_state.is_transport_owned() {
+                continue;
+            }
+
+            let predefined = header_state
+                .predefined
+                .filter(|predefined| editable_predefined.contains(predefined))
+                .or_else(|| {
+                    editable_predefined.iter().copied().find(|predefined| {
+                        predefined.name().eq_ignore_ascii_case(&header_state.key)
+                    })
+                });
+
+            if let Some(predefined) = predefined {
+                if let Some(header) = self
+                    .headers
+                    .iter_mut()
+                    .find(|header| header.predefined == Some(predefined))
+                {
+                    header.enabled = header_state.enabled;
+                    header.header_type = predefined.header_type();
+                    header.value_input.update(cx, |input, cx| {
+                        input.set_value(&header_state.value, window, cx);
+                    });
+                }
+                continue;
+            }
 
             let header_row = HeaderRow {
                 enabled: header_state.enabled,
-                key_input,
+                key_input: custom_header_key_input(&header_state.key, window, cx),
                 value_input: cx.new(|cx| {
                     let mut input = InputState::new(window, cx);
                     input.set_value(&header_state.value, window, cx);
                     input
                 }),
-                header_type: header_state.header_type,
-                predefined: header_state.predefined,
+                header_type: HeaderType::Custom,
+                predefined: None,
                 last_key_len: header_state.key.chars().count(),
             };
 
-            // Subscribe to key input change if it's a custom header
-            if matches!(header_state.header_type, HeaderType::Custom) {
-                let key_input = header_row.key_input.clone();
-                let key_input_for_closure = key_input.clone();
-                let sub = cx.subscribe_in(
-                    &key_input,
-                    window,
-                    move |this, emitter, _event: &InputEvent, window, cx| {
-                        this.maybe_advance_after_completion(emitter, window, cx);
+            let key_input = header_row.key_input.clone();
+            let key_input_for_closure = key_input.clone();
+            let sub = cx.subscribe_in(
+                &key_input,
+                window,
+                move |this, emitter, _event: &InputEvent, window, cx| {
+                    this.maybe_advance_after_completion(emitter, window, cx);
 
-                        if let Some(last) = this.headers.last() {
-                            let has_key = !last.key_input.read(cx).value().is_empty();
-                            if has_key
-                                && matches!(last.header_type, HeaderType::Custom)
-                                && this.headers.last().map(|h| Entity::entity_id(&h.key_input))
-                                    == Some(Entity::entity_id(&key_input_for_closure))
-                            {
-                                this.add_custom_header_row(window, cx);
-                            }
+                    if let Some(last) = this.headers.last() {
+                        let has_key = !last.key_input.read(cx).value().is_empty();
+                        if has_key
+                            && matches!(last.header_type, HeaderType::Custom)
+                            && this.headers.last().map(|h| Entity::entity_id(&h.key_input))
+                                == Some(Entity::entity_id(&key_input_for_closure))
+                        {
+                            this.add_custom_header_row(window, cx);
                         }
-                    },
-                );
-                self._row_subscriptions.push(sub);
-            }
+                    }
+                },
+            );
+            self._row_subscriptions.push(sub);
 
             self.headers.push(header_row);
         }
@@ -810,23 +840,6 @@ impl RequestEditor {
             }
 
             cx.notify();
-        }
-    }
-
-    /// Update Content-Length header with calculated value from body
-    fn update_content_length(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let content_length = self.body_editor.read(cx).calculate_length(cx).to_string();
-
-        // Find Content-Length header and update it
-        for header in &mut self.headers {
-            if let Some(predefined) = header.predefined
-                && matches!(predefined, PredefinedHeader::ContentLength)
-            {
-                header.value_input.update(cx, |input, cx| {
-                    input.set_value(&content_length, window, cx);
-                });
-                break;
-            }
         }
     }
 
@@ -1245,8 +1258,6 @@ impl RequestEditor {
 
         log::debug!("Sending request");
 
-        // Update Content-Length before sending
-        self.update_content_length(window, cx);
         let editor_request_snapshot = self.get_current_request_data(cx);
         let history_request_snapshot = editor_request_snapshot.history_snapshot();
 
@@ -1278,7 +1289,10 @@ impl RequestEditor {
             if header.enabled {
                 let key = header.key_input.read(cx).value().to_string();
                 let value = header.value_input.read(cx).value().to_string();
-                if !key.is_empty() && !value.is_empty() {
+                if !crate::types::is_transport_owned_header(&key)
+                    && !key.is_empty()
+                    && !value.is_empty()
+                {
                     headers.push((key, value));
                 }
             }
@@ -1686,7 +1700,6 @@ impl Render for RequestEditor {
                                             let is_mandatory = matches!(header.header_type, HeaderType::Mandatory);
                                             let is_predefined = !matches!(header.header_type, HeaderType::Custom);
                                             let is_custom = matches!(header.header_type, HeaderType::Custom);
-                                            let is_auto_calculated = header.predefined.map(|p| p.is_auto_calculated()).unwrap_or(false);
 
                                             div()
                                                 .flex()
@@ -1740,13 +1753,13 @@ impl Render for RequestEditor {
                                                         .child(Input::new(&header.key_input).disabled(is_predefined))
                                                 })
                                                 .child(
-                                                    // Value input - disabled for auto-calculated headers and Content-Type
+                                                    // Content-Type follows the selected body subtype.
                                                     // Delete button embedded as suffix for custom headers
                                                     div()
                                                         .flex_1()
                                                         .child(
                                                             Input::new(&header.value_input)
-                                                                .disabled(is_auto_calculated || header.predefined == Some(PredefinedHeader::ContentType))
+                                                                .disabled(header.predefined == Some(PredefinedHeader::ContentType))
                                                                 .when(is_custom, |input| {
                                                                     input.suffix(
                                                                         Button::new(("delete-header", index))

--- a/src/types.rs
+++ b/src/types.rs
@@ -74,7 +74,8 @@ impl Default for AppSettings {
 /// Header type for distinguishing predefined vs custom headers
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub enum HeaderType {
-    /// Mandatory header that cannot be disabled or deleted (e.g., Cache-Control)
+    /// Legacy persisted value for headers that could not be disabled.
+    /// New editor rows never use this variant.
     Mandatory,
     /// Predefined header that can be toggled but not deleted
     Predefined,
@@ -112,31 +113,34 @@ impl PredefinedHeader {
             PredefinedHeader::Accept => "*/*",
             PredefinedHeader::UserAgent => "PostmanRuntime/7.48.0",
             PredefinedHeader::Connection => "keep-alive",
-            PredefinedHeader::ContentLength => "0",
+            // Kept only so old serialized `PredefinedHeader` values still decode.
+            // Content-Length is owned by the HTTP transport and has no editor value.
+            PredefinedHeader::ContentLength => "",
         }
-    }
-
-    pub fn is_auto_calculated(&self) -> bool {
-        matches!(self, PredefinedHeader::ContentLength)
     }
 
     pub fn header_type(&self) -> HeaderType {
-        match self {
-            PredefinedHeader::CacheControl => HeaderType::Mandatory,
-            _ => HeaderType::Predefined,
-        }
+        HeaderType::Predefined
     }
 
-    pub fn all() -> Vec<Self> {
+    /// Headers represented by rows in the editor. The `ContentLength` enum
+    /// variant remains for backward-compatible deserialization, but is never
+    /// user-managed.
+    pub fn editable() -> Vec<Self> {
         vec![
             PredefinedHeader::CacheControl,
             PredefinedHeader::ContentType,
             PredefinedHeader::Accept,
             PredefinedHeader::UserAgent,
             PredefinedHeader::Connection,
-            PredefinedHeader::ContentLength,
         ]
     }
+}
+
+/// Metadata calculated by the HTTP transport from the final encoded body.
+/// Matching is case-insensitive because HTTP field names are case-insensitive.
+pub fn is_transport_owned_header(name: &str) -> bool {
+    name.eq_ignore_ascii_case("content-length")
 }
 
 /// HTTP methods supported by the API client.
@@ -470,12 +474,16 @@ pub fn effective_wire_headers(
     let mut out: Vec<(String, String)> = headers
         .iter()
         .filter(|(name, _)| {
-            claimed_header.is_none_or(|claimed| !name.eq_ignore_ascii_case(claimed))
+            !is_transport_owned_header(name)
+                && claimed_header.is_none_or(|claimed| !name.eq_ignore_ascii_case(claimed))
         })
         .cloned()
         .collect();
 
-    if let Some((name, value)) = auth.compute_header() {
+    if let Some((name, value)) = auth
+        .compute_header()
+        .filter(|(name, _)| !is_transport_owned_header(name))
+    {
         out.push((name, value));
     }
     out
@@ -510,8 +518,16 @@ impl RequestData {
     /// Environment substitution happens only on the separate wire request.
     pub fn history_snapshot(&self) -> Self {
         let mut snapshot = self.clone();
+        snapshot.strip_transport_owned_headers();
         snapshot.auth = snapshot.auth.active_only();
         snapshot
+    }
+
+    /// Remove headers whose values must be computed from the final wire body.
+    /// This also sanitizes records created by older versions of Poopman.
+    pub fn strip_transport_owned_headers(&mut self) {
+        self.headers
+            .retain(|(name, _)| !is_transport_owned_header(name));
     }
 }
 
@@ -664,6 +680,13 @@ pub struct HeaderState {
     pub value: String,
     pub header_type: HeaderType,
     pub predefined: Option<PredefinedHeader>,
+}
+
+impl HeaderState {
+    pub fn is_transport_owned(&self) -> bool {
+        self.predefined == Some(PredefinedHeader::ContentLength)
+            || is_transport_owned_header(&self.key)
+    }
 }
 
 /// A request persisted inside a collection. The request payload and the
@@ -854,6 +877,47 @@ mod tests {
     }
 
     #[test]
+    fn content_length_is_transport_owned_and_not_editable() {
+        assert!(is_transport_owned_header("Content-Length"));
+        assert!(is_transport_owned_header("content-length"));
+        assert!(!is_transport_owned_header("Content-Type"));
+        assert_eq!(
+            serde_json::from_str::<PredefinedHeader>("\"ContentLength\"").unwrap(),
+            PredefinedHeader::ContentLength
+        );
+        assert!(!PredefinedHeader::editable().contains(&PredefinedHeader::ContentLength));
+        assert_eq!(
+            PredefinedHeader::CacheControl.header_type(),
+            HeaderType::Predefined
+        );
+    }
+
+    #[test]
+    fn effective_headers_drop_manual_content_length_case_insensitively() {
+        let manual = vec![
+            ("content-length".to_string(), "1".to_string()),
+            ("X-Trace".to_string(), "kept".to_string()),
+        ];
+
+        assert_eq!(
+            effective_wire_headers(&manual, &AuthConfig::default()),
+            vec![("X-Trace".to_string(), "kept".to_string())]
+        );
+    }
+
+    #[test]
+    fn effective_headers_reject_content_length_as_an_api_key_name() {
+        let auth = AuthConfig {
+            auth_type: AuthType::ApiKey,
+            api_key_name: "Content-Length".into(),
+            api_key_value: "999".into(),
+            ..Default::default()
+        };
+
+        assert!(effective_wire_headers(&[], &auth).is_empty());
+    }
+
+    #[test]
     fn effective_headers_appends_auth() {
         let manual = vec![("Accept".to_string(), "*/*".to_string())];
         let auth = AuthConfig {
@@ -997,6 +1061,20 @@ mod tests {
         };
 
         assert_eq!(request.history_snapshot().auth, AuthConfig::default());
+    }
+
+    #[test]
+    fn history_snapshot_drops_stale_content_length() {
+        let mut request = RequestData::new(HttpMethod::POST, "https://api.test".into());
+        request.headers = vec![
+            ("Content-Length".into(), "0".into()),
+            ("X-Trace".into(), "kept".into()),
+        ];
+
+        assert_eq!(
+            request.history_snapshot().headers,
+            vec![("X-Trace".into(), "kept".into())]
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep the visible predefined headers enabled by default to match Postman behavior
- remove the Content-Length editor row and all manual length calculation
- strip stale Content-Length values from cURL/Postman imports, history, saved requests, generated snippets, and outgoing requests
- preserve disabled header state across tab and persistence round trips
- add wire-level coverage for variable-backed Unicode, empty, and multipart bodies

## Validation

- cargo test -- --test-threads=1 (268 passed)
- cargo check --tests
- cargo clippy --tests (4 existing warnings, no new warnings)
- cargo build --release

Closes #44