### PR TITLE
fix(code-snippet): fit compact windows and copy displayed text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -574,6 +583,21 @@ dependencies = [
  "cmake",
  "dunce",
  "fs_extra",
+]
+
+[[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2217,6 +2241,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "git2"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2310,6 +2353,7 @@ dependencies = [
  "as-raw-xcb-connection",
  "ashpd 0.11.1",
  "async-task",
+ "backtrace",
  "bindgen",
  "blade-graphics",
  "blade-macros",
@@ -2605,12 +2649,15 @@ dependencies = [
  "dunce",
  "futures",
  "futures-lite 1.13.0",
+ "git2",
  "globset",
  "gpui_collections",
+ "gpui_util_macros",
  "itertools 0.14.0",
  "libc",
  "log",
  "nix 0.29.0",
+ "rand 0.9.4",
  "regex",
  "rust-embed",
  "schemars",
@@ -3439,6 +3486,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.2+1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c42fe03df2bd3c53a3a9c7317ad91d80c81cd1fb0caec8d7cc4cd2bfa10c222"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3470,6 +3529,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3a226e576f50782b3305c5ccf458698f92798987f551c6a02efe8276721e22"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -5235,6 +5306,12 @@ dependencies = [
  "toml 0.8.23",
  "triomphe",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
 name = "rustc-hash"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ urlencoding = "2.1"
 
 [dev-dependencies]
 flate2 = "1"
+gpui = { version = "0.2.2", features = ["test-support"] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 winresource = "0.1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,7 +11,7 @@ use gpui_component::{
 };
 use std::sync::{Arc, RwLock};
 
-use crate::code_snippet_panel::CodeSnippetPanel;
+use crate::code_snippet_panel::{CodeSnippetPanel, code_snippet_geometry};
 use crate::collections_panel::{
     CollectionTarget, CollectionsChanged, CollectionsPanel, NewRequestRequested,
     SavedRequestClicked,
@@ -340,17 +340,24 @@ impl PoopmanApp {
                 this.code_panel
                     .update(cx, |panel, cx| panel.set_request(req, window, cx));
                 let panel = code_panel_for_sub.clone();
-                window.open_dialog(cx, move |dialog, _window, cx| {
+                window.open_dialog(cx, move |dialog, window, cx| {
                     let theme = cx.theme();
+                    let geometry = code_snippet_geometry(window.viewport_size());
                     dialog
                         .title(
                             div()
+                                .h(px(24.))
+                                .line_height(px(24.))
                                 .text_lg()
                                 .font_weight(gpui::FontWeight::BOLD)
                                 .text_color(theme.foreground)
                                 .child("Code snippet"),
                         )
-                        .w(px(760.))
+                        .w(geometry.width)
+                        .p(px(24.))
+                        .gap(px(16.))
+                        .margin_top(geometry.margin_top)
+                        .max_h(geometry.max_height)
                         .child(panel.clone())
                 });
             },

--- a/src/code_snippet_panel.rs
+++ b/src/code_snippet_panel.rs
@@ -7,25 +7,55 @@ use std::time::Duration;
 
 use gpui::prelude::FluentBuilder as _;
 use gpui::*;
+use gpui_component::input::InputEvent;
 use gpui_component::{
-    button::*, input::*, select::*, h_flex, v_flex, ActiveTheme as _, IndexPath, Sizable as _,
+    ActiveTheme as _, IndexPath, Sizable as _, button::*, h_flex, input::*, select::*, v_flex,
 };
 
-use crate::code_gen::{generate, CodeTarget};
+use crate::code_gen::{CodeTarget, generate};
 use crate::types::RequestData;
 
-/// Height of the code view inside the dialog (dialog height is content-driven,
-/// so the editor needs a definite height to render).
-const CODE_VIEW_HEIGHT: f32 = 460.;
+const MAX_CODE_VIEW_HEIGHT: f32 = 460.;
+const VIEWPORT_MARGIN: f32 = 16.;
+// gpui-component's dialog entrance animation adds 30 px to margin_top.
+const DIALOG_ANIMATION_OFFSET: f32 = 30.;
+// 24 px padding on each side, 24 px title, 16 px gap, and two 1 px borders.
+const DIALOG_CHROME_HEIGHT: f32 = 90.;
+const TOOLBAR_HEIGHT: f32 = 32.;
+const TOOLBAR_GAP: f32 = 12.;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct CodeSnippetGeometry {
+    pub width: Pixels,
+    pub code_height: Pixels,
+    pub margin_top: Pixels,
+    pub max_height: Pixels,
+}
+
+pub(crate) fn code_snippet_geometry(viewport: Size<Pixels>) -> CodeSnippetGeometry {
+    let max_height =
+        (viewport.height - px(2. * VIEWPORT_MARGIN + DIALOG_ANIMATION_OFFSET)).max(px(0.));
+    let code_height = (max_height - px(DIALOG_CHROME_HEIGHT + TOOLBAR_HEIGHT + TOOLBAR_GAP))
+        .clamp(px(0.), px(MAX_CODE_VIEW_HEIGHT));
+    let dialog_height = code_height + px(DIALOG_CHROME_HEIGHT + TOOLBAR_HEIGHT + TOOLBAR_GAP);
+
+    CodeSnippetGeometry {
+        width: (viewport.width - px(2. * VIEWPORT_MARGIN)).clamp(px(0.), px(760.)),
+        code_height,
+        margin_top: ((viewport.height - dialog_height) / 2. - px(DIALOG_ANIMATION_OFFSET))
+            .max(px(VIEWPORT_MARGIN)),
+        max_height,
+    }
+}
 
 pub struct CodeSnippetPanel {
     request: Option<RequestData>,
     target: CodeTarget,
-    code: String,
     language_select: Entity<SelectState<Vec<&'static str>>>,
     code_display: Entity<InputState>,
     /// True briefly after a Copy click, to show "Copied ✓" feedback.
     copied: bool,
+    copy_feedback_task: Option<Task<()>>,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -42,7 +72,10 @@ impl CodeSnippetPanel {
                 .code_editor(target.language())
                 .line_number(true)
                 .multi_line(true)
-                .tab_size(TabSize { tab_size: 4, hard_tabs: false })
+                .tab_size(TabSize {
+                    tab_size: 4,
+                    hard_tabs: false,
+                })
         });
 
         let sub = cx.subscribe_in(
@@ -52,20 +85,32 @@ impl CodeSnippetPanel {
                 this.on_language_changed(window, cx);
             },
         );
+        let edit_sub = cx.subscribe(&code_display, |this, _, event: &InputEvent, cx| {
+            if matches!(event, InputEvent::Change) {
+                this.copied = false;
+                this.copy_feedback_task = None;
+                cx.notify();
+            }
+        });
 
         Self {
             request: None,
             target,
-            code: String::new(),
             language_select,
             code_display,
             copied: false,
-            _subscriptions: vec![sub],
+            copy_feedback_task: None,
+            _subscriptions: vec![sub, edit_sub],
         }
     }
 
     /// Update the request shown and regenerate the snippet.
-    pub fn set_request(&mut self, request: RequestData, window: &mut Window, cx: &mut Context<Self>) {
+    pub fn set_request(
+        &mut self,
+        request: RequestData,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         self.request = Some(request);
         self.regenerate(window, cx);
     }
@@ -77,9 +122,13 @@ impl CodeSnippetPanel {
             .selected_index(cx)
             .map(|i| i.row)
             .unwrap_or(0);
-        self.target = CodeTarget::all().get(idx).copied().unwrap_or(CodeTarget::Curl);
+        self.target = CodeTarget::all()
+            .get(idx)
+            .copied()
+            .unwrap_or(CodeTarget::Curl);
         let lang = self.target.language();
-        self.code_display.update(cx, |input, cx| input.set_highlighter(lang, cx));
+        self.code_display
+            .update(cx, |input, cx| input.set_highlighter(lang, cx));
         self.regenerate(window, cx);
     }
 
@@ -88,18 +137,21 @@ impl CodeSnippetPanel {
             Some(req) => generate(self.target, req),
             None => String::new(),
         };
-        self.code = code.clone();
         self.copied = false; // new code => clear any stale "Copied" state
-        self.code_display.update(cx, |input, cx| input.set_value(&code, window, cx));
+        self.copy_feedback_task = None;
+        self.code_display
+            .update(cx, |input, cx| input.set_value(&code, window, cx));
         cx.notify();
     }
 
     fn copy(&mut self, _e: &gpui::ClickEvent, window: &mut Window, cx: &mut Context<Self>) {
-        cx.write_to_clipboard(ClipboardItem::new_string(self.code.clone()));
+        cx.write_to_clipboard(ClipboardItem::new_string(
+            self.code_display.read(cx).value().to_string(),
+        ));
         self.copied = true;
         cx.notify();
         // Revert the "Copied ✓" label after a short delay.
-        cx.spawn_in(window, async move |this, cx| {
+        self.copy_feedback_task = Some(cx.spawn_in(window, async move |this, cx| {
             cx.background_executor()
                 .timer(Duration::from_millis(1500))
                 .await;
@@ -107,22 +159,25 @@ impl CodeSnippetPanel {
                 this.copied = false;
                 cx.notify();
             });
-        })
-        .detach();
+        }));
     }
 }
 
 impl Render for CodeSnippetPanel {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let theme = cx.theme();
+        let geometry = code_snippet_geometry(window.viewport_size());
 
         v_flex()
             .id("code-snippet-panel")
             .w_full()
-            .gap_3()
+            .gap(px(TOOLBAR_GAP))
             .child(
                 // Toolbar: language selector (left) + Copy (right)
                 h_flex()
+                    .id("code-snippet-toolbar")
+                    .h(px(TOOLBAR_HEIGHT))
+                    .flex_shrink_0()
                     .items_center()
                     .justify_between()
                     .gap_2()
@@ -137,9 +192,11 @@ impl Render for CodeSnippetPanel {
             )
             .child(
                 div()
+                    .id("code-snippet-editor")
                     .flex()
                     .flex_col()
-                    .h(px(CODE_VIEW_HEIGHT))
+                    .flex_shrink_0()
+                    .h(geometry.code_height)
                     .w_full()
                     .rounded(theme.radius_lg)
                     .border_1()
@@ -148,5 +205,142 @@ impl Render for CodeSnippetPanel {
                     .overflow_hidden()
                     .child(Input::new(&self.code_display).w_full().h_full()),
             )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CodeSnippetPanel, DIALOG_ANIMATION_OFFSET, DIALOG_CHROME_HEIGHT, TOOLBAR_GAP,
+        TOOLBAR_HEIGHT, VIEWPORT_MARGIN, code_snippet_geometry,
+    };
+    use crate::code_gen::{CodeTarget, generate};
+    use crate::types::{HttpMethod, RequestData};
+    use gpui::{AppContext as _, ClickEvent, TestAppContext, px, size};
+
+    #[test]
+    fn dialog_fits_minimum_viewport_including_entrance_animation() {
+        let viewport = size(px(720.), px(480.));
+        let geometry = code_snippet_geometry(viewport);
+        let dialog_height =
+            geometry.code_height + px(DIALOG_CHROME_HEIGHT + TOOLBAR_HEIGHT + TOOLBAR_GAP);
+
+        assert_eq!(geometry.width, px(688.));
+        assert!(geometry.code_height >= px(200.));
+        assert!(dialog_height <= geometry.max_height);
+        assert!(geometry.margin_top >= px(VIEWPORT_MARGIN));
+        assert!(
+            geometry.margin_top + px(DIALOG_ANIMATION_OFFSET) + dialog_height
+                <= viewport.height - px(VIEWPORT_MARGIN)
+        );
+    }
+
+    #[test]
+    fn geometry_recomputes_on_resize_and_caps_large_windows() {
+        let desktop = code_snippet_geometry(size(px(1440.), px(900.)));
+        assert_eq!(desktop.width, px(760.));
+        assert_eq!(desktop.code_height, px(460.));
+
+        for height in [480., 540., 600., 768., 900.] {
+            for width in [720., 800., 1024., 1440.] {
+                let geometry = code_snippet_geometry(size(px(width), px(height)));
+                assert!(geometry.width <= px(width - 32.));
+                assert!(geometry.code_height <= desktop.code_height);
+                assert!(
+                    geometry.margin_top
+                        + px(DIALOG_ANIMATION_OFFSET
+                            + DIALOG_CHROME_HEIGHT
+                            + TOOLBAR_HEIGHT
+                            + TOOLBAR_GAP)
+                        + geometry.code_height
+                        <= px(height - VIEWPORT_MARGIN)
+                );
+            }
+        }
+    }
+
+    #[gpui::test]
+    fn toolbar_copy_uses_current_editor_text(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        let cx = cx.add_empty_window();
+        let panel = cx.update(|window, cx| cx.new(|cx| CodeSnippetPanel::new(window, cx)));
+        let request = RequestData::new(HttpMethod::GET, "https://example.com".into());
+        let generated = generate(CodeTarget::Curl, &request);
+        cx.update(|window, cx| {
+            panel.update(cx, |panel, cx| panel.set_request(request, window, cx));
+        });
+
+        // Include whitespace, Unicode and an empty editor: Copy must preserve
+        // the entire current value, even when it differs from generated code.
+        for displayed in [
+            generated.as_str(),
+            "  # edited 请求\n\tcurl https://example.org\n",
+            "",
+        ] {
+            cx.update(|window, cx| {
+                panel.update(cx, |panel, cx| {
+                    panel.code_display.update(cx, |input, cx| {
+                        input.set_value(displayed.to_string(), window, cx);
+                    });
+                });
+            });
+            cx.update(|window, cx| {
+                panel.update(cx, |panel, cx| {
+                    panel.copy(&ClickEvent::default(), window, cx)
+                });
+            });
+            assert_eq!(cx.read_from_clipboard().unwrap().text().unwrap(), displayed);
+        }
+
+        cx.update(|window, cx| {
+            panel.update(cx, |panel, cx| {
+                assert!(panel.copied);
+                panel
+                    .code_display
+                    .update(cx, |input, cx| input.set_value("another edit", window, cx));
+            });
+        });
+        cx.update(|_, cx| {
+            assert!(!panel.read(cx).copied);
+            assert!(panel.read(cx).copy_feedback_task.is_none());
+        });
+    }
+
+    #[gpui::test]
+    fn keyboard_copy_preserves_selection_behavior(cx: &mut TestAppContext) {
+        cx.update(gpui_component::init);
+        let mut panel = None;
+        let (_, cx) = cx.add_window_view(|window, cx| {
+            let view = cx.new(|cx| CodeSnippetPanel::new(window, cx));
+            panel = Some(view.clone());
+            gpui_component::Root::new(view, window, cx)
+        });
+        let panel = panel.unwrap();
+        cx.update(|window, cx| {
+            panel.update(cx, |panel, cx| {
+                panel.code_display.update(cx, |input, cx| {
+                    input.set_value("abc tail\nsecond line", window, cx);
+                    input.focus(window, cx);
+                });
+            });
+        });
+        cx.run_until_parked();
+        cx.dispatch_action(gpui_component::input::MoveToStart);
+        cx.simulate_keystrokes("shift-right shift-right shift-right");
+        if cfg!(target_os = "macos") {
+            cx.simulate_keystrokes("cmd-c");
+        } else {
+            cx.simulate_keystrokes("ctrl-c");
+        }
+        assert_eq!(cx.read_from_clipboard().unwrap().text().unwrap(), "abc");
+        cx.update(|window, cx| {
+            panel.update(cx, |panel, cx| {
+                panel.copy(&ClickEvent::default(), window, cx)
+            });
+        });
+        assert_eq!(
+            cx.read_from_clipboard().unwrap().text().unwrap(),
+            "abc tail\nsecond line"
+        );
     }
 }


### PR DESCRIPTION
At the minimum 720 x 480 window size, Code Snippet can clip its controls. Editing a snippet also leaves toolbar Copy returning the original generated text.

Size the dialog and scrolling code area from the current viewport, reserving space for the toolbar, dialog chrome and entrance animation. Copy now reads the current editor value; editing or regenerating code clears the copy feedback and cancels its old timer. Standard selection copy remains available.

Closes #55

Validation:
- cargo test --locked: all 284 tests pass on Windows, including four new geometry and GPUI clipboard/keyboard regression tests.
- cargo clippy --locked --all-targets: completes with existing warnings in unchanged code_gen.rs, http_client.rs and settings.rs.
- rustfmt --edition 2024 --check src/code_snippet_panel.rs and git diff --check pass.

GPUI test-support is enabled only as a development dependency to exercise the real editor and test clipboard.

