### PR TITLE
fix(environments): preserve pending edits on shutdown and toggle value visibility

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -56,6 +56,7 @@ enum SidebarView {
 /// stall an already-running UI event loop.
 pub(crate) struct AppInitialState {
     db: Arc<Database>,
+    pub(crate) environment_persistence: crate::environment_persistence::EnvironmentPersistence,
     environments: Vec<crate::types::Environment>,
     active_environment_id: Option<i64>,
     history: Vec<crate::types::HistoryItem>,
@@ -72,6 +73,9 @@ impl AppInitialState {
         let collections = db.load_collections()?;
         let settings = db.load_app_settings()?;
         Ok(Self {
+            environment_persistence: crate::environment_persistence::EnvironmentPersistence::new(
+                db.clone(),
+            ),
             db,
             environments,
             active_environment_id,
@@ -122,6 +126,7 @@ impl PoopmanApp {
     pub fn new(initial: AppInitialState, window: &mut Window, cx: &mut Context<Self>) -> Self {
         let AppInitialState {
             db,
+            environment_persistence,
             environments,
             active_environment_id,
             history,
@@ -143,7 +148,7 @@ impl PoopmanApp {
         let manager_environments = environments.clone();
         let env_manager = cx.new(|cx| {
             EnvironmentManager::new(
-                db.clone(),
+                environment_persistence,
                 manager_environments,
                 active_environment_id,
                 window,
@@ -1240,7 +1245,7 @@ impl Render for PoopmanApp {
                 // Brand + Edit menu are grouped in one child so the TitleBar's
                 // justify_between row keeps them together at the left (otherwise
                 // two children get pushed to opposite ends).
-                TitleBar::new().child(
+                TitleBar::new().on_close_window(|_, _, cx| crate::request_quit(cx)).child(
                     h_flex()
                         .items_center()
                         .gap_2()

--- a/src/db.rs
+++ b/src/db.rs
@@ -426,6 +426,13 @@ impl Database {
         Self::spawn(conn)
     }
 
+    #[cfg(test)]
+    pub(crate) fn open_test_file(path: &std::path::Path) -> Self {
+        let conn = Connection::open(path).expect("open test db");
+        Self::init_schema(&conn).expect("init schema");
+        Self::spawn(conn)
+    }
+
     /// Send `f` to the owning thread and block until it returns a result.
     #[cfg_attr(feature = "profile", profiling::function)]
     fn call<T, F>(&self, f: F) -> Result<T>
@@ -1041,8 +1048,16 @@ impl Database {
 
     pub fn delete_environment(&self, id: i64) -> Result<()> {
         self.call(move |conn| {
+            let tx = conn.transaction()?;
             // env_variables rows are removed by ON DELETE CASCADE (foreign_keys = ON).
-            conn.execute("DELETE FROM environments WHERE id = ?1", params![id])?;
+            tx.execute("DELETE FROM environments WHERE id = ?1", params![id])?;
+            // Consult persisted state at execution time. A delayed deletion must
+            // never clear a newer choice of a different environment.
+            tx.execute(
+                "DELETE FROM app_meta WHERE key = 'active_environment_id' AND value = ?1",
+                params![id.to_string()],
+            )?;
+            tx.commit()?;
             Ok(())
         })
     }

--- a/src/environment_manager.rs
+++ b/src/environment_manager.rs
@@ -1,7 +1,7 @@
 //! Environment management UI (shown inside a Dialog): create/rename/delete
 //! environments, edit their variables, and choose the active one. All mutations
-//! are written to the DB immediately and an `EnvironmentsChanged` event is emitted
-//! so `PoopmanApp` can reload and refresh the request editor's variable map.
+//! enter one ordered persistence queue and emit an `EnvironmentsChanged` event
+//! so `PoopmanApp` can refresh the request editor's variable map immediately.
 
 use gpui::prelude::FluentBuilder as _;
 use gpui::*;
@@ -10,16 +10,15 @@ use gpui_component::{
     ActiveTheme as _, Icon, Sizable as _, button::*, checkbox::Checkbox, h_flex, input::*,
     scroll::ScrollableElement as _, v_flex,
 };
-use std::time::Duration;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
     },
 };
 
-use crate::db::Database;
+use crate::environment_persistence::EnvironmentPersistence;
 use crate::types::{EnvVar, Environment};
 
 /// Emitted with the manager's current in-memory state. The UI never has to
@@ -32,6 +31,7 @@ pub struct EnvironmentsChanged {
 
 struct VarRow {
     enabled: bool,
+    value_visible: bool,
     key_input: Entity<InputState>,
     value_input: Entity<InputState>,
 }
@@ -166,11 +166,34 @@ fn environment_name_is_valid(name: &str) -> bool {
     !name.trim().is_empty()
 }
 
+struct ActiveSelection {
+    id: Option<i64>,
+    generation: u64,
+}
+
+impl ActiveSelection {
+    fn choose(&mut self, id: Option<i64>) -> u64 {
+        self.generation = self.generation.wrapping_add(1);
+        self.id = id;
+        self.generation
+    }
+
+    fn reconcile(&mut self, generation: u64, persisted_id: Option<i64>) -> bool {
+        if self.generation != generation {
+            return false;
+        }
+        self.id = persisted_id;
+        true
+    }
+}
+
 pub struct EnvironmentManager {
-    db: Arc<Database>,
+    persistence: EnvironmentPersistence,
     environments: Vec<Environment>,
-    active_id: Option<i64>,
+    active: ActiveSelection,
     selected_id: Option<i64>,
+    selection_generation: u64,
+    deleting: HashSet<i64>,
     name_input: Entity<InputState>,
     var_rows: Vec<VarRow>,
     env_list_scroll_handle: ScrollHandle,
@@ -188,7 +211,7 @@ impl EventEmitter<EnvironmentsChanged> for EnvironmentManager {}
 
 impl EnvironmentManager {
     pub fn new(
-        db: Arc<Database>,
+        persistence: EnvironmentPersistence,
         environments: Vec<Environment>,
         active_id: Option<i64>,
         window: &mut Window,
@@ -198,10 +221,15 @@ impl EnvironmentManager {
         let name_input = cx.new(|cx| InputState::new(window, cx).placeholder("Environment name"));
 
         let mut this = Self {
-            db,
+            persistence,
             environments,
-            active_id,
+            active: ActiveSelection {
+                id: active_id,
+                generation: 0,
+            },
             selected_id,
+            selection_generation: 0,
+            deleting: HashSet::new(),
             name_input,
             var_rows: vec![],
             env_list_scroll_handle: ScrollHandle::new(),
@@ -247,7 +275,7 @@ impl EnvironmentManager {
     fn changed_event(&self) -> EnvironmentsChanged {
         EnvironmentsChanged {
             environments: self.environments.clone(),
-            active_id: self.active_id,
+            active_id: self.active.id,
         }
     }
 
@@ -294,6 +322,7 @@ impl EnvironmentManager {
         let value = value.to_string();
         VarRow {
             enabled,
+            value_visible: false,
             key_input: cx.new(|cx| {
                 let mut i = InputState::new(window, cx).placeholder("Key");
                 i.set_value(&key, window, cx);
@@ -313,16 +342,26 @@ impl EnvironmentManager {
     }
 
     fn select(&mut self, id: i64, window: &mut Window, cx: &mut Context<Self>) {
+        if self.persistence.is_closing() || self.deleting.contains(&id) {
+            return;
+        }
         // Edits update the in-memory model immediately and persist in the
         // background, so selection never needs a read-back round trip.
         self.selected_id = Some(id);
+        self.selection_generation = self.selection_generation.wrapping_add(1);
         self.load_selected_into_editor(window, cx);
         cx.notify();
     }
 
     fn add_environment(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        let db = self.db.clone();
-        let task = cx.background_spawn(async move { db.create_environment("New Environment") });
+        if self.persistence.is_closing() {
+            return;
+        }
+        self.selection_generation = self.selection_generation.wrapping_add(1);
+        let selection_generation = self.selection_generation;
+        let task = self
+            .persistence
+            .submit(None, |db| db.create_environment("New Environment"));
         cx.spawn_in(window, async move |this, cx| {
             match task.await {
                 Ok(id) => {
@@ -332,8 +371,10 @@ impl EnvironmentManager {
                             name: "New Environment".to_string(),
                             variables: Vec::new(),
                         });
-                        this.selected_id = Some(id);
-                        this.load_selected_into_editor(window, cx);
+                        if this.selection_generation == selection_generation {
+                            this.selected_id = Some(id);
+                            this.load_selected_into_editor(window, cx);
+                        }
                         this.save_tracker.set_status(id, SaveStatus::Saved);
                         cx.emit(this.changed_event());
                         cx.notify();
@@ -342,7 +383,9 @@ impl EnvironmentManager {
                 Err(error) => {
                     log::error!("Failed to create environment: {}", error);
                     this.update(cx, |this, cx| {
-                        if let Some(id) = this.selected_id {
+                        if this.selection_generation == selection_generation
+                            && let Some(id) = this.selected_id
+                        {
                             this.save_tracker.set_status(id, SaveStatus::Failed);
                         }
                         cx.notify();
@@ -355,25 +398,28 @@ impl EnvironmentManager {
     }
 
     fn delete_environment(&mut self, id: i64, window: &mut Window, cx: &mut Context<Self>) {
-        self.save_tracker.invalidate(id);
-        let was_active = self.active_id == Some(id);
-        let db = self.db.clone();
-        let task = cx.background_spawn(async move {
-            db.delete_environment(id)?;
-            if was_active {
-                db.set_active_environment_id(None)?;
-            }
-            Ok::<_, anyhow::Error>(())
-        });
+        if self.persistence.is_closing() || !self.deleting.insert(id) {
+            return;
+        }
+        let selection_generation = self.selection_generation;
+        let task = self
+            .persistence
+            .submit(None, move |db| db.delete_environment(id));
         cx.spawn_in(window, async move |this, cx| {
             match task.await {
                 Ok(()) => {
                     this.update_in(cx, |this, window, cx| {
+                        this.deleting.remove(&id);
+                        this.save_tracker.invalidate(id);
                         this.environments.retain(|environment| environment.id != id);
-                        if was_active {
-                            this.active_id = None;
+                        if this.active.id == Some(id) {
+                            this.active.choose(None);
                         }
                         if this.selected_id == Some(id) {
+                            if this.selection_generation == selection_generation {
+                                this.selection_generation =
+                                    this.selection_generation.wrapping_add(1);
+                            }
                             this.selected_id = this.environments.first().map(|env| env.id);
                             this.load_selected_into_editor(window, cx);
                         }
@@ -384,6 +430,8 @@ impl EnvironmentManager {
                 Err(error) => {
                     log::error!("Failed to delete environment: {}", error);
                     this.update(cx, |this, cx| {
+                        this.deleting.remove(&id);
+                        this.save_tracker.invalidate(id);
                         this.save_tracker.set_status(id, SaveStatus::Failed);
                         cx.notify();
                     })?;
@@ -400,19 +448,35 @@ impl EnvironmentManager {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let previous = self.active_id;
-        self.active_id = id;
+        if self.persistence.is_closing() || id.is_some_and(|id| self.deleting.contains(&id)) {
+            return;
+        }
+        let generation = self.active.choose(id);
         cx.emit(self.changed_event());
         cx.notify();
 
-        let db = self.db.clone();
-        let task = cx.background_spawn(async move { db.set_active_environment_id(id) });
+        let task = self
+            .persistence
+            .submit(None, move |db| db.set_active_environment_id(id));
         cx.spawn_in(window, async move |this, cx| {
             if let Err(error) = task.await {
                 log::error!("Failed to set active environment: {}", error);
+                // Read the actual persisted choice through the same queue. The
+                // previous optimistic choice may itself have failed to save.
+                let recovery = this.update(cx, |this, _| {
+                    (this.active.generation == generation).then(|| {
+                        this.persistence
+                            .submit(None, |db| db.get_active_environment_id())
+                    })
+                })?;
+                let Some(recovery) = recovery else {
+                    return Ok(());
+                };
+                let persisted_id = recovery.await?;
                 this.update(cx, |this, cx| {
-                    if this.active_id == id {
-                        this.active_id = previous;
+                    let persisted_id =
+                        persisted_id.filter(|id| this.environments.iter().any(|env| env.id == *id));
+                    if this.active.reconcile(generation, persisted_id) {
                         cx.emit(this.changed_event());
                         cx.notify();
                     }
@@ -446,9 +510,16 @@ impl EnvironmentManager {
         Some((id, name, vars))
     }
 
-    /// Update the UI immediately, then coalesce rapid edits into one background
-    /// persistence job. The generation check prevents stale timers from writing.
+    /// Update the UI and enqueue its snapshot immediately. The persistence
+    /// worker coalesces edits; generations protect the UI from stale completions.
     fn commit(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.persistence.is_closing()
+            || self
+                .selected_id
+                .is_some_and(|id| self.deleting.contains(&id))
+        {
+            return;
+        }
         let Some((id, name, vars)) = self.snapshot_selected(cx) else {
             return;
         };
@@ -459,29 +530,26 @@ impl EnvironmentManager {
             SaveStatus::InvalidName
         };
         let (generation, save_epoch) = self.save_tracker.begin(id, pending_status);
+        // An invalid name must not discard a valid rename that is still in the
+        // debounce queue. The local model retains the latest valid name.
+        let persisted_name = self
+            .environments
+            .iter()
+            .find(|env| env.id == id)
+            .map(|env| env.name.clone())
+            .unwrap_or(name);
         cx.emit(self.changed_event());
         cx.notify();
 
-        let db = self.db.clone();
+        let task = self.persistence.submit(Some(id), move |db| {
+            db.save_environment_if_current(id, &persisted_name, &vars, save_epoch, generation)
+        });
         cx.spawn_in(window, async move |this, cx| {
-            cx.background_executor()
-                .timer(Duration::from_millis(180))
-                .await;
-            let is_current = this
-                .update(cx, |this, _| this.save_tracker.is_current(id, generation))
-                .unwrap_or(false);
-            if !is_current {
-                return Ok(());
-            }
-
-            let task = cx.background_spawn(async move {
-                db.save_environment_if_current(id, &name, &vars, save_epoch, generation)
-            });
             let result = task.await;
-            if let Err(error) = &result {
-                log::error!("Failed to save environment: {}", error);
-            }
             this.update(cx, |this, cx| {
+                if !this.save_tracker.is_current(id, generation) {
+                    return;
+                }
                 let status = if result.is_ok() {
                     if name_is_valid {
                         SaveStatus::Saved
@@ -509,6 +577,16 @@ impl EnvironmentManager {
         cx.notify();
     }
 
+    fn toggle_var_visibility(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(row) = self.var_rows.get_mut(index) {
+            row.value_visible = !row.value_visible;
+            row.value_input.update(cx, |input, cx| {
+                input.set_masked(!row.value_visible, window, cx);
+            });
+            cx.notify();
+        }
+    }
+
     fn remove_var_row(&mut self, index: usize, window: &mut Window, cx: &mut Context<Self>) {
         if index < self.var_rows.len() {
             self.var_rows.remove(index);
@@ -528,7 +606,7 @@ impl Render for EnvironmentManager {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
         let selected_id = self.selected_id;
-        let active_id = self.active_id;
+        let active_id = self.active.id;
         let viewport = window.viewport_size();
         let geometry = environment_dialog_geometry(viewport.width, viewport.height);
         let save_status = selected_id
@@ -627,7 +705,7 @@ impl Render for EnvironmentManager {
                                             })
                                             .on_click(cx.listener(move |this, _, window, cx| {
                                                 cx.stop_propagation();
-                                                let new = if this.active_id == Some(id) {
+                                                let new = if this.active.id == Some(id) {
                                                     None
                                                 } else {
                                                     Some(id)
@@ -836,7 +914,21 @@ impl Render for EnvironmentManager {
                                                                         .child(
                                                                             Input::new(&row.value_input)
                                                                                 .small()
-                                                                                .mask_toggle(),
+                                                                                .suffix(
+                                                                                    Button::new(("var-visibility", index))
+                                                                                        .ghost()
+                                                                                        .xsmall()
+                                                                                        .tab_stop(false)
+                                                                                        .icon(Icon::empty().path(if row.value_visible {
+                                                                                            "icons/eye-off.svg"
+                                                                                        } else {
+                                                                                            "icons/eye.svg"
+                                                                                        }))
+                                                                                        .tooltip(if row.value_visible { "Hide value" } else { "Show value" })
+                                                                                        .on_click(cx.listener(move |this, _, window, cx| {
+                                                                                            this.toggle_var_visibility(index, window, cx);
+                                                                                        })),
+                                                                                ),
                                                                         ),
                                                                 )
                                                                 .child(
@@ -924,9 +1016,41 @@ impl Render for EnvironmentManager {
 
 #[cfg(test)]
 mod tests {
-    use super::{SaveStatus, SaveTracker, environment_dialog_geometry, environment_name_is_valid};
+    use super::{
+        ActiveSelection, SaveStatus, SaveTracker, environment_dialog_geometry,
+        environment_name_is_valid,
+    };
     use gpui::px;
     use std::sync::atomic::Ordering;
+
+    #[test]
+    fn stale_active_completion_cannot_roll_back_a_repeated_selection() {
+        let mut active = ActiveSelection {
+            id: None,
+            generation: 0,
+        };
+        let first_a = active.choose(Some(1));
+        let b = active.choose(Some(2));
+        let latest_a = active.choose(Some(1));
+        assert!(!active.reconcile(first_a, None));
+        assert!(!active.reconcile(b, Some(2)));
+        assert_eq!(active.id, Some(1));
+        // A failure of the current choice reconciles to the database state.
+        assert!(active.reconcile(latest_a, Some(2)));
+        assert_eq!(active.id, Some(2));
+    }
+
+    #[test]
+    fn deletion_invalidates_an_outstanding_active_completion() {
+        let mut active = ActiveSelection {
+            id: None,
+            generation: 0,
+        };
+        let pending = active.choose(Some(1));
+        active.choose(None);
+        assert!(!active.reconcile(pending, Some(1)));
+        assert_eq!(active.id, None);
+    }
 
     #[test]
     fn desktop_dialog_uses_readable_maximum_dimensions() {

--- a/src/environment_persistence.rs
+++ b/src/environment_persistence.rs
@@ -1,0 +1,321 @@
+//! Ordered environment writes. Commands are submitted synchronously by the UI;
+//! only their completion is asynchronous. The worker owns debounced snapshots,
+//! so they survive dropped views/futures and can be flushed before quitting.
+
+use anyhow::{Result, anyhow};
+use futures::channel::oneshot;
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+        mpsc::{self, RecvTimeoutError},
+    },
+    time::{Duration, Instant},
+};
+
+use crate::db::Database;
+
+type Job = Box<dyn FnOnce(&Database) -> Option<String> + Send>;
+enum Command {
+    Edit(i64, Job),
+    Run(Job),
+    Flush(oneshot::Sender<Result<()>>),
+}
+
+#[derive(Clone)]
+pub(crate) struct EnvironmentPersistence {
+    tx: mpsc::Sender<Command>,
+    closing: Arc<AtomicBool>,
+}
+
+impl EnvironmentPersistence {
+    pub(crate) fn new(db: Arc<Database>) -> Self {
+        Self::with_debounce(db, Duration::from_millis(180))
+    }
+
+    fn with_debounce(db: Arc<Database>, debounce: Duration) -> Self {
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let mut pending: Vec<(i64, Job)> = Vec::new();
+            let mut deadline = Instant::now();
+            let mut last_error = None;
+            loop {
+                let command = if pending.is_empty() {
+                    rx.recv().map_err(|_| RecvTimeoutError::Disconnected)
+                } else {
+                    rx.recv_timeout(deadline.saturating_duration_since(Instant::now()))
+                };
+                match command {
+                    Ok(Command::Edit(id, job)) => {
+                        // Move replacements to the end to preserve the order of
+                        // the latest accepted snapshots across environments.
+                        pending.retain(|(pending_id, _)| *pending_id != id);
+                        pending.push((id, job));
+                        deadline = Instant::now() + debounce;
+                    }
+                    command => {
+                        for (_, job) in pending.drain(..) {
+                            record_error(&mut last_error, job(&db));
+                        }
+                        match command {
+                            Ok(Command::Run(job)) => record_error(&mut last_error, job(&db)),
+                            Ok(Command::Flush(reply)) => {
+                                let result = last_error.take().map_or(Ok(()), |e| Err(anyhow!(e)));
+                                let _ = reply.send(result);
+                            }
+                            Err(RecvTimeoutError::Disconnected) => break,
+                            Err(RecvTimeoutError::Timeout) => {}
+                            Ok(Command::Edit(..)) => unreachable!(),
+                        }
+                    }
+                }
+            }
+        });
+        Self {
+            tx,
+            closing: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    /// This must remain a regular function: enqueue before returning the future,
+    /// never when a detached task happens to poll it.
+    pub(crate) fn submit<T: Send + 'static, F: FnOnce(&Database) -> Result<T> + Send + 'static>(
+        &self,
+        edit_id: Option<i64>,
+        operation: F,
+    ) -> impl Future<Output = Result<T>> + use<T, F> {
+        let (reply, result) = oneshot::channel();
+        if self.is_closing() {
+            let _ = reply.send(Err(anyhow!("environment persistence is shutting down")));
+        } else {
+            let job: Job = Box::new(move |db| {
+                let result = operation(db);
+                let error = result.as_ref().err().map(ToString::to_string);
+                let _ = reply.send(result);
+                error
+            });
+            let command = match edit_id {
+                Some(id) => Command::Edit(id, job),
+                None => Command::Run(job),
+            };
+            let _ = self.tx.send(command);
+        }
+        async move {
+            result
+                .await
+                .map_err(|_| anyhow!("environment save was superseded or worker stopped"))?
+        }
+    }
+
+    pub(crate) fn is_closing(&self) -> bool {
+        self.closing.load(Ordering::Acquire)
+    }
+
+    /// Freeze accepted mutations and force all queued snapshots to disk. The
+    /// caller bounds the wait; no UI callback is needed to complete this future.
+    pub(crate) fn shutdown(&self) -> impl Future<Output = Result<()>> + use<> {
+        self.closing.store(true, Ordering::Release);
+        let (reply, result) = oneshot::channel();
+        let _ = self.tx.send(Command::Flush(reply));
+        async move {
+            result
+                .await
+                .map_err(|_| anyhow!("environment persistence worker stopped"))?
+        }
+    }
+}
+
+fn record_error(last_error: &mut Option<String>, error: Option<String>) {
+    if let Some(error) = error {
+        log::error!("Environment persistence failed: {error}");
+        *last_error = Some(error);
+    }
+}
+
+pub(crate) async fn finish_shutdown(
+    flush: impl Future<Output = Result<()>>,
+    timeout: impl Future<Output = ()>,
+) -> Result<()> {
+    match futures::future::select(Box::pin(flush), Box::pin(timeout)).await {
+        futures::future::Either::Left((result, _)) => result,
+        futures::future::Either::Right(_) => {
+            Err(anyhow!("timed out saving environments before quitting"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::EnvVar;
+    use std::sync::atomic::AtomicU64;
+
+    fn wait<T: Send + 'static>(future: impl Future<Output = T> + Send + 'static) -> T {
+        let (tx, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = tx.send(futures::executor::block_on(future));
+        });
+        rx.recv_timeout(Duration::from_secs(5))
+            .expect("persistence must complete without waiting for debounce")
+    }
+
+    fn edit(
+        persistence: &EnvironmentPersistence,
+        id: i64,
+        value: &str,
+    ) -> impl Future<Output = Result<()>> + use<> {
+        let value = value.to_string();
+        persistence.submit(Some(id), move |db| {
+            db.save_environment_if_current(
+                id,
+                "Edited",
+                &[EnvVar {
+                    enabled: true,
+                    key: "token".into(),
+                    value,
+                }],
+                Arc::new(AtomicU64::new(1)),
+                1,
+            )
+        })
+    }
+
+    fn queue(db: Arc<Database>) -> EnvironmentPersistence {
+        // No timing race: only an explicit barrier can expire these edits.
+        EnvironmentPersistence::with_debounce(db, Duration::from_secs(3600))
+    }
+
+    #[test]
+    fn shutdown_flushes_latest_snapshots_for_multiple_environments_before_debounce() {
+        let db = Arc::new(Database::new_in_memory());
+        let a = db.create_environment("A").unwrap();
+        let b = db.create_environment("B").unwrap();
+        let persistence = queue(db.clone());
+        let stale = edit(&persistence, a, "old");
+        let b_save = edit(&persistence, b, "B value");
+        let a_save = edit(&persistence, a, "latest");
+        wait(persistence.shutdown()).unwrap();
+        assert!(wait(stale).is_err());
+        wait(a_save).unwrap();
+        wait(b_save).unwrap();
+        let environments = db.load_environments().unwrap();
+        assert_eq!(environments[0].variables[0].value, "latest");
+        assert_eq!(environments[1].variables[0].value, "B value");
+    }
+
+    #[test]
+    fn rapid_switches_are_enqueued_before_completion_futures_are_polled() {
+        let db = Arc::new(Database::new_in_memory());
+        let a = db.create_environment("A").unwrap();
+        let b = db.create_environment("B").unwrap();
+        let persistence = queue(db.clone());
+        let (release, gate) = mpsc::channel();
+        let blocked = persistence.submit(None, move |_| {
+            gate.recv()?;
+            Ok(())
+        });
+        // The worker is stalled while all UI operations are accepted. Dropping
+        // their completion futures must neither cancel nor reorder the writes.
+        for id in [Some(a), Some(b), None, Some(a), Some(b)] {
+            drop(persistence.submit(None, move |db| db.set_active_environment_id(id)));
+        }
+        let shutdown = persistence.shutdown();
+        release.send(()).unwrap();
+        wait(shutdown).unwrap();
+        wait(blocked).unwrap();
+        assert_eq!(db.get_active_environment_id().unwrap(), Some(b));
+    }
+
+    #[test]
+    fn edits_are_flushed_before_create_delete_and_active_changes() {
+        let db = Arc::new(Database::new_in_memory());
+        let a = db.create_environment("A").unwrap();
+        db.set_active_environment_id(Some(a)).unwrap();
+        let persistence = queue(db.clone());
+        drop(edit(&persistence, a, "pending"));
+        let create = persistence.submit(None, move |db| {
+            assert_eq!(db.load_environments()?[0].variables[0].value, "pending");
+            db.create_environment("B")
+        });
+        let b = wait(create).unwrap();
+        drop(persistence.submit(None, move |db| db.set_active_environment_id(Some(b))));
+        drop(persistence.submit(None, move |db| db.delete_environment(a)));
+        wait(persistence.shutdown()).unwrap();
+        assert_eq!(db.get_active_environment_id().unwrap(), Some(b));
+        assert_eq!(db.load_environments().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn deleting_the_persisted_active_environment_clears_it() {
+        let db = Arc::new(Database::new_in_memory());
+        let a = db.create_environment("A").unwrap();
+        let persistence = queue(db.clone());
+        drop(persistence.submit(None, move |db| db.set_active_environment_id(Some(a))));
+        drop(persistence.submit(None, move |db| db.delete_environment(a)));
+        wait(persistence.shutdown()).unwrap();
+        assert_eq!(db.get_active_environment_id().unwrap(), None);
+    }
+
+    #[test]
+    fn failure_is_reported_at_shutdown_without_stalling_later_writes() {
+        let db = Arc::new(Database::new_in_memory());
+        let persistence = queue(db.clone());
+        drop(persistence.submit::<(), _>(None, |_| Err(anyhow!("simulated disk failure"))));
+        drop(persistence.submit(None, |db| db.create_environment("Still processed")));
+        let error = wait(persistence.shutdown()).unwrap_err();
+        assert!(error.to_string().contains("simulated disk failure"));
+        assert_eq!(db.load_environments().unwrap().len(), 1);
+        assert!(wait(persistence.submit(None, |db| db.create_environment("Too late"))).is_err());
+        assert_eq!(db.load_environments().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn shutdown_timeout_does_not_wait_for_a_stuck_worker() {
+        let result = wait(finish_shutdown(
+            futures::future::pending(),
+            futures::future::ready(()),
+        ));
+        assert!(result.unwrap_err().to_string().contains("timed out"));
+    }
+
+    #[test]
+    fn expired_debounce_saves_without_shutdown() {
+        let db = Arc::new(Database::new_in_memory());
+        let id = db.create_environment("A").unwrap();
+        let persistence = EnvironmentPersistence::with_debounce(db.clone(), Duration::ZERO);
+        wait(edit(&persistence, id, "saved")).unwrap();
+        assert_eq!(
+            db.load_environments().unwrap()[0].variables[0].value,
+            "saved"
+        );
+    }
+
+    #[test]
+    fn immediate_shutdown_preserves_edit_when_database_is_reopened() {
+        static NEXT_FILE: AtomicU64 = AtomicU64::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "poopman-environment-shutdown-{}-{}-{}.db",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+            NEXT_FILE.fetch_add(1, Ordering::Relaxed)
+        ));
+        let db = Arc::new(Database::open_test_file(&path));
+        let id = db.create_environment("A").unwrap();
+        let persistence = queue(db.clone());
+        drop(edit(&persistence, id, "survives relaunch"));
+        wait(persistence.shutdown()).unwrap();
+        let reopened = Database::open_test_file(&path);
+        assert_eq!(
+            reopened.load_environments().unwrap()[0].variables[0].value,
+            "survives relaunch"
+        );
+        drop(reopened);
+        drop(persistence);
+        drop(db);
+        // Database threads release their file handles asynchronously.
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod collections_panel;
 mod curl_import;
 mod db;
 mod environment_manager;
+mod environment_persistence;
 mod format;
 mod formdata;
 mod header_completion;
@@ -38,6 +39,38 @@ use std::fs::OpenOptions;
 use std::io::Write;
 
 use crate::app::PoopmanApp;
+
+struct EnvironmentShutdown {
+    persistence: environment_persistence::EnvironmentPersistence,
+    requested: bool,
+}
+
+impl Global for EnvironmentShutdown {}
+
+/// Quit actions and native close buttons share this barrier. GPUI's final quit
+/// hook only allows 100 ms, so drain writes here while the event loop is alive.
+fn request_quit(cx: &mut App) {
+    if !cx.has_global::<EnvironmentShutdown>() {
+        cx.quit();
+        return;
+    }
+    let state = cx.global_mut::<EnvironmentShutdown>();
+    if state.requested {
+        return;
+    }
+    state.requested = true;
+    let flush = state.persistence.shutdown();
+    let timeout = cx
+        .background_executor()
+        .timer(std::time::Duration::from_secs(2));
+    cx.spawn(async move |cx| {
+        if let Err(error) = environment_persistence::finish_shutdown(flush, timeout).await {
+            log::error!("Could not save environments before quitting (2 second limit): {error}");
+        }
+        let _ = cx.update(|cx| cx.quit());
+    })
+    .detach();
+}
 
 /// An asset source that loads assets from the `./assets` folder.
 #[derive(RustEmbed)]
@@ -130,7 +163,7 @@ fn main() {
         // the action being available), bind the key so the menu item carries the
         // Cmd+Q equivalent, and install the menu below. `set_menus` is a harmless
         // no-op on Windows/Linux, which quit via the window's close button.
-        cx.on_action(|_: &crate::app::Quit, cx| cx.quit());
+        cx.on_action(|_: &crate::app::Quit, cx| request_quit(cx));
 
         // Late binding on purpose: gpui gives later-added bindings precedence,
         // so the "Input"-context ctrl-enter shadows gpui-component's own
@@ -155,12 +188,35 @@ fn main() {
         let initial = cx.background_spawn(async { crate::app::AppInitialState::load() });
         cx.spawn(async move |cx| {
             let initial = initial.await?;
+            let persistence = initial.environment_persistence.clone();
+            cx.update(|cx| {
+                cx.set_global(EnvironmentShutdown {
+                    persistence: persistence.clone(),
+                    requested: false,
+                });
+                // Also protect platform-driven termination that bypasses the
+                // action/close handlers. This future needs no live UI entities.
+                cx.on_app_quit(move |_| {
+                    let flush = persistence.shutdown();
+                    async move {
+                        if let Err(error) = flush.await {
+                            log::error!("Environment shutdown flush failed: {error}");
+                        }
+                    }
+                })
+                .detach();
+            })?;
             let window_options = WindowOptions {
                 titlebar: Some(gpui_component::TitleBar::title_bar_options()),
                 window_min_size: Some(size(px(720.), px(480.))),
                 ..Default::default()
             };
             cx.open_window(window_options, |window, cx| {
+                window.on_window_should_close(cx, |_, cx| {
+                    // Defer out of the platform's close callback before quitting.
+                    cx.defer(request_quit);
+                    false
+                });
                 let view = cx.new(|cx| PoopmanApp::new(initial, window, cx));
                 cx.new(|cx| Root::new(view, window, cx))
             })?;


### PR DESCRIPTION
Environment edits could be lost when Poopman closed during the 180 ms debounce, and independently scheduled writes could persist a different active environment from the latest UI selection. Queue all environment mutations at the point of the UI action, coalesce pending snapshots in one worker, and flush before quit and native window close with a bounded wait.

Guard asynchronous create, delete, and active-selection completions against newer UI state. Delete the active-environment reference transactionally only when it still points to the deleted environment. Retain the latest valid name when an invalid edit supersedes a pending rename. The value eye button now toggles visibility on each click instead of requiring a held mouse button.

Validation:
- `cargo test --locked -- --quiet`: 280 tests passed, including rapid switching, stale completions, multiple pending environments, shutdown timeout/error handling, and reopening the database after quitting during debounce.
- `cargo build --release --locked`: passed on Windows.
- GUI verification remains incomplete; the release executable is available for manual validation.

Closes #48
